### PR TITLE
suppress reconcile drift orders via szi-change gating

### DIFF
--- a/entity_management/hyperliquid_tracker.py
+++ b/entity_management/hyperliquid_tracker.py
@@ -115,6 +115,9 @@ class HyperliquidTracker:
     ADDRESS_REFRESH_INTERVAL_S = 60.0
     # Persistent backup watermark file (under validator state dir).
     BACKUP_WATERMARK_FILE = "hl_backup_poll_watermarks.json"
+    # Persistent per-address {coin: szi} snapshot used to gate reconcile
+    # against PnL-driven weight drift across restarts.
+    OBSERVED_SZI_FILE = "hl_observed_szi.json"
 
     # ==================== Inner class: _WebSocketShard ====================
 
@@ -381,7 +384,12 @@ class HyperliquidTracker:
         self._proxy_index_rest = 0
         self._hl_universe: dict = {}       # keyed by coin name, refreshed hourly
         self._last_universe_refresh: float = 0.0
+        # (hl_address_lower) -> {coin: last_observed_szi_float}
+        # Used by reconciliation to detect real HL position-size changes vs
+        # PnL-driven weight drift. Populated from _fetch_hl_account_state results.
+        self._last_observed_szi: Dict[str, Dict[str, float]] = {}
         self._load_backup_poll_watermarks()
+        self._load_observed_szi()
 
     @property
     def _unhealthy_ports(self) -> Set[int]:
@@ -952,7 +960,27 @@ class HyperliquidTracker:
             weight = pos_value / total_portfolio_value if total_portfolio_value > 0 else 0
             positions[coin] = {"szi": szi, "positionValue": pos_value_abs, "weight": weight}
 
-        return {"total_portfolio_value": total_portfolio_value, "positions": positions}
+        result = {"total_portfolio_value": total_portfolio_value, "positions": positions}
+        self._remember_hl_szi(hl_address, result)
+        return result
+
+    def _remember_hl_szi(self, hl_address: str, account_state: dict) -> None:
+        """Cache per-coin szi from the latest HL account state for reconcile gating.
+
+        Persists on every update so a validator restart sees the same szi map
+        the pre-restart process had — otherwise the first reconcile cycle
+        post-restart would recompute fresh weights against an empty cache and
+        emit one drift order per open HL position.
+        """
+        key = hl_address.lower() if isinstance(hl_address, str) else hl_address
+        new_snapshot = {
+            coin: float(info.get("szi", 0.0))
+            for coin, info in account_state.get("positions", {}).items()
+        }
+        if self._last_observed_szi.get(key) == new_snapshot:
+            return
+        self._last_observed_szi[key] = new_snapshot
+        self._save_observed_szi()
 
     # ==================== Backup REST Poll ====================
 
@@ -1064,6 +1092,42 @@ class HyperliquidTracker:
             ValiBkpUtils.safe_save_dict_to_disk(self.BACKUP_WATERMARK_FILE, serializable)
         except Exception as e:
             bt.logging.warning(f"[HL_BACKUP] Failed to persist watermarks: {e}")
+
+    def _load_observed_szi(self):
+        """Load persisted per-address szi snapshot for restart continuity."""
+        try:
+            data = ValiBkpUtils.safe_load_dict_from_disk(self.OBSERVED_SZI_FILE, {})
+            if not isinstance(data, dict):
+                return
+            loaded: Dict[str, Dict[str, float]] = {}
+            for addr, coin_map in data.items():
+                if not isinstance(addr, str) or not isinstance(coin_map, dict):
+                    continue
+                parsed: Dict[str, float] = {}
+                for coin, szi in coin_map.items():
+                    try:
+                        parsed[str(coin)] = float(szi)
+                    except (TypeError, ValueError):
+                        continue
+                loaded[addr] = parsed
+            self._last_observed_szi = loaded
+            if loaded:
+                bt.logging.info(
+                    f"[HL_BACKUP] Loaded szi snapshot for {len(loaded)} address(es)"
+                )
+        except Exception as e:
+            bt.logging.warning(f"[HL_BACKUP] Failed to load observed szi: {e}")
+
+    def _save_observed_szi(self):
+        """Persist per-address szi snapshot so reconcile gate survives restart."""
+        try:
+            serializable = {
+                addr: {coin: float(szi) for coin, szi in coin_map.items()}
+                for addr, coin_map in self._last_observed_szi.items()
+            }
+            ValiBkpUtils.safe_save_dict_to_disk(self.OBSERVED_SZI_FILE, serializable)
+        except Exception as e:
+            bt.logging.warning(f"[HL_BACKUP] Failed to persist observed szi: {e}")
 
     async def _fetch_fills_by_time(self, hl_address: str, start_time_ms: int) -> Optional[List[dict]]:
         """Fetch fills for a tracked address via userFillsByTime REST endpoint."""
@@ -1188,19 +1252,34 @@ class HyperliquidTracker:
             await asyncio.sleep(ValiConfig.HL_BACKUP_POLL_INTERVAL_S)
 
     def _reconcile_address_positions(self, hl_address: str):
-        """Reconcile all relevant HL coins for an address using current account state."""
+        """Reconcile only coins whose szi changed since last observation.
+
+        PnL- or funding-driven changes to total_portfolio_value (which shifts
+        weight but not szi) no longer trigger delta orders.
+        """
+        key = hl_address.lower() if isinstance(hl_address, str) else hl_address
+        prev_szi = dict(self._last_observed_szi.get(key, {}))  # snapshot before fetch
+
         account_state = self._fetch_hl_account_state(hl_address)
         if not account_state:
             return
 
-        # Resolve synthetic hotkey to include currently open Vanta positions in reconciliation.
         synthetic_hotkey = self._entity_client.get_synthetic_hotkey_for_hl_address(hl_address)
         if not synthetic_hotkey and isinstance(hl_address, str):
             synthetic_hotkey = self._entity_client.get_synthetic_hotkey_for_hl_address(hl_address.lower())
         if not synthetic_hotkey:
             return
 
-        coins_to_check = set(account_state.get("positions", {}).keys())
+        current_positions = account_state.get("positions", {})
+
+        # coins seen now (real open or newly flat)
+        current_szi = {c: float(info.get("szi", 0.0)) for c, info in current_positions.items()}
+        # coins that were open before but vanished in current state (closed outside of our ws feed)
+        for coin in prev_szi:
+            current_szi.setdefault(coin, 0.0)
+
+        # Include any Vanta-open coins the HL account no longer lists, so we can
+        # drive them to FLAT if HL closed behind our back.
         from vali_objects.vali_config import HL_DYNAMIC_REGISTRY
         trade_pair_to_coin = {
             dtp.trade_pair_id: dtp.hl_coin
@@ -1213,17 +1292,32 @@ class HyperliquidTracker:
         except Exception as e:
             bt.logging.debug(f"[HL_BACKUP] Failed to fetch open positions for reconcile {synthetic_hotkey}: {e}")
             open_positions = []
-
+        # Coins Vanta has open but HL no longer lists must always be reconciled,
+        # even when prev_szi is empty (e.g., first cycle after restart), so the
+        # szi-unchanged-at-zero compare can't mask a stale Vanta open.
+        force_reconcile: Set[str] = set()
         for pos in open_positions or []:
             if pos and not pos.is_closed_position:
                 coin = trade_pair_to_coin.get(pos.trade_pair.trade_pair_id)
-                if coin:
-                    coins_to_check.add(coin)
+                if coin and coin not in current_szi:
+                    current_szi[coin] = 0.0
+                    force_reconcile.add(coin)
 
-        if not coins_to_check:
-            return
+        # Only act on coins whose szi changed (creation, close, or any delta)
+        # or on Vanta-open coins with no current HL exposure.
+        coins_to_reconcile = [
+            coin for coin, new_sz in current_szi.items()
+            if coin in force_reconcile or new_sz != prev_szi.get(coin, 0.0)
+        ]
 
-        for coin in sorted(coins_to_check):
+        if not coins_to_reconcile:
+            return  # pure PnL / funding drift — nothing to do
+
+        bt.logging.info(
+            f"[HL_BACKUP] Reconciling {len(coins_to_reconcile)} coin(s) for {hl_address} "
+            f"with szi changes: {coins_to_reconcile}"
+        )
+        for coin in sorted(coins_to_reconcile):
             try:
                 self._process_fill(
                     hl_address,

--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "8.12.9"
+  "subnet_version": "8.12.10"
 }

--- a/tests/vali_tests/test_hyperliquid.py
+++ b/tests/vali_tests/test_hyperliquid.py
@@ -1240,6 +1240,125 @@ class TestHyperliquidTracker(TestBase):
 
         self.assertIn("tid_hash_1", self.tracker._processed_hashes)
 
+    # ==================== Reconcile szi-change gating ====================
+
+    def _setup_reconcile_mocks(self):
+        """Shared scaffolding for _reconcile_address_positions tests."""
+        self.entity_client.get_synthetic_hotkey_for_hl_address.return_value = "entity_alpha_0"
+        self.tracker._position_client = MagicMock()
+        self.tracker._position_client.get_positions_for_one_hotkey.return_value = []
+
+    def test_reconcile_skips_when_szi_unchanged(self):
+        """szi unchanged since last observation => no delta orders emitted."""
+        self._setup_reconcile_mocks()
+        self.tracker._last_observed_szi[VALID_HL_ADDRESS.lower()] = {"BTC": 1.5}
+        self.tracker._fetch_hl_account_state = MagicMock(return_value={
+            "total_portfolio_value": 100_000,
+            "positions": {"BTC": {"szi": 1.5, "positionValue": 50_000, "weight": 0.5}},
+        })
+
+        with patch.object(self.tracker, '_process_fill') as mock_process:
+            self.tracker._reconcile_address_positions(VALID_HL_ADDRESS)
+            mock_process.assert_not_called()
+
+    def test_reconcile_fires_when_szi_changed(self):
+        """szi delta since last observation => one reconcile _process_fill call."""
+        self._setup_reconcile_mocks()
+        self.tracker._last_observed_szi[VALID_HL_ADDRESS.lower()] = {"BTC": 1.0}
+        self.tracker._fetch_hl_account_state = MagicMock(return_value={
+            "total_portfolio_value": 100_000,
+            "positions": {"BTC": {"szi": 1.5, "positionValue": 75_000, "weight": 0.75}},
+        })
+
+        with patch.object(self.tracker, '_process_fill') as mock_process:
+            self.tracker._reconcile_address_positions(VALID_HL_ADDRESS)
+            mock_process.assert_called_once()
+            args, kwargs = mock_process.call_args
+            self.assertEqual(args[0], VALID_HL_ADDRESS)
+            self.assertEqual(args[1], {"coin": "BTC", "crossed": False})
+
+    def test_reconcile_fires_when_hl_closed_coin_vanta_still_open(self):
+        """HL no longer lists coin but Vanta has it open => reconcile drives to FLAT."""
+        self._setup_reconcile_mocks()
+        # No prior szi observation; reconcile must still notice the stale Vanta open.
+        self.tracker._fetch_hl_account_state = MagicMock(return_value={
+            "total_portfolio_value": 100_000,
+            "positions": {},  # HL sees nothing
+        })
+
+        fake_tp = MagicMock()
+        fake_tp.trade_pair_id = "BTCUSD"
+        fake_pos = MagicMock()
+        fake_pos.is_closed_position = False
+        fake_pos.trade_pair = fake_tp
+        self.tracker._position_client.get_positions_for_one_hotkey.return_value = [fake_pos]
+
+        from vali_objects.vali_config import HL_DYNAMIC_REGISTRY
+        previous_btc = HL_DYNAMIC_REGISTRY.get("BTCUSD")
+        HL_DYNAMIC_REGISTRY["BTCUSD"] = DynamicTradePair(
+            trade_pair_id="BTCUSD", trade_pair="BTC/USD", hl_coin="BTC", max_leverage=0.5
+        )
+        try:
+            with patch.object(self.tracker, '_process_fill') as mock_process:
+                self.tracker._reconcile_address_positions(VALID_HL_ADDRESS)
+                mock_process.assert_called_once()
+                args, _ = mock_process.call_args
+                self.assertEqual(args[1], {"coin": "BTC", "crossed": False})
+        finally:
+            if previous_btc is None:
+                HL_DYNAMIC_REGISTRY.pop("BTCUSD", None)
+            else:
+                HL_DYNAMIC_REGISTRY["BTCUSD"] = previous_btc
+
+    def test_reconcile_ignores_pnl_only_weight_drift(self):
+        """weight halved via portfolio_value drop, szi unchanged => no reconcile."""
+        self._setup_reconcile_mocks()
+        self.tracker._last_observed_szi[VALID_HL_ADDRESS.lower()] = {"BTC": 1.5}
+        # Portfolio value halved (e.g., unrealized loss); szi stays the same.
+        self.tracker._fetch_hl_account_state = MagicMock(return_value={
+            "total_portfolio_value": 50_000,
+            "positions": {"BTC": {"szi": 1.5, "positionValue": 50_000, "weight": 1.0}},
+        })
+
+        with patch.object(self.tracker, '_process_fill') as mock_process:
+            self.tracker._reconcile_address_positions(VALID_HL_ADDRESS)
+            mock_process.assert_not_called()
+
+    def test_observed_szi_persists_across_restart(self):
+        """_remember_hl_szi persists; a fresh tracker loads the same snapshot."""
+        account_state = {
+            "total_portfolio_value": 100_000,
+            "positions": {"BTC": {"szi": 3.25, "positionValue": 50_000, "weight": 0.5}},
+        }
+        self.tracker._remember_hl_szi(VALID_HL_ADDRESS, account_state)
+
+        # New tracker instance should rehydrate _last_observed_szi from disk.
+        fresh = HyperliquidTracker(
+            entity_client=self.entity_client,
+            elimination_client=self.elimination_client,
+            price_fetcher_client=self.price_fetcher_client,
+            asset_selection_client=self.asset_selection_client,
+            market_order_manager=self.market_order_manager,
+            limit_order_client=self.limit_order_client,
+            uuid_tracker=self.uuid_tracker,
+            rate_limiter=self.rate_limiter,
+        )
+        cached = fresh._last_observed_szi.get(VALID_HL_ADDRESS.lower())
+        self.assertEqual(cached, {"BTC": 3.25})
+
+    def test_remember_hl_szi_populates_cache(self):
+        """_remember_hl_szi stores per-coin szi keyed by lowercased address."""
+        account_state = {
+            "total_portfolio_value": 100_000,
+            "positions": {
+                "BTC": {"szi": 1.25, "positionValue": 50_000, "weight": 0.5},
+                "ETH": {"szi": -2.0, "positionValue": 6_000, "weight": -0.06},
+            },
+        }
+        self.tracker._remember_hl_szi(VALID_HL_ADDRESS, account_state)
+        cached = self.tracker._last_observed_szi.get(VALID_HL_ADDRESS.lower())
+        self.assertEqual(cached, {"BTC": 1.25, "ETH": -2.0})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Taoshi Pull Request

Problem

  Mirroring HL address ... (subaccount 103) emitted 50 orders for 24 real HL
  fills over the investigation window. Most of the extras were sub-basis-point "drift" orders at prices that never
  appeared in the HL userFillsByTime feed, and the mirrored PnL (-$718 on $100k) diverged from the real HL account
  (-$0.46 on ~$71) by more than the deliberate account-size scaling should account for.

  Root cause

  _backup_poll_cycle calls _reconcile_address_positions on every poll cycle that returns zero new fills. Reconciliation
  walks every coin the HL account holds and calls _process_fill with a synthetic {"coin": coin, "crossed": False}. The
  computed target weight is:

  weight = positionValue / total_portfolio_value

  Both terms are mark-to-market, so weight drifts with unrealized PnL and funding even when HL szi (actual position
  size) is unchanged. Every drift above min_leverage produced a new delta order on the validator, regardless of whether
  the real HL account did anything.

  Fix

  Gate reconciliation on actual szi changes, not weight. Reconcile is still the recovery path for fills missed by both
  the WebSocket and the REST poll — we just no longer use it as a continuous mirror of PnL swings.

  entity_management/hyperliquid_tracker.py

  - New in-memory state: self._last_observed_szi: Dict[str, Dict[str, float]] — per-address {coin: szi} snapshot.
  - New helper _remember_hl_szi: wired into _fetch_hl_account_state so every successful HL fetch refreshes the cache.
  Skips redundant writes; persists to disk on real changes.
  - Rewrote _reconcile_address_positions:
    a. Snapshot prev_szi before fetching the new account state.
    b. Fetch new state.
    c. Build current_szi from HL positions, union in prior coins (to detect closes) and Vanta-open coins the HL account
  no longer lists (to drive stale opens to FLAT).
    d. Track Vanta-open-but-HL-absent coins in a force_reconcile set so the 0.0 != 0.0 compare can't mask them on a cold
   cache.
    e. Only emit deltas for coins where new_szi != prev_szi[coin] or coin in force_reconcile.
    f. Early-return if nothing changed.

  Restart persistence

  Without persistence, the first reconcile cycle post-restart sees an empty prev_szi, recomputes fresh weights against
  current (drifted) positionValue / total_portfolio_value, and emits one drift order per open HL position — defeating
  the fix on every validator restart.

  - New constant OBSERVED_SZI_FILE = "hl_observed_szi.json".
  - _load_observed_szi / _save_observed_szi mirror the existing backup-watermark persistence pattern
  (ValiBkpUtils.safe_load_dict_from_disk / safe_save_dict_to_disk).
  - __init__ rehydrates the cache on startup.
  - _remember_hl_szi saves only when the per-address snapshot actually mutates (cheap — only fires on real HL fetches).

  tests/vali_tests/test_hyperliquid.py

  Added 6 tests under TestHyperliquidTracker:

  - test_reconcile_skips_when_szi_unchanged — seeded prev_szi matches current → _process_fill not called.
  - test_reconcile_fires_when_szi_changed — szi delta → exactly one _process_fill call with crossed: False.
  - test_reconcile_fires_when_hl_closed_coin_vanta_still_open — HL closed BTC, Vanta still open → reconcile drives to
  FLAT even with empty prev cache.
  - test_reconcile_ignores_pnl_only_weight_drift — total_portfolio_value halved but szi static → no reconcile.
  - test_remember_hl_szi_populates_cache — helper stores per-coin szi keyed by lowercased address.
  - test_observed_szi_persists_across_restart — snapshot survives a fresh tracker instantiation.

  Expected impact

  Against the same HL address used for investigation:
  - Order count drops from ~50 to ~2 × position count (open + close per position).
  - Positions 0583c8cf, 33a50362, 71a1c4d7 drop from 14/8/10 orders to 2-3 each.
  - No order prices exist that aren't in userFillsByTime.
  - Mirrored PnL tracks HL's PnL × (account_size / HL portf