### PR TITLE
End of week hwm subaccount payout

### DIFF
--- a/docs/validator_rest_server.md
+++ b/docs/validator_rest_server.md
@@ -1810,8 +1810,8 @@ Calculate payout for a subaccount based on debt ledger checkpoints within a spec
 ```json
 {
   "subaccount_uuid": "550e8400-e29b-41d4-a716-446655440000",
-  "start_time_ms": 1702345678901,
-  "end_time_ms": 1702432078901
+  "start_time_ms": 1772409600000,
+  "end_time_ms": 1775088000000
 }
 ```
 
@@ -1825,8 +1825,8 @@ Calculate payout for a subaccount based on debt ledger checkpoints within a spec
     "checkpoints": [...],
     "weekly_settlements": [
       {
-        "start_ms": 1702252800000,
-        "end_ms": 1702857600000,
+        "start_ms": 1772409600000,
+        "end_ms": 1773014400000,
         "eow_balance": 130.0,
         "eow_unrealized": -5.0,
         "payout": 125.0,

--- a/docs/validator_rest_server.md
+++ b/docs/validator_rest_server.md
@@ -1822,19 +1822,27 @@ Calculate payout for a subaccount based on debt ledger checkpoints within a spec
   "data": {
     "hotkey": "5GhDr3xy...abc_0",
     "total_checkpoints": 10,
-    "checkpoints": [
-      ...
+    "checkpoints": [...],
+    "weekly_settlements": [
+      {
+        "start_ms": 1702252800000,
+        "end_ms": 1702857600000,
+        "eow_balance": 130.0,
+        "eow_unrealized": -5.0,
+        "payout": 125.0,
+        "orders": [...]
+      }
     ],
     "payout": 125.5
   },
-  "timestamp": 1702432078901
+  "timestamp": 1702857600000
 }
 ```
 
 **Parameters:**
 - `subaccount_uuid` (string, required): The unique UUID of the subaccount
-- `start_time_ms` (int, required): Start timestamp in milliseconds (inclusive)
-- `end_time_ms` (int, required): End timestamp in milliseconds (inclusive)
+- `start_time_ms` (int, required): Start timestamp in milliseconds (inclusive). Must be Monday 00:00:00 UTC or `0`
+- `end_time_ms` (int, required): End timestamp in milliseconds (inclusive). Must align to a 12-hour boundary
 
 **Example:**
 ```bash
@@ -1843,22 +1851,31 @@ curl -X POST http://localhost:48888/entity/subaccount/payout \
   -H "Content-Type: application/json" \
   -d '{
     "subaccount_uuid": "550e8400-e29b-41d4-a716-446655440000",
-    "start_time_ms": 1702345678901,
-    "end_time_ms": 1702432078901
+    "start_time_ms": 1702252800000,
+    "end_time_ms": 1702857600000
   }'
 ```
 
 **Response Fields:**
 - `hotkey`: The synthetic hotkey of the subaccount
-- `total_checkpoints`: Number of debt ledger checkpoints in the time range
-- `checkpoints`: Array of checkpoint data with emissions and performance metrics
-- `payout`: Calculated payout amount based on the ledger data
+- `total_checkpoints`: Total number of debt ledger checkpoints across the subaccount's history
+- `checkpoints`: Array of all debt ledger checkpoint data for the subaccount
+- `weekly_settlements`: Array of per-week payout breakdowns. Each entry includes:
+  - `start_ms`: Monday 00:00:00 UTC start of the week
+  - `end_ms`: Monday 00:00:00 UTC end of the week (exclusive)
+  - `eow_balance`: Cumulative realized PnL minus fees at end of week
+  - `eow_unrealized`: Unrealized PnL at the nearest checkpoint before week end
+  - `payout`: `max(0, eow_balance - prev_hwm + min(0, eow_unrealized))` for this week
+  - `orders`: Orders with non-zero realized PnL that settled in this week
+- `payout`: Sum of weekly payouts for weeks whose `start_ms >= start_time_ms`
 
 **Important Notes:**
 - Timestamps must be valid integers and non-negative
+- `start_time_ms` must be Monday 00:00:00 UTC or `0`
+- `end_time_ms` must align to a 12-hour boundary
 - `start_time_ms` must be less than or equal to `end_time_ms`
-- Returns 404 if the subaccount has no debt ledger data in the specified time range
-- Payout calculation is based on debt ledger checkpoints that fall within the time range
+- Returns 404 if the subaccount is not found, is not in a funded/alpha bucket, or has no orders
+- Payout uses a weekly high-water mark (HWM) model: only weeks where balance exceeds the previous HWM contribute to payout
 
 ### Entity Trading Workflow
 

--- a/entity_management/entity_client.py
+++ b/entity_management/entity_client.py
@@ -314,7 +314,7 @@ class EntityClient(RPCClientBase):
         self,
         subaccount_uuid: str,
         start_time_ms: int,
-        end_time_ms: int
+        end_time_ms: Optional[int]
     ) -> Optional[dict]:
         """
         Calculate payout for a subaccount based on debt ledger checkpoints.
@@ -322,7 +322,7 @@ class EntityClient(RPCClientBase):
         Args:
             subaccount_uuid: The subaccount UUID
             start_time_ms: Start timestamp (inclusive)
-            end_time_ms: End timestamp (inclusive)
+            end_time_ms: End timestamp (inclusive); if None, uses current time
 
         Returns:
             Dict with {hotkey, total_checkpoints, checkpoints, payout} or None

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -1021,13 +1021,20 @@ class EntityManager(ValidatorBroadcastBase):
 
         # Get debt ledger for this hotkey
         try:
-            miner_bucket = self._challenge_period_client.get_miner_bucket(synthetic_hotkey, end_time_ms)
-            if miner_bucket not in (MinerBucket.SUBACCOUNT_FUNDED, MinerBucket.SUBACCOUNT_ALPHA):
-                return None
-
             debt_ledger = self._debt_ledger_client.get_ledger(synthetic_hotkey)
             if not debt_ledger:
                 return None
+
+            EMPTY_RESPONSE = {
+                'hotkey': synthetic_hotkey,
+                'total_checkpoints': 0,
+                'checkpoints': {},
+                'weekly_settlements': [],
+                'payout': 0,
+            }
+            miner_bucket = self._challenge_period_client.get_miner_bucket(synthetic_hotkey, end_time_ms)
+            if miner_bucket not in (MinerBucket.SUBACCOUNT_FUNDED, MinerBucket.SUBACCOUNT_ALPHA):
+                return EMPTY_RESPONSE
 
             checkpoints_dict = [cp.to_dict() for cp in debt_ledger.checkpoints]
 
@@ -1048,13 +1055,7 @@ class EntityManager(ValidatorBroadcastBase):
             orders.sort(key=lambda x: x.processed_ms)
             fees.sort(key=lambda x: x["time_ms"])
             if not orders:
-                return {
-                    'hotkey': synthetic_hotkey,
-                    'total_checkpoints': 0,
-                    'checkpoints': {},
-                    'weekly_settlements': [],
-                    'payout': 0,
-                }
+                return EMPTY_RESPONSE
 
             weekly_settlements = []
             def _record_week(start_ms, end_ms, balance, prev_hwm, eow_unrealized, week_orders):

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -1097,7 +1097,7 @@ class EntityManager(ValidatorBroadcastBase):
                 unrealized_pnl = cp.unrealized_pnl if cp else 0.0
                 if end_time == end_time_ms:
                     unrealized_pnl = realtime_unrealized
-                _record_week(week_start, week_end, running_balance, eow_hwm, unrealized_pnl, week_orders)
+                _record_week(week_start, end_time, running_balance, eow_hwm, unrealized_pnl, week_orders)
                 eow_hwm = max(eow_hwm, running_balance)
                 week_start, week_end = week_end, week_end + MS_IN_WEEK
 

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -975,7 +975,7 @@ class EntityManager(ValidatorBroadcastBase):
         self,
         subaccount_uuid: str,
         start_time_ms: int,
-        end_time_ms: int
+        end_time_ms: Optional[int]
     ) -> Optional[dict]:
         """
         Calculate payout for a subaccount based on debt ledger checkpoints in time range.
@@ -989,7 +989,7 @@ class EntityManager(ValidatorBroadcastBase):
         Args:
             subaccount_uuid: The subaccount UUID
             start_time_ms: Start timestamp (inclusive)
-            end_time_ms: End timestamp (inclusive)
+            end_time_ms: End timestamp (inclusive); if None, uses current time
 
         Returns:
             Dict with {
@@ -999,6 +999,11 @@ class EntityManager(ValidatorBroadcastBase):
                 'payout': float
             } or None if subaccount not found
         """
+        realtime = False
+        if end_time_ms is None:
+            end_time_ms = TimeUtil.now_in_millis()
+            realtime = True
+
         # Translate UUID to hotkey
         synthetic_hotkey = self.get_synthetic_hotkey_from_uuid(subaccount_uuid)
         if not synthetic_hotkey:
@@ -1029,6 +1034,7 @@ class EntityManager(ValidatorBroadcastBase):
             positions = self._position_client.get_positions_for_one_hotkey(synthetic_hotkey, sort_positions=True)
             orders = []
             fees = []
+            realtime_unrealized = 0
             for position in positions:
                 for order in position.orders:
                     if order.processed_ms < end_time_ms:
@@ -1037,10 +1043,18 @@ class EntityManager(ValidatorBroadcastBase):
                     if fee["time_ms"] < end_time_ms:
                         fees.append(fee)
 
+                realtime_unrealized += position.unrealized_pnl
+
             orders.sort(key=lambda x: x.processed_ms)
             fees.sort(key=lambda x: x["time_ms"])
             if not orders:
-                return None
+                return {
+                    'hotkey': synthetic_hotkey,
+                    'total_checkpoints': 0,
+                    'checkpoints': {},
+                    'weekly_settlements': [],
+                    'payout': 0,
+                }
 
             weekly_settlements = []
             def _record_week(start_ms, end_ms, balance, prev_hwm, eow_unrealized, week_orders):
@@ -1080,7 +1094,10 @@ class EntityManager(ValidatorBroadcastBase):
                 # debt checkpoint timestamp is start_ms, but unrealized pnl is at the end_ms
                 # so must offset by a checkpoint for correct unrealized pnl at end time
                 cp = debt_ledger.get_checkpoint_at_time(end_time - CP_DURATION, CP_DURATION)
-                _record_week(week_start, week_end, running_balance, eow_hwm, cp.unrealized_pnl if cp else 0.0, week_orders)
+                unrealized_pnl = cp.unrealized_pnl if cp else 0.0
+                if end_time == end_time_ms:
+                    unrealized_pnl = realtime_unrealized
+                _record_week(week_start, week_end, running_balance, eow_hwm, unrealized_pnl, week_orders)
                 eow_hwm = max(eow_hwm, running_balance)
                 week_start, week_end = week_end, week_end + MS_IN_WEEK
 

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -1043,13 +1043,14 @@ class EntityManager(ValidatorBroadcastBase):
                 return None
 
             weekly_settlements = []
-            def _record_week(start_ms, end_ms, balance, prev_hwm, eow_unrealized):
+            def _record_week(start_ms, end_ms, balance, prev_hwm, eow_unrealized, week_orders):
                 weekly_settlements.append({
                     'start_ms': start_ms,
                     'end_ms': end_ms,
                     'eow_balance': balance,
                     'eow_unrealized': eow_unrealized,
                     'payout': max(0.0, balance - prev_hwm + min(0.0, eow_unrealized)),
+                    'orders': [o.to_python_dict() for o in week_orders],
                 })
 
             running_balance = 0
@@ -1066,8 +1067,11 @@ class EntityManager(ValidatorBroadcastBase):
             idx_order, idx_fee = 0, 0
             while week_start < end_time_ms:
                 end_time = min(week_end, end_time_ms)
+                week_orders = []
                 while idx_order < len(orders) and orders[idx_order].processed_ms < end_time:
                     running_balance += orders[idx_order].realized_pnl
+                    if orders[idx_order].realized_pnl != 0:
+                        week_orders.append(orders[idx_order])
                     idx_order += 1
                 while idx_fee < len(fees) and fees[idx_fee]["time_ms"] < end_time:
                     running_balance -= fees[idx_fee]["amount"]
@@ -1076,7 +1080,7 @@ class EntityManager(ValidatorBroadcastBase):
                 # debt checkpoint timestamp is start_ms, but unrealized pnl is at the end_ms
                 # so must offset by a checkpoint for correct unrealized pnl at end time
                 cp = debt_ledger.get_checkpoint_at_time(end_time - CP_DURATION, CP_DURATION)
-                _record_week(week_start, week_end, running_balance, eow_hwm, cp.unrealized_pnl if cp else 0.0)
+                _record_week(week_start, week_end, running_balance, eow_hwm, cp.unrealized_pnl if cp else 0.0, week_orders)
                 eow_hwm = max(eow_hwm, running_balance)
                 week_start, week_end = week_end, week_end + MS_IN_WEEK
 

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -1096,7 +1096,7 @@ class EntityManager(ValidatorBroadcastBase):
                 # so must offset by a checkpoint for correct unrealized pnl at end time
                 cp = debt_ledger.get_checkpoint_at_time(end_time - CP_DURATION, CP_DURATION)
                 unrealized_pnl = cp.unrealized_pnl if cp else 0.0
-                if end_time == end_time_ms:
+                if end_time == end_time_ms and realtime:
                     unrealized_pnl = realtime_unrealized
                 _record_week(week_start, end_time, running_balance, eow_hwm, unrealized_pnl, week_orders)
                 eow_hwm = max(eow_hwm, running_balance)

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field
 import template.protocol
 from entity_management.entity_utils import is_synthetic_hotkey, parse_synthetic_hotkey
 from vali_objects.miner_account import MinerAccountClient
+from vali_objects.position_management.position_utils.position_utils import PositionUtils
 from vali_objects.scoring.debt_based_scoring import DebtBasedScoring
 from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.utils.vali_utils import ValiUtils
@@ -46,7 +47,7 @@ from vali_objects.contract.contract_client import ContractClient
 from vali_objects.utils.asset_selection.asset_selection_client import AssetSelectionClient
 from vali_objects.utils.limit_order.limit_order_client import LimitOrderClient
 from vali_objects.enums.miner_bucket_enum import MinerBucket
-from time_util.time_util import TimeUtil
+from time_util.time_util import MS_IN_24_HOURS, TimeUtil
 from vanta_api.websocket_notifier import WebSocketNotifierClient
 
 
@@ -1015,43 +1016,79 @@ class EntityManager(ValidatorBroadcastBase):
 
         # Get debt ledger for this hotkey
         try:
+            miner_bucket = self._challenge_period_client.get_miner_bucket(synthetic_hotkey, end_time_ms)
+            if miner_bucket not in (MinerBucket.SUBACCOUNT_FUNDED, MinerBucket.SUBACCOUNT_ALPHA):
+                return None
+
             debt_ledger = self._debt_ledger_client.get_ledger(synthetic_hotkey)
             if not debt_ledger:
                 return None
 
-            def _earning_checkpoints_up_to(timestamp_ms: int):
-                return [
-                    cp for cp in debt_ledger.checkpoints
-                    if cp.timestamp_ms <= timestamp_ms
-                       and cp.challenge_period_status in (
-                           MinerBucket.SUBACCOUNT_FUNDED.value,
-                           MinerBucket.SUBACCOUNT_ALPHA.value
-                       )
-                ]
+            checkpoints_dict = [cp.to_dict() for cp in debt_ledger.checkpoints]
 
-            # payout(0, end) - payout(0, start) for correct HWM-gated calculation
-            checkpoints_to_end = _earning_checkpoints_up_to(end_time_ms)
-            checkpoints_to_start = _earning_checkpoints_up_to(start_time_ms)
+            positions = self._position_client.get_positions_for_one_hotkey(synthetic_hotkey, sort_positions=True)
+            orders = []
+            fees = []
+            for position in positions:
+                for order in position.orders:
+                    if order.processed_ms < end_time_ms:
+                        orders.append(order)
+                for fee in position.fee_history:
+                    if fee["time_ms"] < end_time_ms:
+                        fees.append(fee)
 
-            payout_to_end = max(0.0, DebtBasedScoring.calculate_payout_from_checkpoints(checkpoints_to_end))
-            payout_to_start = max(0.0, DebtBasedScoring.calculate_payout_from_checkpoints(checkpoints_to_start))
-            payout = max(0.0, payout_to_end - payout_to_start)
+            orders.sort(key=lambda x: x.processed_ms)
+            fees.sort(key=lambda x: x["time_ms"])
+            if not orders:
+                return None
 
-            earning_checkpoints = [
-                cp for cp in debt_ledger.checkpoints
-                if start_time_ms <= cp.timestamp_ms <= end_time_ms
-                   and cp.challenge_period_status in (
-                       MinerBucket.SUBACCOUNT_FUNDED.value,
-                       MinerBucket.SUBACCOUNT_ALPHA.value
-                   )
-            ]
-            checkpoints_dict = [cp.to_dict() for cp in earning_checkpoints]
+            weekly_settlements = []
+            def _record_week(start_ms, end_ms, balance, prev_hwm, eow_unrealized):
+                weekly_settlements.append({
+                    'start_ms': start_ms,
+                    'end_ms': end_ms,
+                    'eow_balance': balance,
+                    'eow_unrealized': eow_unrealized,
+                    'payout': max(0.0, balance - prev_hwm + min(0.0, eow_unrealized)),
+                })
+
+            running_balance = 0
+            eow_hwm = 0
+            MS_IN_WEEK = MS_IN_24_HOURS * 7
+            CP_DURATION = ValiConfig.TARGET_CHECKPOINT_DURATION_MS
+
+            # Always start week_start at the Monday 00:00 UTC of the first order.
+            first_day_index = orders[0].processed_ms // MS_IN_24_HOURS
+            days_since_monday = (first_day_index + 3) % 7
+            week_start = (first_day_index - days_since_monday) * MS_IN_24_HOURS
+            week_end = week_start + MS_IN_WEEK
+
+            idx_order, idx_fee = 0, 0
+            while week_start < end_time_ms:
+                end_time = min(week_end, end_time_ms)
+                while idx_order < len(orders) and orders[idx_order].processed_ms < end_time:
+                    running_balance += orders[idx_order].realized_pnl
+                    idx_order += 1
+                while idx_fee < len(fees) and fees[idx_fee]["time_ms"] < end_time:
+                    running_balance -= fees[idx_fee]["amount"]
+                    idx_fee += 1
+
+                # debt checkpoint timestamp is start_ms, but unrealized pnl is at the end_ms
+                # so must offset by a checkpoint for correct unrealized pnl at end time
+                cp = debt_ledger.get_checkpoint_at_time(end_time - CP_DURATION, CP_DURATION)
+                _record_week(week_start, week_end, running_balance, eow_hwm, cp.unrealized_pnl if cp else 0.0)
+                eow_hwm = max(eow_hwm, running_balance)
+                week_start, week_end = week_end, week_end + MS_IN_WEEK
+
+            # Only sum weeks that fall within the requested period.
+            payout = sum(w['payout'] for w in weekly_settlements if w['start_ms'] >= start_time_ms)
 
             return {
                 'hotkey': synthetic_hotkey,
-                'total_checkpoints': len(earning_checkpoints),
+                'total_checkpoints': len(checkpoints_dict),
                 'checkpoints': checkpoints_dict,
-                'payout': payout
+                'weekly_settlements': weekly_settlements,
+                'payout': payout,
             }
 
         except Exception as e:

--- a/entity_management/entity_server.py
+++ b/entity_management/entity_server.py
@@ -373,7 +373,7 @@ class EntityServer(RPCServerBase):
         self,
         subaccount_uuid: str,
         start_time_ms: int,
-        end_time_ms: int
+        end_time_ms: Optional[int]
     ) -> Optional[dict]:
         """
         RPC method to calculate payout for a subaccount.
@@ -381,7 +381,7 @@ class EntityServer(RPCServerBase):
         Args:
             subaccount_uuid: The subaccount UUID
             start_time_ms: Start timestamp (inclusive)
-            end_time_ms: End timestamp (inclusive)
+            end_time_ms: End timestamp (inclusive); if None, uses current time
 
         Returns:
             Dict with payout data or None if not found

--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "8.12.13"
+  "subnet_version": "8.12.14"
 }

--- a/runnable/migrations/migrate_order_realized_pnl.py
+++ b/runnable/migrations/migrate_order_realized_pnl.py
@@ -1,0 +1,115 @@
+"""
+Migration script to populate order.realized_pnl for all positions.
+
+The Order.realized_pnl field was added to track per-order realized PnL as
+computed in Position.calculate_pnl(). This script rebuilds all positions via
+rebuild_position_with_updated_orders(None) so that each order's realized_pnl
+is back-filled from order data (no live price fetcher needed).
+"""
+
+import os
+import traceback
+from collections import defaultdict
+
+import bittensor as bt
+
+from vali_objects.vali_config import TradePair
+from vali_objects.vali_dataclasses.position import Position
+from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
+from vali_objects.enums.misc import OrderStatus
+
+
+def load_all_positions() -> dict[str, list[Position]]:
+    """Load all open and closed positions from disk."""
+    all_positions: dict[str, list[Position]] = defaultdict(list)
+
+    base_dir = ValiBkpUtils.get_miner_dir(running_unit_tests=False)
+    if not os.path.exists(base_dir):
+        bt.logging.error(f"Positions directory not found: {base_dir}")
+        return all_positions
+
+    for hotkey in os.listdir(base_dir):
+        hotkey_path = os.path.join(base_dir, hotkey)
+        if not os.path.isdir(hotkey_path):
+            continue
+
+        for trade_pair in TradePair:
+            for status in (OrderStatus.OPEN, OrderStatus.CLOSED):
+                dir_path = ValiBkpUtils.get_partitioned_miner_positions_dir(
+                    hotkey, trade_pair.trade_pair_id,
+                    order_status=status,
+                    running_unit_tests=False
+                )
+                if not os.path.exists(dir_path):
+                    continue
+                for filename in os.listdir(dir_path):
+                    filepath = os.path.join(dir_path, filename)
+                    try:
+                        file_string = ValiBkpUtils.get_file(filepath)
+                        position = Position.model_validate_json(file_string)
+                        all_positions[hotkey].append(position)
+                    except Exception as e:
+                        bt.logging.warning(f"Failed to load {filepath}: {e}")
+
+    total = sum(len(v) for v in all_positions.values())
+    print(f"Loaded {total} positions from {len(all_positions)} hotkeys")
+    return all_positions
+
+
+def save_position(position: Position) -> None:
+    """Persist position back to disk."""
+    miner_dir = ValiBkpUtils.get_partitioned_miner_positions_dir(
+        position.miner_hotkey,
+        position.trade_pair.trade_pair_id,
+        order_status=OrderStatus.OPEN if position.is_open_position else OrderStatus.CLOSED,
+        running_unit_tests=False
+    )
+    ValiBkpUtils.write_file(miner_dir + position.position_uuid, position)
+
+
+def main() -> bool:
+    """
+    Rebuild all positions so that order.realized_pnl is populated.
+
+    live_price_fetcher=None works because realized_pnl in calculate_pnl()
+    only uses order.quantity, order.slippage, order.quote_usd_rate, and
+    self.average_entry_price — all already stored on disk.
+    """
+    all_positions = load_all_positions()
+    total_positions = sum(len(v) for v in all_positions.values())
+
+    if total_positions == 0:
+        print("No positions found — nothing to migrate.")
+        return True
+
+    print(f"Rebuilding {total_positions} positions...")
+
+    migrated = 0
+    skipped = 0
+    failed = 0
+
+    for hotkey, positions in all_positions.items():
+        for position in positions:
+            try:
+                if not position.orders:
+                    skipped += 1
+                    continue
+
+                position.rebuild_position_with_updated_orders(price_fetcher_client=None)
+                save_position(position)
+                migrated += 1
+
+            except Exception as e:
+                failed += 1
+                bt.logging.error(
+                    f"Failed to rebuild position {position.position_uuid} ({hotkey}): {e}\n"
+                    f"{traceback.format_exc()}"
+                )
+
+    print(f"Done. rebuilt={migrated}, skipped={skipped}, failed={failed}")
+    return failed == 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(0 if main() else 1)

--- a/runnable/migrations/migrate_order_realized_pnl.py
+++ b/runnable/migrations/migrate_order_realized_pnl.py
@@ -132,6 +132,10 @@ def main(dry_run: bool = False) -> bool:
 
                 position.rebuild_position_with_updated_orders(price_fetcher_client=None)
 
+                # Restore unrealized_pnl — rebuild uses order prices rather than live prices,
+                # so the recomputed value is stale for open positions.
+                position.unrealized_pnl = before["unrealized_pnl"]
+
                 after = {
                     "realized_pnl": position.realized_pnl,
                     "unrealized_pnl": position.unrealized_pnl,

--- a/runnable/migrations/migrate_order_realized_pnl.py
+++ b/runnable/migrations/migrate_order_realized_pnl.py
@@ -80,16 +80,16 @@ def _log_pnl_diff(hotkey: str, position: Position, before: dict, after: dict) ->
         return
 
     print(
-        f"[DIFF] hotkey={hotkey[:8]}... uuid={position.position_uuid} "
+        f"[DIFF] hotkey={hotkey}... uuid={position.position_uuid} "
         f"pair={position.trade_pair.trade_pair_id}"
     )
     if realized_changed:
         print(
-            f"       realized_pnl:   {before['realized_pnl']:.6f} -> {after['realized_pnl']:.6f}"
+            f"       realized_pnl:   {before['realized_pnl']} -> {after['realized_pnl']}"
         )
     if unrealized_changed:
         print(
-            f"       unrealized_pnl: {before['unrealized_pnl']:.6f} -> {after['unrealized_pnl']:.6f}"
+            f"       unrealized_pnl: {before['unrealized_pnl']} -> {after['unrealized_pnl']}"
         )
 
 

--- a/runnable/migrations/migrate_order_realized_pnl.py
+++ b/runnable/migrations/migrate_order_realized_pnl.py
@@ -5,8 +5,13 @@ The Order.realized_pnl field was added to track per-order realized PnL as
 computed in Position.calculate_pnl(). This script rebuilds all positions via
 rebuild_position_with_updated_orders(None) so that each order's realized_pnl
 is back-filled from order data (no live price fetcher needed).
+
+Usage:
+    python migrate_order_realized_pnl.py            # live run (writes changes)
+    python migrate_order_realized_pnl.py --dry-run  # preview only (no writes)
 """
 
+import argparse
 import os
 import traceback
 from collections import defaultdict
@@ -67,7 +72,28 @@ def save_position(position: Position) -> None:
     ValiBkpUtils.write_file(miner_dir + position.position_uuid, position)
 
 
-def main() -> bool:
+def _log_pnl_diff(hotkey: str, position: Position, before: dict, after: dict) -> None:
+    realized_changed = before["realized_pnl"] != after["realized_pnl"]
+    unrealized_changed = before["unrealized_pnl"] != after["unrealized_pnl"]
+
+    if not realized_changed and not unrealized_changed:
+        return
+
+    print(
+        f"[DIFF] hotkey={hotkey[:8]}... uuid={position.position_uuid} "
+        f"pair={position.trade_pair.trade_pair_id}"
+    )
+    if realized_changed:
+        print(
+            f"       realized_pnl:   {before['realized_pnl']:.6f} -> {after['realized_pnl']:.6f}"
+        )
+    if unrealized_changed:
+        print(
+            f"       unrealized_pnl: {before['unrealized_pnl']:.6f} -> {after['unrealized_pnl']:.6f}"
+        )
+
+
+def main(dry_run: bool = False) -> bool:
     """
     Rebuild all positions so that order.realized_pnl is populated.
 
@@ -75,6 +101,9 @@ def main() -> bool:
     only uses order.quantity, order.slippage, order.quote_usd_rate, and
     self.average_entry_price — all already stored on disk.
     """
+    if dry_run:
+        print("DRY RUN — no changes will be written to disk.")
+
     all_positions = load_all_positions()
     total_positions = sum(len(v) for v in all_positions.values())
 
@@ -87,6 +116,7 @@ def main() -> bool:
     migrated = 0
     skipped = 0
     failed = 0
+    changed = 0
 
     for hotkey, positions in all_positions.items():
         for position in positions:
@@ -95,8 +125,26 @@ def main() -> bool:
                     skipped += 1
                     continue
 
+                before = {
+                    "realized_pnl": position.realized_pnl,
+                    "unrealized_pnl": position.unrealized_pnl,
+                }
+
                 position.rebuild_position_with_updated_orders(price_fetcher_client=None)
-                save_position(position)
+
+                after = {
+                    "realized_pnl": position.realized_pnl,
+                    "unrealized_pnl": position.unrealized_pnl,
+                }
+
+                _log_pnl_diff(hotkey, position, before, after)
+
+                if before != after:
+                    changed += 1
+
+                if not dry_run:
+                    save_position(position)
+
                 migrated += 1
 
             except Exception as e:
@@ -106,10 +154,22 @@ def main() -> bool:
                     f"{traceback.format_exc()}"
                 )
 
-    print(f"Done. rebuilt={migrated}, skipped={skipped}, failed={failed}")
+    suffix = " (dry run — nothing written)" if dry_run else ""
+    print(
+        f"Done. rebuilt={migrated}, changed={changed}, skipped={skipped}, failed={failed}{suffix}"
+    )
     return failed == 0
 
 
 if __name__ == "__main__":
     import sys
-    sys.exit(0 if main() else 1)
+
+    parser = argparse.ArgumentParser(description="Migrate order.realized_pnl for all positions.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing anything to disk.",
+    )
+    args = parser.parse_args()
+
+    sys.exit(0 if main(dry_run=args.dry_run) else 1)

--- a/vali_objects/data_sync/auto_sync.py
+++ b/vali_objects/data_sync/auto_sync.py
@@ -139,7 +139,7 @@ class PositionSyncer(ValidatorSyncBase):
             return
 
         datetime_now = TimeUtil.generate_start_timestamp(0)  # UTC
-        if not (datetime_now.hour == 0 and (7 < datetime_now.minute < 17)):
+        if not (datetime_now.hour == 22 and (7 < datetime_now.minute < 17)):
             return
 
         self.perform_sync()

--- a/vali_objects/vali_dataclasses/ledger/debt/debt_ledger_server.py
+++ b/vali_objects/vali_dataclasses/ledger/debt/debt_ledger_server.py
@@ -134,9 +134,10 @@ class DebtLedgerServer(RPCServerBase):
         # Step 1: Update penalty ledgers
         bt.logging.info("Step 1/3: Updating penalty ledgers...")
         penalty_start = time.time()
+        self._penalty_delta_update = True
         self._manager.penalty_ledger_manager.build_penalty_ledgers(delta_update=self._penalty_delta_update)
         bt.logging.info(f"Penalty ledgers updated in {time.time() - penalty_start:.2f}s")
-        self._penalty_delta_update = True
+        # self._penalty_delta_update = True
 
         # Step 2: Update emissions ledgers
         bt.logging.info("Step 2/3: Updating emissions ledgers...")
@@ -156,10 +157,10 @@ class DebtLedgerServer(RPCServerBase):
         bt.logging.info("="*80)
 
         # Run at the next checkpoint aligned time interval
-        # + 1 hour delay for autosync (midnight utc) and perf ledger checkpoint regen
+        # + delay for autosync (midnight utc) and perf ledger checkpoint regen
         now = time.time()
         checkpoint_duration_s = ValiConfig.TARGET_CHECKPOINT_DURATION_MS // 1000
-        next_checkpoint_timestamp_s = (int(now) // checkpoint_duration_s + 1) * checkpoint_duration_s + MS_IN_1_HOUR // 1000
+        next_checkpoint_timestamp_s = (int(now) // checkpoint_duration_s + 1) * checkpoint_duration_s + (MS_IN_1_HOUR/2) // 1000
         self.daemon_interval_s = next_checkpoint_timestamp_s - now
 
         bt.logging.info(f"DebtLedger daemon next iteration in {self.daemon_interval_s} seconds")

--- a/vali_objects/vali_dataclasses/order.py
+++ b/vali_objects/vali_dataclasses/order.py
@@ -25,6 +25,7 @@ class Order(Signal):
     order_uuid: str
     price_sources: list = []
     src: int = OrderSource.ORGANIC
+    realized_pnl: float = 0
     margin_loan: float = 0.0
     is_hl_taker: OptionalType[bool] = None  # None=not HL, True=taker (0.045%), False=maker (0.015%)
 
@@ -178,6 +179,7 @@ class Order(Signal):
                 'order_uuid': self.order_uuid,
                 'src': self.src,
                 'execution_type': self.execution_type.name if self.execution_type else None,
+                'realized_pnl': self.realized_pnl,
                 'limit_price': self.limit_price,
                 'stop_loss': self.stop_loss,
                 'take_profit': self.take_profit,

--- a/vali_objects/vali_dataclasses/position.py
+++ b/vali_objects/vali_dataclasses/position.py
@@ -606,7 +606,8 @@ class Position(BaseModel):
             if order.order_type != self.position_type or self.position_type == OrderType.FLAT:
                 exit_price = current_price * (1 + order.slippage) if order.leverage > 0 else current_price * (1 - order.slippage)
                 order_realized_pnl_quote = -1 * (exit_price - self.average_entry_price) * (order.quantity * order.trade_pair.lot_size)
-                self.realized_pnl += order_realized_pnl_quote * order.quote_usd_rate
+                order.realized_pnl = order_realized_pnl_quote * order.quote_usd_rate
+                self.realized_pnl += order.realized_pnl
 
             unrealized_quantity = min(self.net_quantity, self.net_quantity + order.quantity, key=abs)
             unrealized_pnl_quote = (current_price - self.average_entry_price) * (unrealized_quantity * order.trade_pair.lot_size)

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -16,7 +16,7 @@ import traceback
 from bittensor_wallet import Keypair
 
 from entity_management.entity_client import EntityClient
-from time_util.time_util import TimeUtil
+from time_util.time_util import MS_IN_24_HOURS, TimeUtil
 from shared_objects.rpc.rpc_server_base import RPCServerBase
 from vali_objects.challenge_period.challengeperiod_client import ChallengePeriodClient
 from vali_objects.contract.contract_client import ContractClient
@@ -2068,6 +2068,18 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                     return jsonify({'error': 'start_time_ms must be <= end_time_ms'}), 400
             except (ValueError, TypeError):
                 return jsonify({'error': 'Timestamps must be valid integers'}), 400
+
+            # Validate start_time_ms is Monday 00:00:00 UTC or 0
+            # Unix epoch (1970-01-01) was a Thursday; Monday offset = (day_index + 3) % 7
+            if start_time_ms != 0:
+                start_day_index = start_time_ms // MS_IN_24_HOURS
+                days_since_monday = (start_day_index + 3) % 7
+                if start_time_ms % MS_IN_24_HOURS != 0 or days_since_monday != 0:
+                    return jsonify({'error': 'start_time_ms must be Monday 00:00:00 UTC'}), 400
+
+            # Validate end_time_ms aligns to 12-hour boundary
+            if end_time_ms % ValiConfig.TARGET_CHECKPOINT_DURATION_MS != 0:
+                return jsonify({'error': 'end_time_ms must align to a 12-hour boundary'}), 400
 
             # Calculate payout via EntityClient
             payout_data = self._entity_client.calculate_subaccount_payout(

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -2049,7 +2049,7 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 return jsonify({'error': 'Invalid JSON body'}), 400
 
             # Validate required fields
-            required_fields = ['subaccount_uuid', 'start_time_ms', 'end_time_ms']
+            required_fields = ['subaccount_uuid', 'start_time_ms']
             for field in required_fields:
                 if field not in data:
                     return jsonify({'error': f'Missing required field: {field}'}), 400
@@ -2059,13 +2059,16 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             # Validate timestamps
             try:
                 start_time_ms = int(data['start_time_ms'])
-                end_time_ms = int(data['end_time_ms'])
+                end_time_ms = int(data['end_time_ms']) if data.get('end_time_ms') is not None else None
 
-                if start_time_ms < 0 or end_time_ms < 0:
+                if start_time_ms < 0:
                     return jsonify({'error': 'Timestamps must be non-negative'}), 400
 
-                if start_time_ms > end_time_ms:
-                    return jsonify({'error': 'start_time_ms must be <= end_time_ms'}), 400
+                if end_time_ms is not None:
+                    if end_time_ms < 0:
+                        return jsonify({'error': 'Timestamps must be non-negative'}), 400
+                    if start_time_ms > end_time_ms:
+                        return jsonify({'error': 'start_time_ms must be <= end_time_ms'}), 400
             except (ValueError, TypeError):
                 return jsonify({'error': 'Timestamps must be valid integers'}), 400
 
@@ -2078,7 +2081,7 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                     return jsonify({'error': 'start_time_ms must be Monday 00:00:00 UTC'}), 400
 
             # Validate end_time_ms aligns to 12-hour boundary
-            if end_time_ms % ValiConfig.TARGET_CHECKPOINT_DURATION_MS != 0:
+            if end_time_ms is not None and end_time_ms % ValiConfig.TARGET_CHECKPOINT_DURATION_MS != 0:
                 return jsonify({'error': 'end_time_ms must align to a 12-hour boundary'}), 400
 
             # Calculate payout via EntityClient


### PR DESCRIPTION
Subaccount payouts should be based on EOW HWM at Monday 00:00 UTC
- use order realized pnl field and calculate payouts per week.
- start_time_ms must be 0 or start of day Monday
- end_time_ms must be 12 hour aligned for checkpoints
- final payout value sum the weekly payouts queried from start_time_ms to end_time_ms