### PR TITLE
Wire totalVolume into hl-leaderboard route

### DIFF
--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -1439,6 +1439,7 @@ class EntityManager(ValidatorBroadcastBase):
             # Extract common fields
             engagement = stats.get('engagement') or {}
             n_positions = engagement.get('n_positions') or 0
+            trader_volume = engagement.get('total_volume', 0.0)
             percentage_profitable = engagement.get('percentage_profitable')
             win_rate = round(percentage_profitable * 100, 1) if percentage_profitable is not None else None
             drawdowns = stats.get('drawdowns') or {}
@@ -1458,6 +1459,8 @@ class EntityManager(ValidatorBroadcastBase):
             balance = account.get('balance', account_size) if isinstance(account, dict) else account_size
             total_realized_pnl = account.get('total_realized_pnl', 0.0) if isinstance(account, dict) else 0.0
 
+            total_volume += trader_volume
+
             # Since date from created_at_ms
             since = datetime.fromtimestamp(
                 subaccount.created_at_ms / 1000, tz=timezone.utc
@@ -1472,6 +1475,7 @@ class EntityManager(ValidatorBroadcastBase):
                     'sharpe': sharpe,
                     'trades': n_positions,
                     'winRate': win_rate,
+                    'volume': round(trader_volume, 2),
                     'payouts': 0,
                     'since': since,
                     'rank': weight_info.get('rank'),
@@ -1507,6 +1511,7 @@ class EntityManager(ValidatorBroadcastBase):
                     'sharpe': sharpe,
                     'trades': n_positions,
                     'winRate': win_rate,
+                    'volume': round(trader_volume, 2),
                     'drawdown': drawdown_percent,
                     'since': since,
                 })
@@ -1525,7 +1530,7 @@ class EntityManager(ValidatorBroadcastBase):
             'fundedTraders': len(funded_traders),
             'inChallenge': len(challenge_traders),
             'eliminated': len(eliminated_subaccounts),
-            'totalVolume': 0,
+            'totalVolume': round(total_volume, 2),
         }
 
         return {

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -1475,7 +1475,7 @@ class EntityManager(ValidatorBroadcastBase):
                     'sharpe': sharpe,
                     'trades': n_positions,
                     'winRate': win_rate,
-                    'volume': round(trader_volume, 2),
+                    'volume': trader_volume,
                     'payouts': 0,
                     'since': since,
                     'rank': weight_info.get('rank'),
@@ -1511,7 +1511,7 @@ class EntityManager(ValidatorBroadcastBase):
                     'sharpe': sharpe,
                     'trades': n_positions,
                     'winRate': win_rate,
-                    'volume': round(trader_volume, 2),
+                    'volume': trader_volume,
                     'drawdown': drawdown_percent,
                     'since': since,
                 })
@@ -1530,7 +1530,7 @@ class EntityManager(ValidatorBroadcastBase):
             'fundedTraders': len(funded_traders),
             'inChallenge': len(challenge_traders),
             'eliminated': len(eliminated_subaccounts),
-            'totalVolume': round(total_volume, 2),
+            'totalVolume': total_volume,
         }
 
         return {

--- a/vali_objects/statistics/miner_statistics_manager.py
+++ b/vali_objects/statistics/miner_statistics_manager.py
@@ -298,7 +298,7 @@ class MinerStatisticsManager:
         n_positions = len(miner_positions)
         pos_duration = PositionUtils.total_duration(miner_positions)
         percentage_profitable = self.position_manager.get_percent_profitable_positions(miner_positions)
-        total_volume = sum(pos.cumulative_entry_value for pos in miner_positions)
+        total_volume = sum(abs(o.value) for pos in miner_positions for o in pos.orders if o.value is not None)
 
         # Engagement: checkpoints
         n_checkpoints = len([cp for cp in miner_cps if cp.open_ms > 0])

--- a/vali_objects/statistics/miner_statistics_manager.py
+++ b/vali_objects/statistics/miner_statistics_manager.py
@@ -298,6 +298,7 @@ class MinerStatisticsManager:
         n_positions = len(miner_positions)
         pos_duration = PositionUtils.total_duration(miner_positions)
         percentage_profitable = self.position_manager.get_percent_profitable_positions(miner_positions)
+        total_volume = sum(pos.cumulative_entry_value for pos in miner_positions)
 
         # Engagement: checkpoints
         n_checkpoints = len([cp for cp in miner_cps if cp.open_ms > 0])
@@ -314,7 +315,8 @@ class MinerStatisticsManager:
             "positions_info": {
                 "n_positions": n_positions,
                 "positional_duration": pos_duration,
-                "percentage_profitable": percentage_profitable
+                "percentage_profitable": percentage_profitable,
+                "total_volume": total_volume,
             },
             "checkpoints_info": {
                 "n_checkpoints": n_checkpoints,
@@ -880,6 +882,7 @@ class MinerStatisticsManager:
                 "checkpoint_durations": extra.get("checkpoints_info", {}).get("checkpoint_durations"),
                 "minimum_days_boolean": extra.get("minimum_days_boolean"),
                 "percentage_profitable": extra.get("positions_info", {}).get("percentage_profitable"),
+                "total_volume": extra.get("positions_info", {}).get("total_volume", 0.0),
             }
             # Raw PnL
             raw_pnl_info = raw_pnl_dict.get(hotkey)


### PR DESCRIPTION
The totalVolume field in the /hl-leaderboard summary was hardcoded to 0. Compute per-miner volume by summing Position.cumulative_entry_value through the statistics pipeline and expose it in both per-trader entries and the summary total.

## Taoshi Pull Request

### Description
[Provide a brief description of the changes introduced by this pull request.]

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
