### PR TITLE
fixed subaccount elimination so that the entity miner updates the index

### DIFF
--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -843,6 +843,14 @@ class EntityManager(ValidatorBroadcastBase):
 
             subaccount.status = "eliminated"
             subaccount.eliminated_at_ms = TimeUtil.now_in_millis()
+
+            # Remove HL address from reverse index so the wallet can be re-registered
+            if subaccount.hl_address:
+                normalized_hl = self._normalize_hl_address(subaccount.hl_address)
+                if normalized_hl:
+                    with self._entities_lock:
+                        self._hl_address_to_synthetic.pop(normalized_hl, None)
+
             self._write_entities_from_memory_to_disk()
 
             bt.logging.info(
@@ -877,6 +885,14 @@ class EntityManager(ValidatorBroadcastBase):
 
             subaccount.status = "active"
             subaccount.eliminated_at_ms = None
+
+            # Re-add HL address to reverse index
+            if subaccount.hl_address:
+                normalized_hl = self._normalize_hl_address(subaccount.hl_address)
+                if normalized_hl:
+                    with self._entities_lock:
+                        self._hl_address_to_synthetic[normalized_hl] = subaccount.synthetic_hotkey
+
             self._write_entities_from_memory_to_disk()
 
         self.broadcast_subaccount_dashboard(synthetic_hotkey)

--- a/tests/vali_tests/test_hyperliquid.py
+++ b/tests/vali_tests/test_hyperliquid.py
@@ -165,6 +165,66 @@ class TestHyperliquidSubaccounts(TestBase):
         self.assertFalse(success)
         self.assertIn("already registered", message.lower())
 
+    def test_create_hl_subaccount_reregister_after_elimination(self):
+        """Test HL address can be re-registered after the subaccount is eliminated."""
+        self.entity_client.register_entity(entity_hotkey=self.ENTITY_HOTKEY_1)
+
+        # Register address
+        success, subaccount_info, _ = self.entity_client.create_hl_subaccount(
+            entity_hotkey=self.ENTITY_HOTKEY_1,
+            account_size=50_000,
+            hl_address=VALID_HL_ADDRESS
+        )
+        self.assertTrue(success)
+
+        # Eliminate the subaccount
+        success, _ = self.entity_client.eliminate_subaccount(
+            entity_hotkey=self.ENTITY_HOTKEY_1,
+            subaccount_id=subaccount_info['subaccount_id'],
+            reason="test_elimination"
+        )
+        self.assertTrue(success)
+
+        # Re-registration with the same address should now succeed
+        success, new_sub, message = self.entity_client.create_hl_subaccount(
+            entity_hotkey=self.ENTITY_HOTKEY_1,
+            account_size=50_000,
+            hl_address=VALID_HL_ADDRESS
+        )
+        self.assertTrue(success, f"Re-registration after elimination failed: {message}")
+        self.assertIsNotNone(new_sub)
+        self.assertNotEqual(new_sub['subaccount_id'], subaccount_info['subaccount_id'])
+
+    def test_create_hl_subaccount_reregister_after_elimination_cross_entity(self):
+        """Test HL address eliminated on one entity can be registered on another."""
+        self.entity_client.register_entity(entity_hotkey=self.ENTITY_HOTKEY_1)
+        self.entity_client.register_entity(entity_hotkey=self.ENTITY_HOTKEY_2)
+
+        # Register on entity 1
+        success, subaccount_info, _ = self.entity_client.create_hl_subaccount(
+            entity_hotkey=self.ENTITY_HOTKEY_1,
+            account_size=50_000,
+            hl_address=VALID_HL_ADDRESS
+        )
+        self.assertTrue(success)
+
+        # Eliminate on entity 1
+        success, _ = self.entity_client.eliminate_subaccount(
+            entity_hotkey=self.ENTITY_HOTKEY_1,
+            subaccount_id=subaccount_info['subaccount_id'],
+            reason="test_elimination"
+        )
+        self.assertTrue(success)
+
+        # Register same address on entity 2
+        success, new_sub, message = self.entity_client.create_hl_subaccount(
+            entity_hotkey=self.ENTITY_HOTKEY_2,
+            account_size=50_000,
+            hl_address=VALID_HL_ADDRESS
+        )
+        self.assertTrue(success, f"Cross-entity re-registration after elimination failed: {message}")
+        self.assertIsNotNone(new_sub)
+
     def test_create_hl_subaccount_unregistered_entity(self):
         """Test HL subaccount creation fails for unregistered entity."""
         success, _, message = self.entity_client.create_hl_subaccount(
@@ -781,7 +841,7 @@ class TestHyperliquidTracker(TestBase):
         expected = {
             "BTCUSD": "BTC", "ETHUSD": "ETH", "SOLUSD": "SOL",
             "XRPUSD": "XRP", "DOGEUSD": "DOGE", "ADAUSD": "ADA",
-            "TAOUSD": "TAO", "HYPEUSD": "HYPE", "ZECUSD": "ZED",
+            "TAOUSD": "TAO", "HYPEUSD": "HYPE", "ZECUSD": "ZEC",
             "BCHUSD": "BCH", "LINKUSD": "LINK", "XMRUSD": "XMR",
             "LTCUSD": "LTC",
         }


### PR DESCRIPTION
## Taoshi Pull Request

Entity miners maintain an index of registered accounts that is checked with against the validator. This index was not properly updated when miners get eliminated, they should be removed from this index when eliminated.

### Description
[Provide a brief description of the changes introduced by this pull request.]

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
