### PR TITLE
Enforce min order quantity sizes

### DIFF
--- a/vali_objects/utils/limit_order/market_order_manager.py
+++ b/vali_objects/utils/limit_order/market_order_manager.py
@@ -311,7 +311,7 @@ class MarketOrderManager():
             order.quantity, order.leverage, order.value = order_sizes
             bt.logging.info(f"[ADD_ORDER_DETAIL] order resized to ${order.value} (max position: {max_position_value}, max_cash: {buying_power}")
 
-        if order.value == 0 or order.quantity == 0:
+        if abs(order.value) < 1e-9 or abs(order.quantity) < 1e-9:
             raise SignalException(
                 f"Order rejected: 0 order size due to max position value ${max_position_value} or max buying power ${buying_power}"
             )
@@ -654,7 +654,7 @@ class MarketOrderManager():
                 usd_base_price = self.live_price_fetcher.get_usd_base_conversion(trade_pair, now_ms, price, signal_order_type, existing_position)
 
 
-                if signal_order_type == OrderType.FLAT or signal["quantity"] == -existing_position.net_quantity:
+                if signal_order_type == OrderType.FLAT or abs(existing_position.net_quantity + signal["quantity"]) < 1e-9:
                     signal["leverage"] = None
                     signal["value"] = None
                     signal["quantity"] = -existing_position.net_quantity

--- a/vali_objects/utils/limit_order/market_order_manager.py
+++ b/vali_objects/utils/limit_order/market_order_manager.py
@@ -653,8 +653,7 @@ class MarketOrderManager():
                 price = fill_price if fill_price else best_price_source.parse_appropriate_price(now_ms, trade_pair.is_forex, signal_order_type, existing_position)
                 usd_base_price = self.live_price_fetcher.get_usd_base_conversion(trade_pair, now_ms, price, signal_order_type, existing_position)
 
-
-                if signal_order_type == OrderType.FLAT or abs(existing_position.net_quantity + signal["quantity"]) < 1e-9:
+                if signal_order_type == OrderType.FLAT or (signal.get("quantity") and abs(existing_position.net_quantity + signal["quantity"]) < 1e-9):
                     signal["leverage"] = None
                     signal["value"] = None
                     signal["quantity"] = -existing_position.net_quantity

--- a/vali_objects/utils/limit_order/market_order_manager.py
+++ b/vali_objects/utils/limit_order/market_order_manager.py
@@ -410,7 +410,7 @@ class MarketOrderManager():
         return msg
 
     @staticmethod
-    def parse_order_size(signal, usd_base_conversion, trade_pair, portfolio_value, use_floor=False):
+    def parse_order_size(signal, usd_base_conversion, trade_pair, portfolio_value, round_qty=True, use_floor=False):
         """
         parses an order signal and calculates leverage, value, and quantity
         """
@@ -427,11 +427,20 @@ class MarketOrderManager():
         elif value is not None:
             quantity = (value * usd_base_conversion) / trade_pair.lot_size
 
-        if trade_pair.is_forex:
-            lot_increment = (ValiConfig.FOREX_MIN_POSITION_SIZE_LOTS_SUB_NANO
+        if round_qty:
+            if trade_pair.is_forex:
+                increment = (ValiConfig.FOREX_MIN_ORDER_SIZE_SUB_NANO
                              if portfolio_value <= ValiConfig.FOREX_SMALL_ACCOUNT_THRESHOLD
-                             else ValiConfig.FOREX_MIN_POSITION_SIZE_LOTS)
-            quantity = math.trunc(quantity / lot_increment) * lot_increment if use_floor else round(quantity / lot_increment) * lot_increment
+                             else ValiConfig.FOREX_MIN_ORDER_SIZE)
+            elif trade_pair.is_crypto:
+                increment = ValiConfig.CRYPTO_MIN_ORDER_SIZE
+            elif trade_pair.is_equities:
+                increment = ValiConfig.EQUITIES_MIN_ORDER_SIZE
+            elif trade_pair.is_commodities:
+                increment = ValiConfig.COMMODITIES_MIN_ORDER_SIZE
+            else:
+                increment = ValiConfig.CRYPTO_MIN_ORDER_SIZE # Default to low qty
+            quantity = math.trunc(quantity / increment) * increment if use_floor else round(quantity / increment) * increment
 
         value = quantity * trade_pair.lot_size / usd_base_conversion
         leverage = value / portfolio_value
@@ -644,13 +653,18 @@ class MarketOrderManager():
                 price = fill_price if fill_price else best_price_source.parse_appropriate_price(now_ms, trade_pair.is_forex, signal_order_type, existing_position)
                 usd_base_price = self.live_price_fetcher.get_usd_base_conversion(trade_pair, now_ms, price, signal_order_type, existing_position)
 
-                if signal_order_type == OrderType.FLAT:
+
+                if signal_order_type == OrderType.FLAT or signal["quantity"] == -existing_position.net_quantity:
                     signal["leverage"] = None
                     signal["value"] = None
                     signal["quantity"] = -existing_position.net_quantity
+                    signal_order_type = OrderType.FLAT
 
                 # Parse order size (supports leverage, value, or quantity)
-                quantity, leverage, value = self.parse_order_size(signal, usd_base_price, trade_pair, existing_position.account_size)
+                quantity, leverage, value = self.parse_order_size(
+                    signal, usd_base_price, trade_pair, existing_position.account_size,
+                    round_qty=signal_order_type != OrderType.FLAT # if the position is closing, don't round - use exact position qty
+                )
 
                 created_order = self._add_order_to_existing_position(existing_position, trade_pair, signal_order_type,
                                                      quantity, leverage, value, now_ms, miner_hotkey,

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -350,13 +350,20 @@ class ValiConfig:
     HS_PORTFOLIO_MAX_LEVERAGE = 4.0     # HS portfolio-level leverage cap (funded accounts)
     HS_MIN_LEVERAGE = 0.01              # HS minimum leverage for any DynamicTradePair position
 
-    # Minimum position size limits
+    # Minimum position size
     FOREX_MIN_POSITION_SIZE_LOTS = 0.01            # micro lot — subaccounts above FOREX_SMALL_ACCOUNT_THRESHOLD
     FOREX_MIN_POSITION_SIZE_LOTS_NANO = 0.001      # nano lot — deprecated; no account tier currently uses this
     FOREX_MIN_POSITION_SIZE_LOTS_SUB_NANO = 0.0001 # sub-nano lot — subaccounts at or below FOREX_SMALL_ACCOUNT_THRESHOLD
     FOREX_SMALL_ACCOUNT_THRESHOLD = 10_000.0       # USD; subaccounts at or below this use sub-nano lot minimum
     CRYPTO_MIN_POSITION_SIZE_USD = 10.0  # $10 USD
     EQUITIES_MIN_POSITION_SIZE_SHARES = 0.01 # 0.01 shares
+
+    # Minimum order size in quantity (different from minimum position size ex. crypto)
+    CRYPTO_MIN_ORDER_SIZE = 0.00001
+    COMMODITIES_MIN_ORDER_SIZE = 0.00001
+    EQUITIES_MIN_ORDER_SIZE = 0.00001
+    FOREX_MIN_ORDER_SIZE = 0.01
+    FOREX_MIN_ORDER_SIZE_SUB_NANO = 0.0001
 
     MAX_DAILY_DRAWDOWN = 0.95  # Portfolio should never fall below .95 x of initial value when measured day to day
     MAX_TOTAL_DRAWDOWN = 0.9  # Portfolio should never fall below .90 x of initial value when measured at any instant

--- a/vali_objects/vali_dataclasses/position.py
+++ b/vali_objects/vali_dataclasses/position.py
@@ -903,9 +903,9 @@ class Position(BaseModel):
         # Flatten order
         flatten = False
         if self.position_type == OrderType.LONG:
-            flatten = proposed_quantity <= 0 or proposed_value <= 0
+            flatten = proposed_quantity <= 1e-9 or proposed_value <= 1e-9
         elif self.position_type == OrderType.SHORT:
-            flatten = proposed_quantity >= 0 or proposed_value >= 0
+            flatten = proposed_quantity >= -1e-9 or proposed_value >= -1e-9
 
         if flatten:
             order.order_type = OrderType.FLAT


### PR DESCRIPTION
- All non-forex trade pairs will be subject to quantity multiples of 0.00001 to match hyperliquid
- Improve fill issues based on size with limit/bracket orders