### PR TITLE
Fix limit order cancels and v2 dashboard dict

### DIFF
--- a/vali_objects/utils/limit_order/limit_order_manager.py
+++ b/vali_objects/utils/limit_order/limit_order_manager.py
@@ -1,6 +1,5 @@
 import os
 import traceback
-import uuid
 
 import bittensor as bt
 
@@ -1501,12 +1500,6 @@ class LimitOrderManager(CacheController):
                 try:
                     order = Order.from_dict(order_dict)
                     trade_pair = order.trade_pair
-
-                    # Backwards compatibility for limit stop limit orders with unfilled bracket orders
-                    if order.bracket_orders:
-                        for o in order.bracket_orders:
-                            if "order_uuid" not in o:
-                                o["order_uuid"] = str(uuid.uuid4())
 
                     # Initialize nested structure
                     if trade_pair not in self._limit_orders:

--- a/vali_objects/utils/limit_order/limit_order_manager.py
+++ b/vali_objects/utils/limit_order/limit_order_manager.py
@@ -1,5 +1,6 @@
 import os
 import traceback
+import uuid
 
 import bittensor as bt
 
@@ -1500,6 +1501,12 @@ class LimitOrderManager(CacheController):
                 try:
                     order = Order.from_dict(order_dict)
                     trade_pair = order.trade_pair
+
+                    # Backwards compatibility for limit stop limit orders with unfilled bracket orders
+                    if order.bracket_orders:
+                        for o in order.bracket_orders:
+                            if "order_uuid" not in o:
+                                o["order_uuid"] = str(uuid.uuid4())
 
                     # Initialize nested structure
                     if trade_pair not in self._limit_orders:

--- a/vali_objects/utils/limit_order/limit_order_manager.py
+++ b/vali_objects/utils/limit_order/limit_order_manager.py
@@ -1499,6 +1499,7 @@ class LimitOrderManager(CacheController):
             for order_dict in miner_order_dicts:
                 try:
                     order = Order.from_dict(order_dict)
+                    self._write_to_disk(hotkey, order)
                     trade_pair = order.trade_pair
 
                     # Initialize nested structure

--- a/vali_objects/utils/limit_order/order_processor.py
+++ b/vali_objects/utils/limit_order/order_processor.py
@@ -511,12 +511,10 @@ class OrderProcessor:
                 bracket_uuid = bracket.get("order_uuid")
 
                 # Check if this bracket order exists (for update)
-                if bracket_uuid:
-                    existing_bracket = limit_order_client.get_limit_order_by_uuid(miner_hotkey, bracket_uuid)
-                    if not existing_bracket:
-                        bt.logging.warning(f"Cannot edit order {bracket_uuid}: order not found, skipping")
-                        continue
+                existing_bracket = limit_order_client.get_limit_order_by_uuid(miner_hotkey, bracket_uuid) if bracket_uuid else None
 
+                if existing_bracket:
+                    is_edit = True
                     # If bracket_uuid exists but no SL, TP, or trailing fields, cancel the order
                     has_trailing = bracket.get("trailing_percent") is not None or bracket.get("trailing_value") is not None
                     if bracket.get("stop_loss") is None and bracket.get("take_profit") is None and not has_trailing:
@@ -530,12 +528,11 @@ class OrderProcessor:
                         except SignalException as e:
                             bt.logging.warning(f"Failed to cancel bracket order {bracket_uuid}: {e}, skipping")
                         continue
-
-                    is_edit = True
                 else:
-                    # No UUID provided - generate new one
                     is_edit = False
-                    bracket_uuid = str(uuid.uuid4())
+                    # UUID not found or not provided - create new order using provided uuid (or generate one)
+                    if not bracket_uuid:
+                        bracket_uuid = str(uuid.uuid4())
 
                 # Build bracket signal
                 # Build trailing_stop dict if trailing fields present in bracket entry

--- a/vali_objects/utils/limit_order/order_processor.py
+++ b/vali_objects/utils/limit_order/order_processor.py
@@ -304,7 +304,7 @@ class OrderProcessor:
 
     @staticmethod
     def process_limit_cancel(signal: dict, trade_pair, order_uuid: str, now_ms: int,
-                            miner_hotkey: str, limit_order_client) -> dict:
+                            miner_hotkey: str, limit_order_client, execution_type=None) -> dict:
         """
         Process a LIMIT_CANCEL operation by calling limit_order_client.
 
@@ -315,6 +315,7 @@ class OrderProcessor:
             now_ms: Current timestamp in milliseconds
             miner_hotkey: Miner's hotkey
             limit_order_client: Client to process the cancellation
+            execution_type: Optional ExecutionType filter — when set with cancel_all, only cancels orders of this type
 
         Returns:
             Result dictionary from limit_order_client
@@ -328,7 +329,8 @@ class OrderProcessor:
             miner_hotkey,
             trade_pair.trade_pair_id if trade_pair else None,
             order_uuid,
-            now_ms
+            now_ms,
+            execution_type
         )
 
         bt.logging.debug(f"Cancelled LIMIT order(s) for {miner_hotkey}: {order_uuid or 'all'}")
@@ -711,7 +713,7 @@ class OrderProcessor:
             )
 
             try:
-                OrderProcessor.process_limit_cancel(None, None, "ALL", now_ms, miner_hotkey, limit_order_client)
+                OrderProcessor.process_limit_cancel(None, None, "ALL", now_ms, miner_hotkey, limit_order_client, ExecutionType.BRACKET)
             except Exception as e:
                 bt.logging.warning(f"Failed to cancel bracket orders after FLAT_ALL: {e}")
 
@@ -735,7 +737,7 @@ class OrderProcessor:
             # Cancel unfilled bracket orders immediately if position is now closed
             if updated_position and updated_position.is_closed_position:
                 try:
-                    OrderProcessor.process_limit_cancel(None, updated_position.trade_pair, "ALL", now_ms, miner_hotkey, limit_order_client)
+                    OrderProcessor.process_limit_cancel(None, updated_position.trade_pair, "ALL", now_ms, miner_hotkey, limit_order_client, ExecutionType.BRACKET)
                 except Exception as e:
                     bt.logging.warning(f"Failed to cancel bracket orders after position close: {e}")
 

--- a/vali_objects/vali_dataclasses/order.py
+++ b/vali_objects/vali_dataclasses/order.py
@@ -231,26 +231,28 @@ class Order(Signal):
             results["tk"] = self.take_profit
 
         if self.bracket_orders is not None:
-            bo = {}
-            for order in self.bracket_orders:
-                bracket_orders = {}
-                if sl := order.get("stop_loss"):
-                    bracket_orders["sl"] = sl
-                if tp := order.get("take_profit"):
-                    bracket_orders["tp"] = tp
-                if val := order.get("value"):
-                    bracket_orders["v"] = val
-                if qty := order.get("quantity"):
-                    bracket_orders["q"] = qty
-                if tsl := order.get("trailing_stop"):
-                    tsl_compact = {}
-                    if 'trailing_percent' in tsl:
-                        tsl_compact["pct"] = tsl["trailing_percent"]
-                    if 'trailing_value' in tsl:
-                        tsl_compact["val"] = tsl["trailing_value"]
-                    bracket_orders["tsl"] = tsl_compact
-                bo[order["order_uuid"]] = bracket_orders
-            results["uo"] = bo  # index as uo to match positions
+            unfilled_orders = {}
+            for sub_order in self.bracket_orders:
+                sub_bracket_orders = {}
+                if sl := sub_order.get("stop_loss"):
+                    sub_bracket_orders["sl"] = sl
+                if tp := sub_order.get("take_profit"):
+                    sub_bracket_orders["tp"] = tp
+                if val := sub_order.get("value"):
+                    sub_bracket_orders["v"] = val
+                if qty := sub_order.get("quantity"):
+                    sub_bracket_orders["q"] = qty
+
+                tsl_compact = {}
+                if 'trailing_percent' in sub_order:
+                    tsl_compact["pct"] = sub_order["trailing_percent"]
+                if 'trailing_value' in sub_order:
+                    tsl_compact["val"] = sub_order["trailing_value"]
+                if not tsl_compact:
+                    sub_bracket_orders["tsl"] = tsl_compact
+
+                unfilled_orders[sub_order["order_uuid"]] = sub_bracket_orders
+            results["uo"] = unfilled_orders  # index as uo to match positions
 
         if self.execution_type == ExecutionType.STOP_LIMIT:
             results["sp"] = self.stop_price

--- a/vali_objects/vali_dataclasses/order.py
+++ b/vali_objects/vali_dataclasses/order.py
@@ -121,6 +121,15 @@ class Order(Signal):
             return [PriceSource(**ps) if isinstance(ps, dict) else ps for ps in v]
         return v
 
+    @field_validator('bracket_orders', mode='before')
+    @classmethod
+    def ensure_bracket_order_uuids(cls, v):
+        if isinstance(v, list):
+            for sub in v:
+                if isinstance(sub, dict) and 'order_uuid' not in sub:
+                    sub['order_uuid'] = str(uuid.uuid4())
+        return v
+
     # @model_validator(mode='before')
     # def validate_size(cls, values):
     #     """
@@ -248,7 +257,8 @@ class Order(Signal):
                     tsl_compact["pct"] = sub_order["trailing_percent"]
                 if 'trailing_value' in sub_order:
                     tsl_compact["val"] = sub_order["trailing_value"]
-                if not tsl_compact:
+
+                if tsl_compact:
                     sub_bracket_orders["tsl"] = tsl_compact
 
                 unfilled_orders[sub_order["order_uuid"]] = sub_bracket_orders

--- a/vali_objects/vali_dataclasses/order.py
+++ b/vali_objects/vali_dataclasses/order.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024 Taoshi Inc
 
 from typing import Optional as OptionalType
+import uuid
 
 from time_util.time_util import TimeUtil
 from pydantic import field_validator, model_validator
@@ -228,6 +229,30 @@ class Order(Signal):
 
         if self.take_profit is not None:
             results["tk"] = self.take_profit
+
+        if self.bracket_orders is not None:
+            bo = {}
+            for order in self.bracket_orders:
+                bracket_orders = {}
+                if sl := order.get("stop_loss"):
+                    bracket_orders["sl"] = sl
+                if tp := order.get("take_profit"):
+                    bracket_orders["tp"] = tp
+                if val := order.get("value"):
+                    bracket_orders["v"] = val
+                if qty := order.get("quantity"):
+                    bracket_orders["q"] = qty
+                if tsl := order.get("trailing_stop"):
+                    tsl_compact = {}
+                    if 'trailing_percent' in tsl:
+                        tsl_compact["pct"] = tsl["trailing_percent"]
+                    if 'trailing_value' in tsl:
+                        tsl_compact["val"] = tsl["trailing_value"]
+                    bracket_orders["tsl"] = tsl_compact
+                if "order_uuid" not in order:
+                    order["order_uuid"] = str(uuid.uuid4())
+                bo[order["order_uuid"]] = bracket_orders
+            results["uo"] = bo  # index as uo to match positions
 
         if self.execution_type == ExecutionType.STOP_LIMIT:
             results["sp"] = self.stop_price

--- a/vali_objects/vali_dataclasses/order.py
+++ b/vali_objects/vali_dataclasses/order.py
@@ -249,8 +249,6 @@ class Order(Signal):
                     if 'trailing_value' in tsl:
                         tsl_compact["val"] = tsl["trailing_value"]
                     bracket_orders["tsl"] = tsl_compact
-                if "order_uuid" not in order:
-                    order["order_uuid"] = str(uuid.uuid4())
                 bo[order["order_uuid"]] = bracket_orders
             results["uo"] = bo  # index as uo to match positions
 

--- a/vali_objects/vali_dataclasses/order_signal.py
+++ b/vali_objects/vali_dataclasses/order_signal.py
@@ -1,5 +1,6 @@
 # developer: Taoshidev
 # Copyright (c) 2024 Taoshi Inc
+import uuid
 from typing import Optional, Union
 
 from vali_objects.enums.execution_type_enum import ExecutionType
@@ -52,7 +53,7 @@ class Signal(BaseModel):
             return values
 
         if (has_sl_tp or has_trailing) and not bracket_orders:
-            bracket_entry = {'stop_loss': stop_loss, 'take_profit': take_profit}
+            bracket_entry = {'stop_loss': stop_loss, 'take_profit': take_profit, 'order_uuid': str(uuid.uuid4())}
             if has_trailing:
                 if 'trailing_percent' in trailing_stop:
                     bracket_entry['trailing_percent'] = trailing_stop['trailing_percent']
@@ -72,6 +73,8 @@ class Signal(BaseModel):
             trailing_present = [f for f in trailing_fields if bracket.get(f) is not None]
             if len(price_present) < 1 and len(trailing_present) < 1:
                 raise ValueError(f"bracket_orders[{i}]: at least one of stop_loss/take_profit/trailing_percent/trailing_value required")
+            if not bracket.get('order_uuid'):
+                bracket['order_uuid'] = str(uuid.uuid4())
 
         return values
 


### PR DESCRIPTION
- Only cancel pending bracket orders
- Include unfilled orders of unfilled limit/stop limit orders.
  - auto generate uuid for existing unfilled limit orders with unfilled bracket orders
  - generate for each attached bracket order entry at miner signal
  
  ## Notion Tasks
https://www.notion.so/TP-SL-User-Issue-35da5340ff908078b4e9ec90b05914a0