### PR TITLE
Debt ledger + Positions based HWM emissions

### DIFF
--- a/time_util/time_util.py
+++ b/time_util/time_util.py
@@ -437,7 +437,8 @@ class TimeUtil:
     @staticmethod
     def ms_at_start_of_week(time: int) -> int:
         start_dt = TimeUtil.millis_to_datetime(time)
-        return int(start_dt.replace(day=0, hour=0, minute=0, second=0).timestamp() * 1000)
+        monday = start_dt - timedelta(days=start_dt.weekday())
+        return int(monday.replace(hour=0, minute=0, second=0, microsecond=0).timestamp() * 1000)
 
 
     @staticmethod

--- a/time_util/time_util.py
+++ b/time_util/time_util.py
@@ -21,6 +21,7 @@ from pandas.tseries.holiday import Holiday, nearest_workday, GoodFriday  # noqa:
 MS_IN_1_HOUR = 3600000
 MS_IN_8_HOURS =  28800000
 MS_IN_24_HOURS = 86400000
+MS_IN_WEEK = 604_800_000
 S_IN_24_HOURS = 86400
 
 
@@ -432,6 +433,12 @@ class TimeUtil:
     @staticmethod
     def ms_at_start_of_day(dt: datetime) -> int:
         return int(dt.replace(hour=0, minute=0, second=0, microsecond=0).timestamp() * 1000)
+
+    @staticmethod
+    def ms_at_start_of_week(time: int) -> int:
+        start_dt = TimeUtil.millis_to_datetime(time)
+        return int(start_dt.replace(day=0, hour=0, minute=0, second=0).timestamp() * 1000)
+
 
     @staticmethod
     def ms_to_next_hour(t_ms: int) -> int:

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -388,12 +388,15 @@ class DebtBasedScoring:
         miner_positions: dict[str, list[Position]],
         perf_ledgers: dict[str, PerfLedger],
         debt_ledgers: dict[str, DebtLedger],
+        start_time_ms: int | None = None,
         end_time_ms: int | None = None,
         # interval,  # TODO support different intervals base
     ) -> dict[str, list[PayoutSettlement]]:
         """
         Calculate weekly payout for hotkeys for what their debt ledger allows
         """
+        if not start_time_ms:
+            start_time_ms = 0
 
         if not end_time_ms:
             end_time_ms = TimeUtil.now_in_millis()
@@ -414,7 +417,7 @@ class DebtBasedScoring:
                 result[hotkey] = []
                 continue
 
-            payout_start_ms = first_earning_checkpoint.timestamp_ms
+            payout_start_ms = max(first_earning_checkpoint.timestamp_ms, start_time_ms)
             payout_end_ms = TimeUtil.ms_at_start_of_week(end_time_ms)
 
             settlements = DebtBasedScoring.generate_weekly_settlements(

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -365,7 +365,8 @@ class DebtBasedScoring:
             payout_penalized = max(0.0, eow_payout_balance_penalized - eow_hwm_raw + unrealized_losses)
 
             # Only return desired weekly settlements
-            if start_time_ms <= week_end_ms <= end_time_ms:
+            if (start_time_ms <= week_end_ms <= end_time_ms
+                    or start_time_ms <= week_start_ms <= end_time_ms):
                 weekly_settlements.append(PayoutSettlement(
                     start_ms=week_start_ms,
                     end_ms=week_end_ms,

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -308,8 +308,8 @@ class DebtBasedScoring:
             return []
 
         weekly_settlements = []
-        balance = 0
-        eow_hwm = 0
+        balance_raw = 0
+        eow_hwm_raw = 0
 
         # Always start week_start at the Monday 00:00 UTC of the first order.
         week_start_ms = TimeUtil.ms_at_start_of_week(orders[0].processed_ms)
@@ -318,10 +318,11 @@ class DebtBasedScoring:
             week_end_ms = min(week_start_ms + MS_IN_WEEK, end_time_ms)
             realized_orders_in_week = []
 
-            weekly_net_pnl, weekly_penalized_pnl = 0, 0
+            weekly_pnl_raw, weekly_pnl_penalized = 0, 0
             while order_idx < len(orders) and orders[order_idx].processed_ms < week_end_ms:
                 order = orders[order_idx]
-                if order.realized_pnl != 0:
+                realized_pnl = order.realized_pnl
+                if realized_pnl != 0:
                     realized_orders_in_week.append(order)
 
                 order_penalty = 1.0
@@ -329,14 +330,15 @@ class DebtBasedScoring:
                     order_penalty_ms = TimeUtil.align_to_12hour_checkpoint_boundary(order.processed_ms)
                     penalty_checkpoint = debt_ledger.get_checkpoint_at_time(order_penalty_ms, CP_DURATION_MS)
                     order_penalty = penalty_checkpoint.total_penalty if penalty_checkpoint else 1.0
+                    order_penalty = min(1.0, max(0, order_penalty))
 
-                weekly_net_pnl += order.realized_pnl
-                weekly_penalized_pnl += order.realized_pnl * order_penalty
+                weekly_pnl_raw += realized_pnl
+                weekly_pnl_penalized += realized_pnl * order_penalty if realized_pnl > 0 else realized_pnl
 
                 order_idx += 1
             while fee_idx < len(fees) and fees[fee_idx]["time_ms"] < week_end_ms:
-                weekly_net_pnl -= fees[fee_idx]["amount"]
-                weekly_penalized_pnl -= fees[fee_idx]["amount"]
+                weekly_pnl_raw -= fees[fee_idx]["amount"]
+                weekly_pnl_penalized -= fees[fee_idx]["amount"]
                 fee_idx += 1
 
             # Use perf ledger instead of delayed debt ledger
@@ -345,24 +347,24 @@ class DebtBasedScoring:
             if week_end_ms == end_time_ms and is_realtime:
                 unrealized_pnl = realtime_unrealized_pnl
 
-            eow_balance = balance + weekly_net_pnl
-            eow_balance_penalty = balance + weekly_penalized_pnl
-            payout_raw = max(0.0, eow_balance - eow_hwm + min(0, unrealized_pnl))
-            payout_penalized = max(0.0, eow_balance_penalty - eow_hwm + min(0, unrealized_pnl))
+            eow_balance_raw = balance_raw + weekly_pnl_raw
+            eow_balance_penalized = balance_raw + weekly_pnl_penalized
+            payout_raw = max(0.0, eow_balance_raw - eow_hwm_raw + min(0, unrealized_pnl))
+            payout_penalized = max(0.0, eow_balance_penalized - eow_hwm_raw + min(0, unrealized_pnl))
             # Only return desired weekly settlements
             if week_start_ms >= start_time_ms and week_end_ms <= end_time_ms:
                 weekly_settlements.append(PayoutSettlement(
                     start_ms=week_start_ms,
                     end_ms=week_end_ms,
-                    balance=eow_balance,
+                    balance=eow_balance_raw,
                     unrealized_pnl=unrealized_pnl,
                     payout_raw=payout_raw,
                     payout_penalized=payout_penalized,
                     orders=realized_orders_in_week
                 ))
 
-            balance = eow_balance
-            eow_hwm = max(eow_hwm, balance)
+            balance_raw = eow_balance_raw
+            eow_hwm_raw = max(eow_hwm_raw, balance_raw)
             week_start_ms = week_end_ms
 
         return weekly_settlements

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -319,6 +319,7 @@ class DebtBasedScoring:
             realized_orders_in_week = []
 
             weekly_pnl_raw, weekly_pnl_penalized = 0, 0
+            payout_eligible_pnl_raw, payout_eligible_pnl_penalized = 0, 0
             while order_idx < len(orders) and orders[order_idx].processed_ms < week_end_ms:
                 order = orders[order_idx]
                 realized_pnl = order.realized_pnl
@@ -332,13 +333,19 @@ class DebtBasedScoring:
                     order_penalty = penalty_checkpoint.total_penalty if penalty_checkpoint else 1.0
                     order_penalty = min(1.0, max(0, order_penalty))
 
+                _payout_pnl = realized_pnl if order.processed_ms > start_time_ms else 0
                 weekly_pnl_raw += realized_pnl
+                payout_eligible_pnl_raw += _payout_pnl
                 weekly_pnl_penalized += realized_pnl * order_penalty if realized_pnl > 0 else realized_pnl
+                payout_eligible_pnl_penalized += _payout_pnl * order_penalty if _payout_pnl > 0 else _payout_pnl
 
                 order_idx += 1
             while fee_idx < len(fees) and fees[fee_idx]["time_ms"] < week_end_ms:
+                _payout_fee = fees[fee_idx]["amount"] if fees[fee_idx]["time_ms"] > start_time_ms else 0
                 weekly_pnl_raw -= fees[fee_idx]["amount"]
+                payout_eligible_pnl_raw -= _payout_fee
                 weekly_pnl_penalized -= fees[fee_idx]["amount"]
+                payout_eligible_pnl_penalized -= _payout_fee
                 fee_idx += 1
 
             # Use perf ledger instead of delayed debt ledger
@@ -348,11 +355,17 @@ class DebtBasedScoring:
                 unrealized_pnl = realtime_unrealized_pnl
 
             eow_balance_raw = balance_raw + weekly_pnl_raw
-            eow_balance_penalized = balance_raw + weekly_pnl_penalized
-            payout_raw = max(0.0, eow_balance_raw - eow_hwm_raw + min(0, unrealized_pnl))
-            payout_penalized = max(0.0, eow_balance_penalized - eow_hwm_raw + min(0, unrealized_pnl))
+
+            # Cannot be paid out for more than payout eligible pnl (case if first earning checkpoint is mid-week)
+            eow_payout_balance_raw = balance_raw + min(weekly_pnl_raw, payout_eligible_pnl_raw)
+            eow_payout_balance_penalized = balance_raw + min(weekly_pnl_penalized, payout_eligible_pnl_penalized)
+
+            unrealized_losses = min(0, unrealized_pnl)
+            payout_raw = max(0.0, eow_payout_balance_raw - eow_hwm_raw + unrealized_losses)
+            payout_penalized = max(0.0, eow_payout_balance_penalized - eow_hwm_raw + unrealized_losses)
+
             # Only return desired weekly settlements
-            if week_start_ms >= start_time_ms and week_end_ms <= end_time_ms:
+            if start_time_ms <= week_end_ms <= end_time_ms:
                 weekly_settlements.append(PayoutSettlement(
                     start_ms=week_start_ms,
                     end_ms=week_end_ms,
@@ -395,10 +408,13 @@ class DebtBasedScoring:
                 continue
 
             # Start the payout cycle from the full week we have of the debt ledger
-            payout_start_ms = 0
-            if debt_ledger.checkpoints:
-                payout_start_ms = TimeUtil.ms_at_start_of_week(debt_ledger.checkpoints[0].timestamp_ms) + MS_IN_WEEK
+            first_earning_checkpoint = next((cp for cp in debt_ledger.checkpoints
+                                             if cp.challenge_period_status in DebtBasedScoring.EARNING_MINER_BUCKETS), None)
+            if first_earning_checkpoint is None:
+                result[hotkey] = []
+                continue
 
+            payout_start_ms = first_earning_checkpoint.timestamp_ms
             payout_end_ms = TimeUtil.ms_at_start_of_week(end_time_ms)
 
             settlements = DebtBasedScoring.generate_weekly_settlements(

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -408,11 +408,7 @@ class DebtBasedScoring:
                 start_time_ms=payout_start_ms,
                 end_time_ms=payout_end_ms
             )
-
             result[hotkey] = settlements
-            print(f"  {hotkey} settlements ({len(settlements)}):")
-            for s in settlements:
-                print(f"    {s}")
 
         return result
 

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -511,7 +511,7 @@ class DebtBasedScoring:
         prev_target_day_offset = (current_weekday + 1) % 7
         days_until_target = 7 - prev_target_day_offset
         prev_target_dt = current_dt - timedelta(days=prev_target_day_offset)
-        prev_target_end_dt = datetime.combine(prev_target_dt, datetime.min.time())
+        prev_target_end_dt = datetime.combine(prev_target_dt, datetime.min.time(), tzinfo=timezone.utc)
         prev_target_end_ms = int(prev_target_end_dt.timestamp() * 1000)
 
         if verbose:

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -41,12 +41,13 @@ Important Notes:
 - Uses real-time subtensor queries for emission rate estimation
 """
 
+from dataclasses import dataclass, field
 import bittensor as bt
 from datetime import datetime, timedelta, timezone
 from typing import List, Tuple
 
 from shared_objects.rpc.metagraph_client import MetagraphClient
-from time_util.time_util import TimeUtil
+from time_util.time_util import MS_IN_WEEK, TimeUtil
 from vali_objects.challenge_period.challengeperiod_client import ChallengePeriodClient
 from vali_objects.miner_account.miner_account_client import MinerAccountClient
 from vali_objects.vali_dataclasses.ledger.debt.debt_ledger import DebtLedger, DebtCheckpoint
@@ -54,6 +55,31 @@ from vali_objects.enums.miner_bucket_enum import MinerBucket
 from vali_objects.vali_config import ValiConfig
 from vali_objects.scoring.scoring import Scoring
 from collections import defaultdict
+
+from vali_objects.vali_dataclasses.ledger.perf.perf_ledger import PerfLedger
+from vali_objects.vali_dataclasses.order import Order
+from vali_objects.vali_dataclasses.position import Position
+
+@dataclass
+class PayoutSettlement:
+    start_ms: int
+    end_ms: int
+    balance: float
+    unrealized_pnl: float
+    payout_raw: float
+    payout_penalized: float
+    orders: list[Order] = field(default_factory=list)
+
+    # different field names for backwards compatibility with UI
+    def to_dict(self):
+        return {
+            'start_ms': self.start_ms,
+            'end_ms': self.end_ms,
+            'eow_balance': self.balance,
+            'eow_unrealized': self.unrealized_pnl,
+            'payout': self.payout_raw,
+            'orders': [o.to_python_dict() for o in self.orders],
+        }
 
 
 class DebtBasedScoring:
@@ -238,6 +264,139 @@ class DebtBasedScoring:
 
         payout = realized_component + unrealized_component
         return payout
+
+    @staticmethod
+    def generate_weekly_settlements(
+        positions: List[Position],
+        perf_ledger: PerfLedger,
+        debt_ledger: DebtLedger | None = None,
+        start_time_ms: int = 0,
+        end_time_ms: int | None = None,
+    ) -> list[PayoutSettlement]:
+        """
+        Calculate weekly payout from positions
+        """
+        CP_DURATION_MS = ValiConfig.TARGET_CHECKPOINT_DURATION_MS
+        is_realtime = False
+        if end_time_ms is None:
+            is_realtime = True
+            end_time_ms = TimeUtil.now_in_millis()
+
+        orders, fees = [], []
+        realtime_unrealized_pnl = 0
+        for position in positions:
+            orders.extend(order for order in position.orders if order.processed_ms < end_time_ms)
+            fees.extend(fee for fee in position.fee_history if fee["time_ms"] < end_time_ms)
+            realtime_unrealized_pnl += position.unrealized_pnl
+
+        orders.sort(key=lambda x: x.processed_ms)
+        fees.sort(key=lambda x: x["time_ms"])
+        if not orders:
+            return []
+
+        weekly_settlements = []
+        balance = 0
+        eow_hwm = 0
+
+        # Always start week_start at the Monday 00:00 UTC of the first order.
+        week_start_ms = TimeUtil.ms_at_start_of_week(orders[0].processed_ms)
+        order_idx, fee_idx = 0, 0
+        while week_start_ms < end_time_ms:
+            week_end_ms = min(week_start_ms + MS_IN_WEEK, end_time_ms)
+            realized_orders_in_week = []
+
+            weekly_net_pnl, weekly_penalized_pnl = 0, 0
+            while order_idx < len(orders) and orders[order_idx].processed_ms < week_end_ms:
+                order = orders[order_idx]
+                if order.realized_pnl != 0:
+                    realized_orders_in_week.append(order)
+
+                order_penalty = 1.0
+                if debt_ledger:
+                    order_penalty_ms = TimeUtil.align_to_12hour_checkpoint_boundary(order.processed_ms)
+                    penalty_checkpoint = debt_ledger.get_checkpoint_at_time(order_penalty_ms, CP_DURATION_MS)
+                    order_penalty = penalty_checkpoint.total_penalty if penalty_checkpoint else 1.0
+
+                weekly_net_pnl += order.realized_pnl
+                weekly_penalized_pnl += order.realized_pnl * order_penalty
+
+                order_idx += 1
+            while fee_idx < len(fees) and fees[fee_idx]["time_ms"] < week_end_ms:
+                weekly_net_pnl -= fees[fee_idx]["amount"]
+                weekly_penalized_pnl -= fees[fee_idx]["amount"]
+                fee_idx += 1
+
+            # Use perf ledger instead of delayed debt ledger
+            perf_checkpoint = perf_ledger.get_checkpoint_at_time(week_end_ms, ValiConfig.TARGET_CHECKPOINT_DURATION_MS)
+            unrealized_pnl = perf_checkpoint.unrealized_pnl if perf_checkpoint else 0.0
+            if week_end_ms == end_time_ms and is_realtime:
+                unrealized_pnl = realtime_unrealized_pnl
+
+            eow_balance = balance + weekly_net_pnl
+            eow_balance_penalty = balance + weekly_penalized_pnl
+            payout_raw = max(0.0, eow_balance - eow_hwm + min(0, unrealized_pnl))
+            payout_penalized = max(0.0, eow_balance_penalty - eow_hwm + min(0, unrealized_pnl))
+            # Only return desired weekly settlements
+            if week_start_ms >= start_time_ms and week_end_ms <= end_time_ms:
+                weekly_settlements.append(PayoutSettlement(
+                    start_ms=week_start_ms,
+                    end_ms=week_end_ms,
+                    balance=eow_balance,
+                    unrealized_pnl=unrealized_pnl,
+                    payout_raw=payout_raw,
+                    payout_penalized=payout_penalized,
+                    orders=realized_orders_in_week
+                ))
+
+            balance = eow_balance
+            eow_hwm = max(eow_hwm, balance)
+            week_start_ms = week_end_ms
+
+        return weekly_settlements
+
+    @staticmethod
+    def generate_payout_settlements(
+        hotkeys: list[str],
+        miner_positions: dict[str, list[Position]],
+        perf_ledgers: dict[str, PerfLedger],
+        debt_ledgers: dict[str, DebtLedger],
+        end_time_ms: int | None = None,
+        # interval,  # TODO support different intervals base
+    ) -> dict[str, list[PayoutSettlement]]:
+        """
+        Calculate weekly payout for hotkeys for what their debt ledger allows
+        """
+
+        if not end_time_ms:
+            end_time_ms = TimeUtil.now_in_millis()
+
+        result = {}
+        for hotkey in hotkeys:
+            positions = miner_positions.get(hotkey)
+            perf_ledger = perf_ledgers.get(hotkey)
+            debt_ledger = debt_ledgers.get(hotkey)
+            if not positions or not perf_ledger or not debt_ledger or not debt_ledger.checkpoints:
+                result[hotkey] = []
+                continue
+
+            # Start the payout cycle from the full week we have of the debt ledger
+            payout_start_ms = 0
+            if debt_ledger.checkpoints:
+                payout_start_ms = TimeUtil.ms_at_start_of_week(debt_ledger.checkpoints[0].timestamp_ms) + MS_IN_WEEK
+
+            payout_end_ms = TimeUtil.ms_at_start_of_week(end_time_ms)
+
+            settlements = DebtBasedScoring.generate_weekly_settlements(
+                positions=positions,
+                perf_ledger=perf_ledger,
+                debt_ledger=debt_ledger,
+                start_time_ms=payout_start_ms,
+                end_time_ms=payout_end_ms
+            )
+
+            result[hotkey] = settlements
+
+        return result
 
     @staticmethod
     def compute_results(

--- a/vali_objects/scoring/debt_based_scoring.py
+++ b/vali_objects/scoring/debt_based_scoring.py
@@ -70,6 +70,19 @@ class PayoutSettlement:
     payout_penalized: float
     orders: list[Order] = field(default_factory=list)
 
+    def __str__(self):
+        from time_util.time_util import TimeUtil
+        start = TimeUtil.millis_to_datetime(self.start_ms).strftime('%Y-%m-%d')
+        end = TimeUtil.millis_to_datetime(self.end_ms).strftime('%Y-%m-%d')
+        return (
+            f"PayoutSettlement [{start} → {end}] "
+            f"balance={self.balance:.4f} unrealized_pnl={self.unrealized_pnl:.4f} "
+            f"payout_raw={self.payout_raw:.4f} payout_penalized={self.payout_penalized:.4f}"
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
     # different field names for backwards compatibility with UI
     def to_dict(self):
         return {
@@ -395,6 +408,9 @@ class DebtBasedScoring:
             )
 
             result[hotkey] = settlements
+            print(f"  {hotkey} settlements ({len(settlements)}):")
+            for s in settlements:
+                print(f"    {s}")
 
         return result
 

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -8,7 +8,7 @@ WeightCalculatorServer wraps this and exposes methods via RPC.
 
 This follows the same pattern as ChallengePeriodManager.
 """
-import time
+from datetime import datetime, timedelta, timezone
 import traceback
 import threading
 from typing import List, Tuple
@@ -18,10 +18,11 @@ import bittensor as bt
 from shared_objects.cache_controller import CacheController
 from shared_objects.error_utils import ErrorUtils
 from shared_objects.slack_notifier import SlackNotifier
-from time_util.time_util import TimeUtil
+from time_util.time_util import MS_IN_WEEK, TimeUtil
 from vali_objects.vali_config import ValiConfig, RPCConnectionMode
 from vali_objects.scoring.debt_based_scoring import DebtBasedScoring
 from vali_objects.enums.miner_bucket_enum import MinerBucket
+from vali_objects.vali_dataclasses.ledger.perf.perf_ledger_client import PerfLedgerClient
 
 
 class WeightCalculatorManager(CacheController):
@@ -104,6 +105,13 @@ class WeightCalculatorManager(CacheController):
 
         from vali_objects.miner_account.miner_account_client import MinerAccountClient
         self._miner_account_client = MinerAccountClient()
+        from vali_objects.vali_dataclasses.ledger.debt.debt_ledger_client import DebtLedgerClient
+
+        self._perf_ledger_client = PerfLedgerClient(
+            running_unit_tests=running_unit_tests,
+            connect_immediately=False,
+            connection_mode=connection_mode
+        )
 
         from vali_objects.vali_dataclasses.ledger.debt.debt_ledger_client import DebtLedgerClient
         self._debt_ledger_client = DebtLedgerClient(
@@ -285,7 +293,6 @@ class WeightCalculatorManager(CacheController):
             for hotkey, ledger in all_debt_ledgers.items()
             if hotkey in hotkeys_to_compute_weights_for
         }
-
         if len(filtered_debt_ledgers) == 0:
             total_ledgers = len(all_debt_ledgers)
             if total_ledgers == 0:
@@ -307,15 +314,194 @@ class WeightCalculatorManager(CacheController):
         verbose = current_time - self._last_verbose_ms >= 30 * 60 * 1000
         if verbose:
             self._last_verbose_ms = current_time
-        checkpoint_results = DebtBasedScoring.compute_results(
-            ledger_dict=filtered_debt_ledgers,
+
+        current_time_ms = TimeUtil.now_in_millis()
+        # Get current datetime
+        current_dt = TimeUtil.millis_to_datetime(current_time_ms)
+
+        if verbose:
+            bt.logging.info(
+                f"Computing debt-based weights for {current_dt.strftime('%B %Y')} "
+                f"({len(filtered_debt_ledgers)} miners)"
+            )
+
+        # Calculate boundaries
+        # Needed payout calculation: Sum from activation through end of previous
+        # week (considered midnight on Sunday 00:00:00)
+        # This allows negative PnL to carry across weeks and offset future gains
+        payout_activation_start_dt = datetime(
+            DebtBasedScoring.ACTIVATION_YEAR,
+            DebtBasedScoring.ACTIVATION_MONTH,
+            1, 0, 0, 0,
+            tzinfo=timezone.utc
+        ) - timedelta(days=7)
+        payout_activation_start_ms = int(payout_activation_start_dt.timestamp() * 1000)
+
+        current_weekday = current_dt.weekday()
+        prev_target_day_offset = (current_weekday + 1) % 7
+        days_until_target = 7 - prev_target_day_offset
+        prev_target_dt = current_dt - timedelta(days=prev_target_day_offset)
+        prev_target_end_dt = datetime.combine(prev_target_dt, datetime.min.time())
+        prev_target_end_ms = int(prev_target_end_dt.timestamp() * 1000)
+
+        all_positions = self._position_client.get_positions_for_all_miners()
+        all_perf_ledgers = self._perf_ledger_client.get_perf_ledgers()
+
+        # Calculate regular hotkey payouts
+        funded_hotkeys = self._challengeperiod_client.get_hotkeys_by_bucket(
+            [MinerBucket.PROBATION, MinerBucket.MAINCOMP]
+        )
+
+        # Payout settlements are generated starting the first full week of each miner's debt ledger
+        miner_required_payout_settlements = DebtBasedScoring.generate_payout_settlements(
+            hotkeys=funded_hotkeys,
+            miner_positions=all_positions,
+            perf_ledgers=all_perf_ledgers,
+            debt_ledgers=all_debt_ledgers,
+            end_time_ms=prev_target_end_ms
+        )
+        miner_required_payouts = {
+            hotkey: sum(payout.payout_penalized for payout in payouts)
+            for hotkey, payouts in miner_required_payout_settlements.items()
+        }
+
+        # Emissions should be calculated starting from the full week after the first weekly settlement
+        miner_emissions_cumulative = {}
+        for hotkey, weekly_settlements in miner_required_payout_settlements.items():
+            if not weekly_settlements:
+                miner_emissions_cumulative[hotkey] = 0
+                continue
+
+            debt_ledger = all_debt_ledgers.get(hotkey)
+            if not debt_ledger:
+                miner_emissions_cumulative[hotkey] = 0
+                continue
+
+            emissions_start_ms = weekly_settlements[0].end_ms
+            emissions_end_ms = weekly_settlements[-1].end_ms + MS_IN_WEEK
+            miner_emissions_cumulative[hotkey] = sum(
+                cp.chunk_emissions_usd
+                for cp in debt_ledger.checkpoints
+                if emissions_start_ms <= cp.timestamp_ms <= emissions_end_ms
+            )
+
+        # Use regular checkopint calculations for entity miners for frozen ledgers
+        # Means we have to use the full cumulative emissions of the debt ledger
+        # Debt ledger of entity miners should have full history from first funded miner's perf ledger
+        entity_hotkeys = self._challengeperiod_client.get_hotkeys_by_bucket(MinerBucket.ENTITY)
+        entity_miner_required_payouts = {
+            hotkey: DebtBasedScoring.calculate_payout_from_checkpoints([])
+            for hotkey in entity_hotkeys
+        }
+        entity_miner_emissions_cumulative = {}
+        for hotkey in entity_hotkeys:
+            debt_ledger = all_debt_ledgers.get(hotkey)
+            if not debt_ledger:
+                entity_miner_emissions_cumulative[hotkey] = 0
+                continue
+            entity_miner_emissions_cumulative[hotkey] = sum(
+                cp.chunk_emissions_usd for cp in debt_ledger.checkpoints
+            )
+
+        # Combine miner and entity payouts/emissions into unified dicts
+        all_required_payouts = {**miner_required_payouts, **entity_miner_required_payouts}
+        all_emissions_cumulative = {**miner_emissions_cumulative, **entity_miner_emissions_cumulative}
+
+        # Calculate remaining payouts: needed minus already paid, clamped to zero
+        miner_remaining_payouts_usd = {}
+        for hotkey in all_required_payouts:
+            needed = all_required_payouts.get(hotkey, 0.0)
+            actual = all_emissions_cumulative.get(hotkey, 0.0)
+            miner_remaining_payouts_usd[hotkey] = max(0.0, needed - actual)
+
+        total_remaining_payout_usd = sum(miner_remaining_payouts_usd.values())
+        total_actual_payout_usd = sum(all_emissions_cumulative.values())
+        total_needed_payout_usd = total_remaining_payout_usd + total_actual_payout_usd
+        bt.logging.info(
+            f"[PAYOUT] SUMMARY ({len(miner_remaining_payouts_usd)} miners): "
+            f"remaining_payouts=${total_remaining_payout_usd:.2f}, "
+            f"required_payouts=${total_needed_payout_usd:.2f}, "
+            f"paid_out=${total_actual_payout_usd:.2f}"
+        )
+
+        if verbose:
+            _payouts_sorted = sorted(all_required_payouts.keys(), key=lambda hk: miner_remaining_payouts_usd.get(hk, 0.0), reverse=True)
+            for hotkey in _payouts_sorted:
+                remaining = miner_remaining_payouts_usd.get(hotkey, 0.0)
+                actual = all_emissions_cumulative.get(hotkey, 0.0)
+                needed = all_required_payouts.get(hotkey, 0.0)
+                bt.logging.info(
+                    f"[PAYOUT] [{hotkey}] remaining=${remaining:.2f}, paid_out=${actual:.2f}, required=${needed:.2f}"
+                )
+
+        # Estimate projected emissions in USD for weight normalization
+        projected_alpha_available = DebtBasedScoring._estimate_alpha_emissions_until_target(
             metagraph_client=self._metagraph_client,
+            days_until_target=days_until_target,
+            verbose=verbose
+        )
+        projected_usd_available = DebtBasedScoring._convert_alpha_to_usd(
+            alpha_amount=projected_alpha_available,
+            metagraph_client=self._metagraph_client,
+            verbose=verbose
+        )
+
+        if verbose:
+            bt.logging.info(
+                f"[PAYOUT_DEBUG] PROJECTED EMISSIONS: {projected_alpha_available:.2f} ALPHA = "
+                f"${projected_usd_available:.2f} USD over {days_until_target} days "
+                f"(${projected_usd_available / days_until_target:.2f}/day)"
+            )
+
+        if total_remaining_payout_usd > 0:
+            DebtBasedScoring.log_projections(self._metagraph_client, days_until_target, verbose, total_remaining_payout_usd)
+
+        # Spread remaining payouts over days until target
+        miner_daily_target_payouts_usd = {
+            hotkey: remaining / days_until_target
+            for hotkey, remaining in miner_remaining_payouts_usd.items()
+        }
+        projected_daily_usd = projected_usd_available / days_until_target
+
+        # Normalize daily payouts against projected daily emissions to get raw weights
+        raw_debt_weights = DebtBasedScoring._compute_raw_weights_from_payouts(
+            miner_daily_target_payouts_usd=miner_daily_target_payouts_usd,
+            projected_daily_emissions_usd=projected_daily_usd,
+            verbose=verbose
+        )
+
+        # Enforce minimum dust weights per bucket for all eligible hotkeys
+        miner_weights_with_minimums = DebtBasedScoring._apply_minimum_weights(
+            eligible_hotkeys=hotkeys_to_compute_weights_for,
+            raw_debt_weights=raw_debt_weights,
+            ledger_dict=filtered_debt_ledgers,
             challengeperiod_client=self._challengeperiod_client,
             miner_account_client=self._miner_account_client,
-            current_time_ms=current_time,
-            verbose=verbose,
+            current_time_ms=current_time_ms,
+            verbose=verbose
+        )
+
+        if verbose:
+            bt.logging.info(
+                f"[PAYOUT_DEBUG] WEIGHT SUMMARY: {len(miner_weights_with_minimums)} miners, "
+                f"total_remaining=${total_remaining_payout_usd:.2f}, "
+                f"projected_daily_emissions=${projected_daily_usd:.2f}, "
+                f"days_until_target={days_until_target}"
+            )
+            for hk, w in sorted(miner_weights_with_minimums.items(), key=lambda x: -x[1]):
+                daily_target = miner_daily_target_payouts_usd.get(hk, 0.0)
+                if daily_target > 0:
+                    bt.logging.info(
+                        f"[PAYOUT_DEBUG] TOP WEIGHT [{hk}]: weight={w:.8f}, "
+                        f"daily_target=${daily_target:.2f}"
+                    )
+
+        # Normalize weights; excess emissions assigned to burn address
+        checkpoint_results = DebtBasedScoring._normalize_with_burn_address(
+            weights=miner_weights_with_minimums,
+            metagraph_client=self._metagraph_client,
             is_testnet=not self.is_mainnet,
-            eligible_hotkeys=hotkeys_to_compute_weights_for
+            verbose=verbose
         )
 
         bt.logging.info(f"Debt-based scoring results: [{checkpoint_results}]")

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -337,13 +337,7 @@ class WeightCalculatorManager(CacheController):
             tzinfo=timezone.utc
         ) - timedelta(days=7)
         payout_activation_start_ms = int(payout_activation_start_dt.timestamp() * 1000)
-
-        current_weekday = current_dt.weekday()
-        prev_target_day_offset = (current_weekday + 1) % 7
-        days_until_target = 7 - prev_target_day_offset
-        prev_target_dt = current_dt - timedelta(days=prev_target_day_offset)
-        prev_target_end_dt = datetime.combine(prev_target_dt, datetime.min.time())
-        prev_target_end_ms = int(prev_target_end_dt.timestamp() * 1000)
+        prev_target_end_ms = TimeUtil.ms_at_start_of_week(current_time_ms)
 
         all_positions = self._position_client.get_positions_for_all_miners()
         all_perf_ledgers = self._perf_ledger_client.get_perf_ledgers()
@@ -419,7 +413,7 @@ class WeightCalculatorManager(CacheController):
             f"[PAYOUT] SUMMARY ({len(miner_remaining_payouts_usd)} miners): "
             f"remaining_payouts=${total_remaining_payout_usd:.2f}, "
             f"required_payouts=${total_needed_payout_usd:.2f}, "
-            f"paid_out=${total_actual_payout_usd:.2f}"
+            f"paid_out=${total_actual_payout_usd:.2f} (accumulated until {TimeUtil.millis_to_short_date_str(prev_target_end_ms)}"
         )
 
         all_time_emissions = {
@@ -445,6 +439,7 @@ class WeightCalculatorManager(CacheController):
                     f"[PAYOUT] [{hotkey}] remaining=${remaining:.2f}, paid_out=${actual:.2f}, required=${needed:.2f}, all_time_emissions=${all_time:.2f}{week_range}"
                 )
 
+        days_until_target = 7 - current_dt.weekday()
         # Estimate projected emissions in USD for weight normalization
         projected_alpha_available = DebtBasedScoring._estimate_alpha_emissions_until_target(
             metagraph_client=self._metagraph_client,

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -422,14 +422,27 @@ class WeightCalculatorManager(CacheController):
             f"paid_out=${total_actual_payout_usd:.2f}"
         )
 
+        all_time_emissions = {
+            hotkey: sum(cp.chunk_emissions_usd for cp in ledger.checkpoints)
+            for hotkey, ledger in all_emissions_ledgers.items()
+        }
+
         if verbose:
             _payouts_sorted = sorted(all_required_payouts.keys(), key=lambda hk: miner_remaining_payouts_usd.get(hk, 0.0), reverse=True)
             for hotkey in _payouts_sorted:
                 remaining = miner_remaining_payouts_usd.get(hotkey, 0.0)
                 actual = all_emissions_cumulative.get(hotkey, 0.0)
                 needed = all_required_payouts.get(hotkey, 0.0)
+                all_time = all_time_emissions.get(hotkey, 0.0)
+                settlements = miner_required_payout_settlements.get(hotkey, [])
+                if settlements:
+                    first_week = TimeUtil.millis_to_datetime(settlements[0].start_ms).strftime('%Y-%m-%d')
+                    last_week = TimeUtil.millis_to_datetime(settlements[-1].end_ms).strftime('%Y-%m-%d')
+                    week_range = f" ({first_week} - {last_week})"
+                else:
+                    week_range = ""
                 bt.logging.info(
-                    f"[PAYOUT] [{hotkey}] remaining=${remaining:.2f}, paid_out=${actual:.2f}, required=${needed:.2f}"
+                    f"[PAYOUT] [{hotkey}] remaining=${remaining:.2f}, paid_out=${actual:.2f}, required=${needed:.2f}, all_time_emissions=${all_time:.2f}{week_range}"
                 )
 
         # Estimate projected emissions in USD for weight normalization

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -360,6 +360,14 @@ class WeightCalculatorManager(CacheController):
             hotkey: sum(payout.payout_penalized for payout in payouts)
             for hotkey, payouts in miner_required_payout_settlements.items()
         }
+        miner_required_payouts_raw = {
+            hotkey: sum(payout.payout_raw for payout in payouts)
+            for hotkey, payouts in miner_required_payout_settlements.items()
+        }
+        miner_required_payouts_raw = {
+            hotkey: sum(payout.payout_raw for payout in payouts)
+            for hotkey, payouts in miner_required_payout_settlements.items()
+        }
 
         # Emissions should be calculated starting from the full week after the first weekly settlement
         miner_emissions_cumulative = {}
@@ -402,9 +410,9 @@ class WeightCalculatorManager(CacheController):
         # Calculate remaining payouts: needed minus already paid, clamped to zero
         miner_remaining_payouts_usd = {}
         for hotkey in all_required_payouts:
-            needed = all_required_payouts.get(hotkey, 0.0)
+            payout_penalized = all_required_payouts.get(hotkey, 0.0)
             actual = all_emissions_cumulative.get(hotkey, 0.0)
-            miner_remaining_payouts_usd[hotkey] = max(0.0, needed - actual)
+            miner_remaining_payouts_usd[hotkey] = max(0.0, payout_penalized - actual)
 
         total_remaining_payout_usd = sum(miner_remaining_payouts_usd.values())
         total_actual_payout_usd = sum(all_emissions_cumulative.values())
@@ -426,7 +434,8 @@ class WeightCalculatorManager(CacheController):
             for hotkey in _payouts_sorted:
                 remaining = miner_remaining_payouts_usd.get(hotkey, 0.0)
                 actual = all_emissions_cumulative.get(hotkey, 0.0)
-                needed = all_required_payouts.get(hotkey, 0.0)
+                payout_penalized = all_required_payouts.get(hotkey, 0.0)
+                payout_raw = miner_required_payouts_raw.get(hotkey, 0.0)
                 all_time = all_time_emissions.get(hotkey, 0.0)
                 settlements = miner_required_payout_settlements.get(hotkey, [])
                 if settlements:
@@ -436,7 +445,8 @@ class WeightCalculatorManager(CacheController):
                 else:
                     week_range = ""
                 bt.logging.info(
-                    f"[PAYOUT] [{hotkey}] remaining=${remaining:.2f}, paid_out=${actual:.2f}, required=${needed:.2f}, all_time_emissions=${all_time:.2f}{week_range}"
+                    f"[PAYOUT] [{hotkey}] remaining=${remaining:.2f}, paid_out=${actual:.2f}, "
+                    f"payout_penalized=${payout_penalized:.2f}, payout_raw=${payout_raw:.2f}{week_range}, all_time_emissions=${all_time:.2f}"
                 )
 
         days_until_target = 7 - current_dt.weekday()

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -390,18 +390,14 @@ class WeightCalculatorManager(CacheController):
         # Debt ledger of entity miners should have full history from first funded miner's perf ledger
         entity_hotkeys = self._challengeperiod_client.get_hotkeys_by_bucket(MinerBucket.ENTITY)
         entity_miner_required_payouts = {
-            hotkey: DebtBasedScoring.calculate_payout_from_checkpoints([])
+            hotkey: DebtBasedScoring.calculate_payout_from_checkpoints(
+                all_debt_ledgers[hotkey].checkpoints if hotkey in all_debt_ledgers else [])
             for hotkey in entity_hotkeys
         }
-        entity_miner_emissions_cumulative = {}
-        for hotkey in entity_hotkeys:
-            debt_ledger = all_debt_ledgers.get(hotkey)
-            if not debt_ledger:
-                entity_miner_emissions_cumulative[hotkey] = 0
-                continue
-            entity_miner_emissions_cumulative[hotkey] = sum(
-                cp.chunk_emissions_usd for cp in debt_ledger.checkpoints
-            )
+        entity_miner_emissions_cumulative = {
+            hotkey: sum(cp.chunk_emissions_usd for cp in all_debt_ledgers[hotkey].checkpoints)
+            for hotkey in entity_hotkeys if hotkey in all_debt_ledgers
+        }
 
         # Combine miner and entity payouts/emissions into unified dicts
         all_required_payouts = {**miner_required_payouts, **entity_miner_required_payouts}

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -293,6 +293,7 @@ class WeightCalculatorManager(CacheController):
             for hotkey, ledger in all_debt_ledgers.items()
             if hotkey in hotkeys_to_compute_weights_for
         }
+        all_emissions_ledgers = self._debt_ledger_client.get_all_emissions_ledgers()
         if len(filtered_debt_ledgers) == 0:
             total_ledgers = len(all_debt_ledgers)
             if total_ledgers == 0:
@@ -357,7 +358,7 @@ class WeightCalculatorManager(CacheController):
             hotkeys=funded_hotkeys,
             miner_positions=all_positions,
             perf_ledgers=all_perf_ledgers,
-            debt_ledgers=all_debt_ledgers,
+            debt_ledgers=filtered_debt_ledgers,
             end_time_ms=prev_target_end_ms
         )
         miner_required_payouts = {
@@ -395,8 +396,8 @@ class WeightCalculatorManager(CacheController):
             for hotkey in entity_hotkeys
         }
         entity_miner_emissions_cumulative = {
-            hotkey: sum(cp.chunk_emissions_usd for cp in all_debt_ledgers[hotkey].checkpoints)
-            for hotkey in entity_hotkeys if hotkey in all_debt_ledgers
+            hotkey: sum(cp.chunk_emissions_usd for cp in all_emissions_ledgers[hotkey].checkpoints)
+            for hotkey in entity_hotkeys if hotkey in all_emissions_ledgers
         }
 
         # Combine miner and entity payouts/emissions into unified dicts

--- a/vali_objects/scoring/weight_calculator_manager.py
+++ b/vali_objects/scoring/weight_calculator_manager.py
@@ -327,13 +327,13 @@ class WeightCalculatorManager(CacheController):
             )
 
         # Calculate boundaries
-        # Needed payout calculation: Sum from activation through end of previous
-        # week (considered midnight on Sunday 00:00:00)
+        # Needed payout calculation: Sum from activation through end of previous week
+        # Payout activation start Nov 3, 2025 Monday 00:00 UTC
         # This allows negative PnL to carry across weeks and offset future gains
         payout_activation_start_dt = datetime(
             DebtBasedScoring.ACTIVATION_YEAR,
             DebtBasedScoring.ACTIVATION_MONTH,
-            1, 0, 0, 0,
+            3, 0, 0, 0,
             tzinfo=timezone.utc
         ) - timedelta(days=7)
         payout_activation_start_ms = int(payout_activation_start_dt.timestamp() * 1000)
@@ -359,6 +359,7 @@ class WeightCalculatorManager(CacheController):
             miner_positions=all_positions,
             perf_ledgers=all_perf_ledgers,
             debt_ledgers=filtered_debt_ledgers,
+            start_time_ms=payout_activation_start_ms,
             end_time_ms=prev_target_end_ms
         )
         miner_required_payouts = {


### PR DESCRIPTION
Use positions to calculate weekly hwm based on penalty of order realized pnl time.
- Calculate required payout from full position history accumulating hwm from first position
- filter payout eligible orders based on first earning checkpoint in debt ledger
- only calculate payouts for weeks with full penalty checkpoints
- offset cumulative emissions received by a week from the first calculated week
- keep entity miner emissions based on debt ledger to cover eliminated subaccounts