### PR TITLE
Fix post elimination states

### DIFF
--- a/vali_objects/data_export/core_outputs_manager.py
+++ b/vali_objects/data_export/core_outputs_manager.py
@@ -275,6 +275,12 @@ class CoreOutputsManager:
         except Exception as e:
             bt.logging.warning(f"Could not fetch entity data: {e}")
 
+        frozen_perf_ledgers = {}
+        try:
+            frozen_perf_ledgers = self._perf_ledger_client.get_frozen_ledgers()
+        except Exception as e:
+            bt.logging.warning(f"Could not fetch frozen perf ledgers: {e}")
+
         final_dict = {
             'version': ValiConfig.VERSION,
             'created_timestamp_ms': time_now,
@@ -287,6 +293,7 @@ class CoreOutputsManager:
             'oldest_order_processed_ms': oldest_order_processed_ms,
             'positions': ord_dict_hotkey_position_map,
             'perf_ledgers': perf_ledgers,
+            'frozen_perf_ledgers': frozen_perf_ledgers,
             'asset_selections': asset_selections,
             'limit_orders': limit_orders_dict,
             'archived_positions': archived_positions or {}

--- a/vali_objects/data_sync/validator_sync_base.py
+++ b/vali_objects/data_sync/validator_sync_base.py
@@ -173,6 +173,12 @@ class ValidatorSyncBase():
                 bt.logging.info(f"Syncing {len(miner_account_sizes_data)} miner account size records from auto sync")
                 self._miner_account_client.sync_miner_account_sizes_data(miner_account_sizes_data)
 
+        # Sync frozen perf ledgers if available
+        frozen_perf_ledgers_data = candidate_data.get('frozen_perf_ledgers', {})
+        if frozen_perf_ledgers_data and not shadow_mode:
+            bt.logging.info(f"Syncing {len(frozen_perf_ledgers_data)} frozen perf ledger records from auto sync")
+            self._perf_ledger_client.sync_frozen_ledgers(frozen_perf_ledgers_data)
+
         eliminated_hotkeys = set([e['hotkey'] for e in eliminations])
         # For a healthy validator, the existing positions will always be a superset of the candidate positions
         for hotkey, positions in candidate_hk_to_positions.items():

--- a/vali_objects/utils/elimination/elimination_manager.py
+++ b/vali_objects/utils/elimination/elimination_manager.py
@@ -772,11 +772,12 @@ class EliminationManager(CacheController):
                 if deleted_limit_orders:
                     bt.logging.info(f"Cancelled {deleted_limit_orders} pending limit orders for eliminated miner [{hotkey}]")
 
-                positions = self._position_client.get_positions_for_one_hotkey(hotkey, only_open_positions=False)
-                for p in positions:
+                open_positions = self._position_client.get_positions_for_one_hotkey(hotkey, only_open_positions=True)
+                for p in open_positions:
                     self._close_position(hotkey, p, elimination_data.elimination_initiated_time_ms, iteration_epoch=iteration_epoch)
 
-                self._miner_account_client.rebuild_account_state_from_positions(hotkey, positions)
+                all_positions = self._position_client.get_positions_for_one_hotkey(hotkey)
+                self._miner_account_client.rebuild_account_state_from_positions(hotkey, all_positions)
 
                 with self.eliminations_lock:
                     self.eliminations[hotkey].positions_closed = True

--- a/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_client.py
+++ b/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_client.py
@@ -71,6 +71,15 @@ class PerfLedgerClient(RPCClientBase):
         """
         return self._server.get_frozen_ledgers_rpc(from_disk=from_disk)
 
+    def sync_frozen_ledgers(self, frozen_ledgers_data: dict) -> None:
+        """
+        Sync frozen performance ledgers from auto sync checkpoint data.
+
+        Args:
+            frozen_ledgers_data: Dict mapping hotkey to frozen perf ledger dict
+        """
+        self._server.sync_frozen_ledgers_rpc(frozen_ledgers_data)
+
     def generate_perf_ledgers_for_analysis(self, hotkey_to_positions, t_ms: int = None) -> dict:
         """Generate performance ledgers for analysis."""
         return self._server.generate_perf_ledgers_for_analysis_rpc(hotkey_to_positions, t_ms=t_ms)

--- a/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_manager.py
+++ b/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_manager.py
@@ -388,6 +388,12 @@ class PerfLedgerManager(CacheController):
         if os.path.exists(json_gz_path):
             os.remove(json_gz_path)
 
+    def sync_frozen_ledgers(self, frozen_ledgers_data: dict):
+        file_path = ValiBkpUtils.get_frozen_perf_ledgers_path(self.running_unit_tests)
+        ValiBkpUtils.write_compressed_json(file_path, frozen_ledgers_data)
+        self._frozen_ledgers = self.get_frozen_ledgers(from_disk=True)
+        bt.logging.info(f"Synced {len(self._frozen_ledgers)} frozen perf ledgers from auto sync")
+
     @staticmethod
     def clear_perf_ledgers_from_disk_autosync(hotkeys:list):
         compressed_json_path = ValiBkpUtils.get_perf_ledgers_path(running_unit_tests=False)

--- a/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_server.py
+++ b/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_server.py
@@ -163,6 +163,10 @@ class PerfLedgerServer(RPCServerBase):
         """Get frozen performance ledgers via RPC."""
         return self._manager.get_frozen_ledgers(from_disk=from_disk)
 
+    def sync_frozen_ledgers_rpc(self, frozen_ledgers_data: dict) -> None:
+        """Sync frozen performance ledgers from auto sync checkpoint data."""
+        self._manager.sync_frozen_ledgers(frozen_ledgers_data)
+
     def filtered_ledger_for_scoring_rpc(
         self,
         hotkeys: List[str] = None


### PR DESCRIPTION
- rebuild account state on elimination was running on stale open positions
- Include frozen perf ledgers in autosync for missed ledgers of funded accounts (can't reproduce from positions)
- Write raw dict to file then read again for serialization... update to similar read/write checkpoint style with future perf ledger overhaul