### PR TITLE
Create MinerAssetClass independent of TradePairCategory

### DIFF
--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -37,6 +37,7 @@ from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.utils.vali_utils import ValiUtils
 from datetime import datetime, timezone
 from vali_objects.vali_config import ValiConfig, RPCConnectionMode, TradePairCategory
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from shared_objects.cache_controller import CacheController
 from vali_objects.vali_dataclasses.ledger.perf.perf_ledger_client import PerfLedgerClient
 from vali_objects.validator_broadcast_base import ValidatorBroadcastBase
@@ -1471,7 +1472,7 @@ class EntityManager(ValidatorBroadcastBase):
                 # Calculate challenge progress
                 asset_class = (subaccount.asset_class or '').lower()
                 target_return = ValiConfig.SUBACCOUNT_CHALLENGE_RETURNS_THRESHOLD.get(
-                    TradePairCategory(asset_class) if asset_class else None,
+                    MinerAssetClass(asset_class) if MinerAssetClass.is_valid(asset_class) else None,
                     ValiConfig.SUBACCOUNT_CHALLENGE_RETURNS_THRESHOLD_DEFAULT
                 )
 

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -428,6 +428,10 @@ class EntityManager(ValidatorBroadcastBase):
         current_balance = self._entity_collateral_client.get_cached_collateral(entity_hotkey)
         required_min_theta = self._entity_collateral_client.compute_entity_required_collateral(entity_hotkey)
 
+        # Map hl_all to all markets for non-hyperliquid TODO remove after migration
+        if asset_class == "hl_all" and not hl_address:
+            asset_class = "all_markets"
+
         # Use per-entity lock: only operates on single entity
         entity_lock = self._get_entity_lock(entity_hotkey)
         with entity_lock:

--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "8.14.3"
+  "subnet_version": "8.14.4"
 }

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -525,7 +525,7 @@ class Validator(ValidatorBase):
                        f"https://github.com/taoshidev/vanta-cli")
                 synapse.error_message = msg
 
-            elif not self.asset_selection_client.validate_order_asset_class_local_cache(selected_asset, tp) and order_type != OrderType.FLAT:
+            elif not selected_asset.allows_trade_pair(tp) and order_type != OrderType.FLAT:
                 asset_validate_ms = (time.perf_counter() - asset_validate_start) * 1000
                 bt.logging.info(f"[FAIL_EARLY_DEBUG] validate_order_asset_class_local_cache took {asset_validate_ms:.2f}ms")
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -525,9 +525,9 @@ class Validator(ValidatorBase):
                        f"https://github.com/taoshidev/vanta-cli")
                 synapse.error_message = msg
 
-            elif not selected_asset.allows_trade_pair(tp) and order_type != OrderType.FLAT:
+            elif not selected_asset.can_trade(tp) and order_type != OrderType.FLAT:
                 asset_validate_ms = (time.perf_counter() - asset_validate_start) * 1000
-                bt.logging.info(f"[FAIL_EARLY_DEBUG] validate_order_asset_class_local_cache took {asset_validate_ms:.2f}ms")
+                bt.logging.info(f"[FAIL_EARLY_DEBUG] miner_asset_class_can_trade took {asset_validate_ms:.2f}ms")
 
                 msg = (
                     f"Selected asset class [{selected_asset}] cannot submit orders for trade pair [{tp.trade_pair}]. "

--- a/runnable/migration_utils.py
+++ b/runnable/migration_utils.py
@@ -8,11 +8,17 @@ operate directly on on-disk state.
 
 Helpers exposed:
 
-  MigrationUtils.load_all_positions  — walks validation/miners/<hotkey>/<pair>/<status>
-                                       and returns hotkey -> [Position] for every
-                                       open and closed position on disk.
-  MigrationUtils.save_position       — persists a single Position back to disk
-                                       under its OPEN or CLOSED partition dir.
+  MigrationUtils.load_all_positions    — walks validation/miners/<hotkey>/<pair>/<status>
+                                         and returns hotkey -> [Position] for every
+                                         open and closed position on disk.
+  MigrationUtils.save_position         — persists a single Position back to disk
+                                         under its OPEN or CLOSED partition dir.
+  MigrationUtils.load_asset_selections — returns dict from validation/asset_selections.json
+  MigrationUtils.save_asset_selections — writes dict back to asset_selections.json
+  MigrationUtils.load_miner_accounts   — returns dict from validation/miner_account_sizes.json
+  MigrationUtils.save_miner_accounts   — writes dict back to miner_account_sizes.json
+  MigrationUtils.load_entities         — returns dict from validation/entities.json
+  MigrationUtils.save_entities         — writes dict back to entities.json
 
 This file lives at runnable/migration_utils.py (NOT under runnable/migrations/)
 because run_migrations.py scans runnable/migrations/ for .py files and treats
@@ -21,6 +27,7 @@ that scan.
 """
 
 from collections import defaultdict
+import json
 import os
 from typing import Dict, List
 
@@ -90,3 +97,87 @@ class MigrationUtils:
             running_unit_tests=running_unit_tests,
         )
         ValiBkpUtils.write_file(miner_dir + position.position_uuid, position)
+
+    # ------------------------------------------------------------------ #
+    # JSON file loaders / savers                                          #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _load_json(path: str) -> dict:
+        if not os.path.exists(path):
+            return {}
+        with open(path) as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                bt.logging.warning(f"Failed to decode JSON at {path}; returning empty dict.")
+                return {}
+
+    @staticmethod
+    def _save_json(path: str, data: dict) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+    @staticmethod
+    def load_asset_selections(running_unit_tests: bool = False) -> dict:
+        """Load validation/asset_selections.json. Returns {} if missing."""
+        path = ValiBkpUtils.get_asset_selections_file_location(running_unit_tests=running_unit_tests)
+        return MigrationUtils._load_json(path)
+
+    @staticmethod
+    def save_asset_selections(data: dict, running_unit_tests: bool = False) -> None:
+        """Write validation/asset_selections.json."""
+        path = ValiBkpUtils.get_asset_selections_file_location(running_unit_tests=running_unit_tests)
+        MigrationUtils._save_json(path, data)
+
+    @staticmethod
+    def load_miner_accounts(running_unit_tests: bool = False):
+        """Load validation/miner_account_sizes.json as typed MinerAccount objects.
+
+        Uses MinerAccountManager._parse_accounts_dict so the asset_class field
+        comes from asset_selections.json (the source of truth) — matches the
+        validator boot path. Returns {} if the on-disk file is missing.
+        """
+        from vali_objects.miner_account.miner_account_manager import MinerAccountManager
+
+        path = ValiBkpUtils.get_miner_account_sizes_file_location(running_unit_tests=running_unit_tests)
+        raw = MigrationUtils._load_json(path)
+        raw.pop("_cost_per_theta", None)  # legacy top-level key; never written back
+        selections = MigrationUtils.load_asset_selections(running_unit_tests=running_unit_tests)
+        return MinerAccountManager._parse_accounts_dict(raw, selections)
+
+    @staticmethod
+    def save_miner_accounts(accounts, running_unit_tests: bool = False) -> None:
+        """Persist Dict[hotkey, MinerAccount] back to miner_account_sizes.json.
+
+        Mirrors MinerAccountManager.accounts_dict serialization: each hotkey's
+        value is a list of CollateralRecord dicts followed by the account
+        summary dict from MinerAccount.to_dict.
+        """
+        data: dict = {}
+        for hotkey, account in accounts.items():
+            records_list = [vars(record).copy() for record in account.collateral_records]
+            records_list.append(account.to_dict(include_collateral_records=False))
+            data[hotkey] = records_list
+
+        path = ValiBkpUtils.get_miner_account_sizes_file_location(running_unit_tests=running_unit_tests)
+        ValiBkpUtils.write_file(path, data)
+
+    @staticmethod
+    def load_entities(running_unit_tests: bool = False):
+        """Load validation/entities.json as Dict[hotkey, EntityData] (typed)."""
+        from entity_management.entity_manager import EntityManager
+
+        path = ValiBkpUtils.get_entity_file_location(running_unit_tests=running_unit_tests)
+        raw = MigrationUtils._load_json(path)
+        if not raw:
+            return {}
+        return EntityManager.parse_checkpoint_dict(raw)
+
+    @staticmethod
+    def save_entities(entities, running_unit_tests: bool = False) -> None:
+        """Persist Dict[hotkey, EntityData] back to entities.json via model_dump."""
+        data = {hotkey: entity.model_dump() for hotkey, entity in entities.items()}
+        path = ValiBkpUtils.get_entity_file_location(running_unit_tests=running_unit_tests)
+        ValiBkpUtils.write_file(path, data)

--- a/runnable/migrations/migrate_hl_all_to_all_markets.py
+++ b/runnable/migrations/migrate_hl_all_to_all_markets.py
@@ -1,0 +1,113 @@
+"""
+Re-tag non-HL multi-class subaccounts from "hl_all" to "all_markets".
+
+HL_ALL was originally the multi-class asset class for Hyperliquid-linked
+subaccounts (those with an hl_address). The new ALL_MARKETS class mirrors
+HL_ALL semantics but is intended for non-HL (i.e. Vanta-source) subaccounts
+that want cross-asset-class trading. Subaccounts currently flagged hl_all
+that do NOT have an hl_address belong under all_markets.
+
+For each such subaccount we update three files:
+  - entities.json            (SubaccountInfo.asset_class)
+  - asset_selections.json    (selection keyed by synthetic_hotkey)
+  - miner_account_sizes.json (MinerAccount.asset_class)
+
+Usage:
+    python runnable/migrations/migrate_hl_all_to_all_markets.py
+    python runnable/migrations/migrate_hl_all_to_all_markets.py --dry-run
+"""
+
+import argparse
+import sys
+
+from runnable.migration_utils import MigrationUtils
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
+
+OLD_STR = "hl_all"
+NEW_STR = "all_markets"
+NEW_ENUM = MinerAssetClass.ALL_MARKETS
+
+
+def _migrate(dry_run: bool = False, running_unit_tests: bool = False) -> bool:
+    prefix = "[DRY RUN] " if dry_run else ""
+
+    entities = MigrationUtils.load_entities(running_unit_tests=running_unit_tests)
+    if not entities:
+        print("entities.json not found or empty — nothing to migrate.")
+        return True
+
+    selections = MigrationUtils.load_asset_selections(running_unit_tests=running_unit_tests)
+    accounts = MigrationUtils.load_miner_accounts(running_unit_tests=running_unit_tests)
+
+    target_synthetic_hotkeys: set[str] = set()
+    subaccounts_changed = 0
+
+    for entity_hotkey, entity in entities.items():
+        for sub_id, subaccount in entity.subaccounts.items():
+            if subaccount.asset_class != OLD_STR:
+                continue
+            if subaccount.hl_address:
+                # HL-linked subaccounts stay on hl_all.
+                continue
+
+            target_synthetic_hotkeys.add(subaccount.synthetic_hotkey)
+            print(f"  {prefix}entities.json: {subaccount.synthetic_hotkey}: {OLD_STR} → {NEW_STR}")
+            if not dry_run:
+                subaccount.asset_class = NEW_STR
+            subaccounts_changed += 1
+
+    if not target_synthetic_hotkeys:
+        print("No non-HL hl_all subaccounts found — nothing to migrate.")
+        return True
+
+    print(f"\nFound {len(target_synthetic_hotkeys)} non-HL hl_all subaccount(s).")
+
+    selections_changed = 0
+    for hk in target_synthetic_hotkeys:
+        if selections.get(hk) == OLD_STR:
+            print(f"  {prefix}asset_selections.json: {hk}: {OLD_STR} → {NEW_STR}")
+            if not dry_run:
+                selections[hk] = NEW_STR
+            selections_changed += 1
+
+    accounts_changed = 0
+    for hk in target_synthetic_hotkeys:
+        account = accounts.get(hk)
+        if account is None:
+            continue
+        if account.asset_class == MinerAssetClass.HL_ALL:
+            print(f"  {prefix}miner_account_sizes.json: {hk}: {OLD_STR} → {NEW_STR}")
+            if not dry_run:
+                account.asset_class = NEW_ENUM
+            accounts_changed += 1
+
+    print(
+        f"\nSummary: entities={subaccounts_changed}, "
+        f"selections={selections_changed}, accounts={accounts_changed}"
+    )
+
+    if not dry_run:
+        if subaccounts_changed:
+            MigrationUtils.save_entities(entities, running_unit_tests=running_unit_tests)
+        if selections_changed:
+            MigrationUtils.save_asset_selections(selections, running_unit_tests=running_unit_tests)
+        if accounts_changed:
+            MigrationUtils.save_miner_accounts(accounts, running_unit_tests=running_unit_tests)
+        print("Migration complete.")
+    else:
+        print("Dry run complete — no files written.")
+
+    return True
+
+
+def main() -> bool:
+    return _migrate(dry_run=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Re-tag non-HL hl_all subaccounts to all_markets.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing.")
+    args = parser.parse_args()
+    sys.exit(0 if _migrate(dry_run=args.dry_run) else 1)

--- a/tests/vali_tests/test_asset_selection_manager.py
+++ b/tests/vali_tests/test_asset_selection_manager.py
@@ -3,7 +3,8 @@ import unittest
 from tests.vali_tests.base_objects.test_base import TestBase
 from shared_objects.rpc.server_orchestrator import ServerOrchestrator, ServerMode
 from vali_objects.utils.vali_utils import ValiUtils
-from vali_objects.vali_config import TradePairCategory, TradePairSource, TradePair
+from vali_objects.vali_config import TradePairCategory, TradePair
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 
 
 class TestAssetSelectionManager(TestBase):
@@ -69,41 +70,43 @@ class TestAssetSelectionManager(TestBase):
         """Per-test teardown: Clear data for next test."""
         self.orchestrator.clear_all_test_data()
 
-    def _can_trade(self, miner_hotkey, trade_pair_category, trade_pair_src):
-        """Refresh the local cache, then validate an order via the no-RPC cache path.
+    def _can_trade(self, miner_hotkey, trade_pair):
+        """Refresh the local cache, then check the miner's asset class against the trade pair.
 
-        This mirrors how neurons/validator.py validates orders at entry (the
-        AssetSelectionClient local cache is the source), so the cache is refreshed
-        first to pick up any selection made earlier in the test.
+        Mirrors how neurons/validator.py validates orders at entry: the
+        AssetSelectionClient local cache is the source of the selection, and
+        MinerAssetClass.can_trade is the gating check.
         """
         self.asset_selection_client.refresh_local_cache()
-        return self.asset_selection_client.validate_order_asset_class_local_cache(
-            miner_hotkey, trade_pair_category, trade_pair_src)
+        selected = self.asset_selection_client.get_selection_local_cache(miner_hotkey)
+        if selected is None:
+            return False
+        return selected.can_trade(trade_pair)
 
     def test_is_valid_asset_class(self):
         """Test asset class validation"""
         # Valid asset classes
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('crypto'))
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('forex'))
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('indices'))
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('equities'))
+        self.assertTrue(MinerAssetClass.is_valid('crypto'))
+        self.assertTrue(MinerAssetClass.is_valid('forex'))
+        self.assertTrue(MinerAssetClass.is_valid('indices'))
+        self.assertTrue(MinerAssetClass.is_valid('equities'))
 
         # Case insensitive
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('CRYPTO'))
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('Forex'))
+        self.assertTrue(MinerAssetClass.is_valid('CRYPTO'))
+        self.assertTrue(MinerAssetClass.is_valid('Forex'))
 
         # Invalid asset classes
         # hl_all is selectable
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('hl_all'))
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('HL_ALL'))
+        self.assertTrue(MinerAssetClass.is_valid('hl_all'))
+        self.assertTrue(MinerAssetClass.is_valid('HL_ALL'))
 
         # commodities is selectable
-        self.assertTrue(self.asset_selection_client.is_valid_asset_class('commodities'))
+        self.assertTrue(MinerAssetClass.is_valid('commodities'))
 
         # Invalid asset classes
-        self.assertFalse(self.asset_selection_client.is_valid_asset_class('invalid'))
-        self.assertFalse(self.asset_selection_client.is_valid_asset_class('stocks'))
-        self.assertFalse(self.asset_selection_client.is_valid_asset_class(''))
+        self.assertFalse(MinerAssetClass.is_valid('invalid'))
+        self.assertFalse(MinerAssetClass.is_valid('stocks'))
+        self.assertFalse(MinerAssetClass.is_valid(''))
         
     def test_asset_selection_request_success(self):
         """Test successful asset selection request"""
@@ -169,70 +172,52 @@ class TestAssetSelectionManager(TestBase):
     def test_validate_order_no_selection(self):
         """A miner with no asset selected cannot trade any asset class"""
         # Don't select any asset class for the miner
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePairCategory.CRYPTO, TradePairSource.VANTA))
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePairCategory.FOREX, TradePairSource.VANTA))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.BTCUSD))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.EURUSD))
 
     def test_validate_order_with_selection(self):
         """Orders are validated against the miner's selected asset class"""
         self.asset_selection_client.process_asset_selection_request('crypto', self.test_miner_1)
 
         # Matching Vanta asset class is allowed
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePairCategory.CRYPTO, TradePairSource.VANTA))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.BTCUSD))
 
         # HL pair with crypto selection → rejected (wrong source)
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePairCategory.CRYPTO, TradePairSource.HYPERLIQUID))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.BTCUSDC))
 
         # Non-matching asset classes are rejected
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePairCategory.FOREX, TradePairSource.VANTA))
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePairCategory.INDICES, TradePairSource.VANTA))
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePairCategory.EQUITIES, TradePairSource.VANTA))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.EURUSD))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.SPX))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.NVDA))
 
     def test_validate_order_different_trade_pairs_same_asset_class(self):
         """Test that different trade pairs from same asset class are allowed"""
         self.asset_selection_client.process_asset_selection_request('crypto', self.test_miner_1)
 
         # All Vanta crypto trade pairs should be allowed
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePair.BTCUSD.trade_pair_category, TradePair.BTCUSD.src))
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePair.ETHUSD.trade_pair_category, TradePair.ETHUSD.src))
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePair.SOLUSD.trade_pair_category, TradePair.SOLUSD.src))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.BTCUSD))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.ETHUSD))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.SOLUSD))
 
         # HL crypto pairs should be rejected for a crypto-selected miner
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePair.BTCUSDC.trade_pair_category, TradePair.BTCUSDC.src))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.BTCUSDC))
 
         # Forex trade pairs should be rejected
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePair.EURUSD.trade_pair_category, TradePair.EURUSD.src))
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePair.GBPUSD.trade_pair_category, TradePair.GBPUSD.src))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.EURUSD))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.GBPUSD))
 
     def test_hl_all_selection_allows_hl_pairs(self):
         """hl_all selection permits HL pairs and blocks Vanta pairs"""
         self.asset_selection_client.process_asset_selection_request('hl_all', self.test_miner_1)
 
         # HL pairs allowed
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePair.BTCUSDC.trade_pair_category, TradePairSource.HYPERLIQUID))
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePair.GOLDUSDC.trade_pair_category, TradePairSource.HYPERLIQUID))
-        self.assertTrue(self._can_trade(
-            self.test_miner_1, TradePair.NVDAUSDC.trade_pair_category, TradePairSource.HYPERLIQUID))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.BTCUSDC))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.GOLDUSDC))
+        self.assertTrue(self._can_trade(self.test_miner_1, TradePair.NVDAUSDC))
 
         # Vanta pairs blocked
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePair.BTCUSD.trade_pair_category, TradePairSource.VANTA))
-        self.assertFalse(self._can_trade(
-            self.test_miner_1, TradePair.EURUSD.trade_pair_category, TradePairSource.VANTA))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.BTCUSD))
+        self.assertFalse(self._can_trade(self.test_miner_1, TradePair.EURUSD))
 
     def test_commodities_selectable(self):
         """commodities can be selected as a standalone asset class"""

--- a/tests/vali_tests/test_capital_used_by_class.py
+++ b/tests/vali_tests/test_capital_used_by_class.py
@@ -4,7 +4,7 @@ Unit tests for per-asset-class capital tracking on MinerAccount
 
 Covers:
   * MinerAccount.capital_used_by_class default and reset semantics.
-  * MinerAccount.multiplier / buying_power / is_multi_class branches for
+  * MinerAccount.multiplier / buying_power branches for
     single-class vs multi-class (HL_ALL).
   * MinerAccountManager.compute_account_state_from_positions populates the
     per-class breakdown.
@@ -58,7 +58,7 @@ class TestCapitalUsedByClassDefault(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# multiplier / buying_power / is_multi_class
+# multiplier / buying_power
 # ---------------------------------------------------------------------------
 
 class TestMinerAccountMultiplier(unittest.TestCase):
@@ -83,7 +83,7 @@ class TestMinerAccountMultiplier(unittest.TestCase):
             asset_class=MinerAssetClass.HL_ALL,
             miner_bucket=MinerBucket.SUBACCOUNT_FUNDED,
         )
-        self.assertEqual(account.multiplier, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[2])
+        self.assertEqual(account.multiplier, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][MinerAssetClass.HL_ALL])
 
     def test_multiplier_challenge_bucket_uses_tier_1(self):
         account = MinerAccount(
@@ -91,17 +91,7 @@ class TestMinerAccountMultiplier(unittest.TestCase):
             asset_class=MinerAssetClass.HL_ALL,
             miner_bucket=MinerBucket.SUBACCOUNT_CHALLENGE,
         )
-        self.assertEqual(account.multiplier, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[1])
-
-    def test_is_multi_class_true_only_for_multi_class_categories(self):
-        for cat in MinerAssetClass:
-            with self.subTest(cat=cat):
-                account = MinerAccount(miner_hotkey="hk", asset_class=cat)
-                self.assertEqual(account.is_multi_class(), cat.is_multi_class)
-
-    def test_is_multi_class_false_when_asset_class_none(self):
-        account = MinerAccount(miner_hotkey="hk", asset_class=None)
-        self.assertFalse(account.is_multi_class())
+        self.assertEqual(account.multiplier, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][MinerAssetClass.HL_ALL])
 
     def test_buying_power_multi_class_uses_overall_cap(self):
         """buying_power = balance × multiplier − capital_used for non-equities."""
@@ -112,7 +102,7 @@ class TestMinerAccountMultiplier(unittest.TestCase):
             capital_used=1_000.0,
         )
         balance = account.balance
-        expected = balance * ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[2] - 1_000.0
+        expected = balance * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][MinerAssetClass.HL_ALL] - 1_000.0
         self.assertAlmostEqual(account.buying_power, expected)
 
 

--- a/tests/vali_tests/test_capital_used_by_class.py
+++ b/tests/vali_tests/test_capital_used_by_class.py
@@ -22,8 +22,8 @@ import unittest
 
 from vali_objects.enums.miner_bucket_enum import MinerBucket
 from vali_objects.miner_account.miner_account_manager import MinerAccount, MinerAccountManager
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.vali_config import (
-    MULTI_CLASS_CATEGORIES,
     TradePair,
     TradePairCategory,
     ValiConfig,
@@ -70,17 +70,17 @@ class TestMinerAccountMultiplier(unittest.TestCase):
     def test_multiplier_single_class_reads_by_asset_class_table(self):
         account = MinerAccount(
             miner_hotkey="hk",
-            asset_class=TradePairCategory.CRYPTO,
+            asset_class=MinerAssetClass.CRYPTO,
             miner_bucket=MinerBucket.SUBACCOUNT_FUNDED,
         )
         # Tier defaults to 2 (funded, no collateral records → MIN_CAPITAL < 200K)
-        expected = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][TradePairCategory.CRYPTO]
+        expected = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][MinerAssetClass.CRYPTO]
         self.assertEqual(account.multiplier, expected)
 
     def test_multiplier_multi_class_reads_overall_cap_table(self):
         account = MinerAccount(
             miner_hotkey="hk",
-            asset_class=TradePairCategory.HL_ALL,
+            asset_class=MinerAssetClass.HL_ALL,
             miner_bucket=MinerBucket.SUBACCOUNT_FUNDED,
         )
         self.assertEqual(account.multiplier, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[2])
@@ -88,27 +88,16 @@ class TestMinerAccountMultiplier(unittest.TestCase):
     def test_multiplier_challenge_bucket_uses_tier_1(self):
         account = MinerAccount(
             miner_hotkey="hk",
-            asset_class=TradePairCategory.HL_ALL,
+            asset_class=MinerAssetClass.HL_ALL,
             miner_bucket=MinerBucket.SUBACCOUNT_CHALLENGE,
         )
         self.assertEqual(account.multiplier, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[1])
 
     def test_is_multi_class_true_only_for_multi_class_categories(self):
-        for cat in (
-            TradePairCategory.CRYPTO,
-            TradePairCategory.FOREX,
-            TradePairCategory.EQUITIES,
-            TradePairCategory.INDICES,
-            TradePairCategory.COMMODITIES,
-        ):
+        for cat in MinerAssetClass:
             with self.subTest(cat=cat):
                 account = MinerAccount(miner_hotkey="hk", asset_class=cat)
-                self.assertFalse(account.is_multi_class())
-
-        for cat in MULTI_CLASS_CATEGORIES:
-            with self.subTest(cat=cat):
-                account = MinerAccount(miner_hotkey="hk", asset_class=cat)
-                self.assertTrue(account.is_multi_class())
+                self.assertEqual(account.is_multi_class(), cat.is_multi_class)
 
     def test_is_multi_class_false_when_asset_class_none(self):
         account = MinerAccount(miner_hotkey="hk", asset_class=None)
@@ -118,7 +107,7 @@ class TestMinerAccountMultiplier(unittest.TestCase):
         """buying_power = balance × multiplier − capital_used for non-equities."""
         account = MinerAccount(
             miner_hotkey="hk",
-            asset_class=TradePairCategory.HL_ALL,
+            asset_class=MinerAssetClass.HL_ALL,
             miner_bucket=MinerBucket.SUBACCOUNT_FUNDED,
             capital_used=1_000.0,
         )

--- a/tests/vali_tests/test_equities.py
+++ b/tests/vali_tests/test_equities.py
@@ -854,8 +854,8 @@ class TestEquities(TestBase):
 
     # ==================== SUBACCOUNT_CHALLENGE Buying Power Tests ====================
 
-    EQUITIES_MULTIPLIER = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][TradePairCategory.EQUITIES]   # 1.5 (Tier 2, <$200K)
-    REDUCED_MULTIPLIER = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][TradePairCategory.EQUITIES]    # 1.0 (Tier 1, challenge)
+    EQUITIES_MULTIPLIER = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.EQUITIES]   # 1.5 (Tier 2, <$200K)
+    REDUCED_MULTIPLIER = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[1][TradePairCategory.EQUITIES]    # 1.0 (Tier 1, challenge)
 
     def test_subaccount_challenge_buying_power_reduced(self):
         """

--- a/tests/vali_tests/test_hl_trader_limits_endpoint.py
+++ b/tests/vali_tests/test_hl_trader_limits_endpoint.py
@@ -26,14 +26,14 @@ ACCOUNT_SIZE = 50_000.0  # Tier 2 (<$200K)
 
 # Expected limits — Tier 2 (SUBACCOUNT_FUNDED, account_size < $200K), crypto
 TIER2_POSITIONAL = ValiConfig.TIER_POSITIONAL_LEVERAGE[2][TradePairCategory.CRYPTO]   # 1.0x
-TIER2_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][TradePairCategory.CRYPTO]   # 2.0x
+TIER2_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.CRYPTO]   # 2.0x
 
 EXPECTED_MAX_POSITION = ACCOUNT_SIZE * TIER2_POSITIONAL   # 50_000
 EXPECTED_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER2_PORTFOLIO   # 100_000
 
 # Expected limits — Tier 1 (SUBACCOUNT_CHALLENGE), crypto
 TIER1_POSITIONAL = ValiConfig.TIER_POSITIONAL_LEVERAGE[1][TradePairCategory.CRYPTO]   # 0.5x
-TIER1_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][TradePairCategory.CRYPTO]   # 1.0x
+TIER1_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[1][TradePairCategory.CRYPTO]   # 1.0x
 
 EXPECTED_CHALLENGE_MAX_POSITION = ACCOUNT_SIZE * TIER1_POSITIONAL  # 25_000
 EXPECTED_CHALLENGE_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER1_PORTFOLIO   # 50_000
@@ -260,7 +260,7 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         self.assertEqual(data['max_portfolio_usd'], expected_overall)
 
     def test_hl_all_per_class_values_match_table(self):
-        """Each per-class entry matches TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS for the right tier."""
+        """Each per-class entry matches TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY for the right tier."""
         from vali_objects.vali_config import TradePairCategory, ValiConfig
         self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
             asset_class="hl_all",
@@ -278,7 +278,7 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
             ('indices',    TradePairCategory.INDICES),
             ('commodities', TradePairCategory.COMMODITIES),
         ):
-            expected = ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][cat]
+            expected = ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][cat]
             self.assertEqual(breakdown[cat_str], expected, f"per-class mismatch for {cat_str}")
 
     def test_hl_all_challenge_period_uses_tier_1(self):
@@ -323,7 +323,7 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         status, data = self._get(VALID_HL_ADDRESS)
 
         self.assertEqual(status, 200)
-        expected = ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][TradePairCategory.COMMODITIES]
+        expected = ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.COMMODITIES]
         self.assertEqual(data['max_portfolio_usd'], expected)
 
     def test_commodities_max_position_matches_hl_commodity_pair_base(self):

--- a/tests/vali_tests/test_hl_trader_limits_endpoint.py
+++ b/tests/vali_tests/test_hl_trader_limits_endpoint.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 from flask import Flask
 from vali_objects.vali_config import ValiConfig, TradePairCategory
 from vali_objects.enums.miner_bucket_enum import MinerBucket
+from vanta_api.validator_rest_server import ValidatorRestServer
 
 
 # ==================== Test constants ====================
@@ -25,14 +26,14 @@ VALID_HL_ADDRESS_2 = "0x" + "1234567890abcdef" * 2 + "12345678"
 ACCOUNT_SIZE = 50_000.0  # Tier 2 (<$200K)
 
 # Expected limits — Tier 2 (SUBACCOUNT_FUNDED, account_size < $200K), crypto
-TIER2_POSITIONAL = ValiConfig.TIER_POSITIONAL_LEVERAGE[2][TradePairCategory.CRYPTO]   # 1.0x
+TIER2_POSITIONAL = ValidatorRestServer._ENDPOINT_TIER_POSITIONAL_LEVERAGE[2][TradePairCategory.CRYPTO]   # 1.0x
 TIER2_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.CRYPTO]   # 2.0x
 
 EXPECTED_MAX_POSITION = ACCOUNT_SIZE * TIER2_POSITIONAL   # 50_000
 EXPECTED_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER2_PORTFOLIO   # 100_000
 
 # Expected limits — Tier 1 (SUBACCOUNT_CHALLENGE), crypto
-TIER1_POSITIONAL = ValiConfig.TIER_POSITIONAL_LEVERAGE[1][TradePairCategory.CRYPTO]   # 0.5x
+TIER1_POSITIONAL = ValidatorRestServer._ENDPOINT_TIER_POSITIONAL_LEVERAGE[1][TradePairCategory.CRYPTO]   # 0.5x
 TIER1_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[1][TradePairCategory.CRYPTO]   # 1.0x
 
 EXPECTED_CHALLENGE_MAX_POSITION = ACCOUNT_SIZE * TIER1_POSITIONAL  # 25_000
@@ -245,9 +246,10 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
             {'crypto', 'forex', 'equities', 'indices', 'commodities'},
         )
 
-    def test_hl_all_overall_cap_from_multi_class_table(self):
-        """HL_ALL max_portfolio_usd sources from TIER_MULTI_CLASS_OVERALL_CAP, not the per-class table."""
+    def test_hl_all_overall_cap_from_asset_class_table(self):
+        """HL_ALL max_portfolio_usd sources from the HL_ALL entry in TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS."""
         from vali_objects.vali_config import ValiConfig
+        from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
         self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
             asset_class="hl_all",
             challenge_bucket=MinerBucket.SUBACCOUNT_FUNDED.value,
@@ -256,7 +258,7 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         status, data = self._get(VALID_HL_ADDRESS)
 
         self.assertEqual(status, 200)
-        expected_overall = ACCOUNT_SIZE * ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[2]
+        expected_overall = ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][MinerAssetClass.HL_ALL]
         self.assertEqual(data['max_portfolio_usd'], expected_overall)
 
     def test_hl_all_per_class_values_match_table(self):
@@ -282,8 +284,9 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
             self.assertEqual(breakdown[cat_str], expected, f"per-class mismatch for {cat_str}")
 
     def test_hl_all_challenge_period_uses_tier_1(self):
-        """HL_ALL during challenge period uses TIER_MULTI_CLASS_OVERALL_CAP[1]."""
+        """HL_ALL during challenge period uses tier-1 entry in TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS."""
         from vali_objects.vali_config import ValiConfig
+        from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
         self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
             asset_class="hl_all",
             challenge_bucket=MinerBucket.SUBACCOUNT_CHALLENGE.value,
@@ -295,7 +298,7 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         self.assertTrue(data['in_challenge_period'])
         self.assertEqual(
             data['max_portfolio_usd'],
-            ACCOUNT_SIZE * ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[1],
+            ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][MinerAssetClass.HL_ALL],
         )
 
     def test_single_class_response_has_no_per_class_breakdown(self):

--- a/tests/vali_tests/test_hl_trader_limits_endpoint.py
+++ b/tests/vali_tests/test_hl_trader_limits_endpoint.py
@@ -4,8 +4,12 @@
 Unit tests for the GET /hl-traders/<hl_address>/limits endpoint.
 
 Tests the public (no-auth) endpoint that resolves a Hyperliquid address
-and returns trading limits (account size, max position per pair, max portfolio,
-challenge period status).
+and returns trading limits (account size, leverage tier, asset class,
+per-class caps, overall portfolio cap, challenge period status).
+
+Every HL subaccount is treated as HL_ALL: the handler ignores the stored
+asset_class and always returns the cross-class overall cap plus the
+per-class breakdown.
 
 Uses a lightweight Flask test client with a mocked entity_client to
 isolate endpoint logic from the full RPC stack.
@@ -17,6 +21,7 @@ from unittest.mock import MagicMock
 from flask import Flask
 from vali_objects.vali_config import ValiConfig, TradePairCategory
 from vali_objects.enums.miner_bucket_enum import MinerBucket
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vanta_api.validator_rest_server import ValidatorRestServer
 
 
@@ -25,19 +30,19 @@ VALID_HL_ADDRESS = "0x" + "a1b2c3d4" * 5
 VALID_HL_ADDRESS_2 = "0x" + "1234567890abcdef" * 2 + "12345678"
 ACCOUNT_SIZE = 50_000.0  # Tier 2 (<$200K)
 
-# Expected limits — Tier 2 (SUBACCOUNT_FUNDED, account_size < $200K), crypto
-TIER2_POSITIONAL = ValidatorRestServer._ENDPOINT_TIER_POSITIONAL_LEVERAGE[2][TradePairCategory.CRYPTO]   # 1.0x
-TIER2_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.CRYPTO]   # 2.0x
+# Expected limits — Tier 2 (SUBACCOUNT_FUNDED, account_size < $200K), HL_ALL
+TIER2_POSITIONAL = ValidatorRestServer._ENDPOINT_TIER_POSITIONAL_LEVERAGE[2][MinerAssetClass.HL_ALL]   # 1.0x
+TIER2_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][MinerAssetClass.HL_ALL]   # 7.0x
 
 EXPECTED_MAX_POSITION = ACCOUNT_SIZE * TIER2_POSITIONAL   # 50_000
-EXPECTED_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER2_PORTFOLIO   # 100_000
+EXPECTED_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER2_PORTFOLIO   # 350_000
 
-# Expected limits — Tier 1 (SUBACCOUNT_CHALLENGE), crypto
-TIER1_POSITIONAL = ValidatorRestServer._ENDPOINT_TIER_POSITIONAL_LEVERAGE[1][TradePairCategory.CRYPTO]   # 0.5x
-TIER1_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[1][TradePairCategory.CRYPTO]   # 1.0x
+# Expected limits — Tier 1 (SUBACCOUNT_CHALLENGE), HL_ALL
+TIER1_POSITIONAL = ValidatorRestServer._ENDPOINT_TIER_POSITIONAL_LEVERAGE[1][MinerAssetClass.HL_ALL]   # 0.5x
+TIER1_PORTFOLIO  = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][MinerAssetClass.HL_ALL]   # 4.0x
 
 EXPECTED_CHALLENGE_MAX_POSITION = ACCOUNT_SIZE * TIER1_POSITIONAL  # 25_000
-EXPECTED_CHALLENGE_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER1_PORTFOLIO   # 50_000
+EXPECTED_CHALLENGE_MAX_PORTFOLIO = ACCOUNT_SIZE * TIER1_PORTFOLIO   # 200_000
 
 
 def _build_limits_data(
@@ -97,14 +102,17 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         self.assertEqual(data['status'], 'success')
         self.assertEqual(data['hl_address'], VALID_HL_ADDRESS)
         self.assertEqual(data['account_size'], ACCOUNT_SIZE)
+        self.assertEqual(data['tier'], 2)
+        self.assertEqual(data['asset_class'], 'hl_all')
         self.assertEqual(data['max_position_per_pair_usd'], EXPECTED_MAX_POSITION)
         self.assertEqual(data['max_portfolio_usd'], EXPECTED_MAX_PORTFOLIO)
+        self.assertIn('max_asset_class_usd', data)
         self.assertFalse(data['in_challenge_period'])
         self.assertIn('timestamp', data)
         self.assertIsInstance(data['timestamp'], int)
 
     def test_success_no_challenge_bucket(self):
-        """200 with normal limits when challenge_bucket is None."""
+        """challenge_bucket=None (no trades yet) is treated as challenge period (tier 1)."""
         self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
             challenge_bucket=None
         )
@@ -112,9 +120,10 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         status, data = self._get(VALID_HL_ADDRESS)
 
         self.assertEqual(status, 200)
-        self.assertEqual(data['max_position_per_pair_usd'], EXPECTED_MAX_POSITION)
-        self.assertEqual(data['max_portfolio_usd'], EXPECTED_MAX_PORTFOLIO)
-        self.assertFalse(data['in_challenge_period'])
+        self.assertEqual(data['tier'], 1)
+        self.assertEqual(data['max_position_per_pair_usd'], EXPECTED_CHALLENGE_MAX_POSITION)
+        self.assertEqual(data['max_portfolio_usd'], EXPECTED_CHALLENGE_MAX_PORTFOLIO)
+        self.assertTrue(data['in_challenge_period'])
 
     # ==================== Happy path — challenge period ====================
 
@@ -128,6 +137,7 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
 
         self.assertEqual(status, 200)
         self.assertTrue(data['in_challenge_period'])
+        self.assertEqual(data['tier'], 1)
         self.assertEqual(data['max_position_per_pair_usd'], EXPECTED_CHALLENGE_MAX_POSITION)
         self.assertEqual(data['max_portfolio_usd'], EXPECTED_CHALLENGE_MAX_PORTFOLIO)
 
@@ -301,8 +311,9 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
             ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][MinerAssetClass.HL_ALL],
         )
 
-    def test_single_class_response_has_no_per_class_breakdown(self):
-        """Single-class subaccount response stays single-keyed (no max_asset_class_usd)."""
+    def test_stored_single_class_still_gets_full_breakdown(self):
+        """Stored asset_class is ignored: every HL subaccount is reported as hl_all
+        with the full per-class breakdown."""
         self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
             asset_class="crypto",
             challenge_bucket=MinerBucket.SUBACCOUNT_FUNDED.value,
@@ -311,46 +322,55 @@ class TestHlTraderLimitsEndpoint(unittest.TestCase):
         status, data = self._get(VALID_HL_ADDRESS)
 
         self.assertEqual(status, 200)
-        self.assertNotIn('max_asset_class_usd', data)
+        self.assertEqual(data['asset_class'], 'hl_all')
+        self.assertIn('max_asset_class_usd', data)
+        self.assertEqual(data['max_portfolio_usd'], EXPECTED_MAX_PORTFOLIO)
 
-    # ==================== Single-class commodities ====================
+    # ==================== Leverage tier field ====================
 
-    def test_commodities_uses_per_class_table(self):
-        """Single-class COMMODITIES subaccount portfolio cap comes from the per-class table."""
-        from vali_objects.vali_config import TradePairCategory, ValiConfig
-        self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
-            asset_class="commodities",
-            challenge_bucket=MinerBucket.SUBACCOUNT_FUNDED.value,
+    def test_tier_field_by_bucket_and_size(self):
+        """`tier` follows get_leverage_tier: challenge → 1; funded by size → 2/3/4."""
+        cases = (
+            (MinerBucket.SUBACCOUNT_CHALLENGE.value, 50_000.0, 1),
+            (MinerBucket.SUBACCOUNT_FUNDED.value, 50_000.0, 2),
+            (MinerBucket.SUBACCOUNT_FUNDED.value, 250_000.0, 3),
+            (MinerBucket.SUBACCOUNT_FUNDED.value, 2_000_000.0, 4),
         )
+        for bucket, size, expected_tier in cases:
+            with self.subTest(bucket=bucket, size=size):
+                self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
+                    account_size=size,
+                    challenge_bucket=bucket,
+                )
 
-        status, data = self._get(VALID_HL_ADDRESS)
+                status, data = self._get(VALID_HL_ADDRESS)
 
-        self.assertEqual(status, 200)
-        expected = ACCOUNT_SIZE * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.COMMODITIES]
-        self.assertEqual(data['max_portfolio_usd'], expected)
+                self.assertEqual(status, 200)
+                self.assertEqual(data['tier'], expected_tier)
 
-    def test_commodities_max_position_matches_hl_commodity_pair_base(self):
-        """COMMODITIES max_position equals HL commodity pair's base × tier on the order path.
+    # ==================== Deprecated per-pair field ====================
 
-        Regression guard: the endpoint table was previously aligned with XAU/XAG's legacy
-        non-linear curve (1.0/1.0/1.5/2.0); after the alignment fix it should equal the
-        HL commodity pair tier formula (0.5 × tier).
+    def test_deprecated_max_position_uses_canonical_base_not_raised_pairs(self):
+        """max_position_per_pair_usd reports the canonical HL_ALL base (0.5 × tier).
+
+        Pairs with a raised subaccount_tier_base_leverage (e.g. GOLDUSDC at 1.0)
+        intentionally diverge from this deprecated class-level stand-in — clients
+        must resolve per-pair caps from /trade-pairs instead.
         """
-        from vali_objects.vali_config import TradePair, ValiConfig
+        from vali_objects.vali_config import TradePair
         from vali_objects.utils.leverage_utils import get_tier_positional_leverage
         self.mock_entity.get_hl_subaccount_limits_data.return_value = _build_limits_data(
-            asset_class="commodities",
             challenge_bucket=MinerBucket.SUBACCOUNT_FUNDED.value,
         )
 
         status, data = self._get(VALID_HL_ADDRESS)
 
         self.assertEqual(status, 200)
-        # Endpoint reports for category=COMMODITIES at tier 2
         endpoint_reported = data['max_position_per_pair_usd'] / ACCOUNT_SIZE
-        # Order-entry path for a representative HL commodity pair at tier 2
-        order_path = get_tier_positional_leverage(2, TradePair.GOLDUSDC)
-        self.assertEqual(endpoint_reported, order_path)
+        self.assertEqual(endpoint_reported, TIER2_POSITIONAL)
+        # GOLDUSDC's order-path cap is higher than the deprecated stand-in reports
+        gold_order_path = get_tier_positional_leverage(2, TradePair.GOLDUSDC)
+        self.assertGreater(gold_order_path, endpoint_reported)
 
 
 if __name__ == '__main__':

--- a/tests/vali_tests/test_trade_pair_dispatch.py
+++ b/tests/vali_tests/test_trade_pair_dispatch.py
@@ -73,11 +73,6 @@ class TestConfigCompleteness(unittest.TestCase):
                 else:
                     self.assertEqual(tp.instrument_type, InstrumentType.SPOT)
 
-    def test_only_hl_all_is_multi_class(self):
-        for cls in MinerAssetClass:
-            with self.subTest(cls=cls):
-                self.assertEqual(cls.is_multi_class, cls == MinerAssetClass.HL_ALL)
-
     def test_subaccount_challenge_returns_threshold_has_commodities(self):
         self.assertIn(
             TradePairCategory.COMMODITIES,
@@ -105,10 +100,11 @@ class TestConfigCompleteness(unittest.TestCase):
                 with self.subTest(tier=tier, cat=cat):
                     self.assertIn(cat, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier])
 
-    def test_tier_multi_class_overall_cap_has_all_tiers(self):
+    def test_tier_portfolio_leverage_by_asset_class_has_multi_class_entries(self):
         for tier in self.ALL_TIERS:
-            self.assertIn(tier, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP)
-            self.assertGreater(ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier], 0)
+            for ac in (MinerAssetClass.HL_ALL, MinerAssetClass.ALL_MARKETS):
+                self.assertIn(ac, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier])
+                self.assertGreater(ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier][ac], 0)
 
     def test_portfolio_leverage_cap_full_matrix(self):
         for cat in self.ALL_REAL_CATEGORIES:
@@ -214,7 +210,7 @@ class TestGetPortfolioCaps(unittest.TestCase):
         _, overall = get_portfolio_caps(
             MinerAssetClass.HL_ALL, self.BUCKET, self.ACCT, TradePairCategory.CRYPTO,
         )
-        self.assertEqual(overall, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[2])
+        self.assertEqual(overall, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][MinerAssetClass.HL_ALL])
 
     def test_multi_class_per_class_keyed_on_order_category(self):
         for cat in (

--- a/tests/vali_tests/test_trade_pair_dispatch.py
+++ b/tests/vali_tests/test_trade_pair_dispatch.py
@@ -25,8 +25,8 @@ from vali_objects.utils.leverage_utils import (
     get_portfolio_caps,
     get_tier_positional_leverage,
 )
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.vali_config import (
-    MULTI_CLASS_CATEGORIES,
     DynamicTradePair,
     InstrumentType,
     SubaccountTierBaseLeverage,
@@ -73,9 +73,10 @@ class TestConfigCompleteness(unittest.TestCase):
                 else:
                     self.assertEqual(tp.instrument_type, InstrumentType.SPOT)
 
-    def test_multi_class_categories_is_frozenset_of_hl_all_only(self):
-        self.assertIsInstance(MULTI_CLASS_CATEGORIES, frozenset)
-        self.assertEqual(MULTI_CLASS_CATEGORIES, frozenset({TradePairCategory.HL_ALL}))
+    def test_only_hl_all_is_multi_class(self):
+        for cls in MinerAssetClass:
+            with self.subTest(cls=cls):
+                self.assertEqual(cls.is_multi_class, cls == MinerAssetClass.HL_ALL)
 
     def test_subaccount_challenge_returns_threshold_has_commodities(self):
         self.assertIn(
@@ -90,19 +91,19 @@ class TestConfigCompleteness(unittest.TestCase):
                     with self.subTest(tier=tier, cat=cat, it=it):
                         self.assertIn((cat, it), ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_PAIR[tier])
 
-    def test_tier_portfolio_leverage_by_asset_class_has_no_hl_all(self):
+    def test_tier_portfolio_leverage_by_category_has_no_hl_all(self):
         for tier in self.ALL_TIERS:
             with self.subTest(tier=tier):
                 self.assertNotIn(
                     TradePairCategory.HL_ALL,
-                    ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier],
+                    ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier],
                 )
 
-    def test_tier_portfolio_leverage_by_asset_class_full_matrix(self):
+    def test_tier_portfolio_leverage_by_category_full_matrix(self):
         for tier in self.ALL_TIERS:
             for cat in self.ALL_REAL_CATEGORIES:
                 with self.subTest(tier=tier, cat=cat):
-                    self.assertIn(cat, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier])
+                    self.assertIn(cat, ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier])
 
     def test_tier_multi_class_overall_cap_has_all_tiers(self):
         for tier in self.ALL_TIERS:
@@ -201,17 +202,17 @@ class TestGetPortfolioCaps(unittest.TestCase):
 
     def test_single_class_returns_same_value_twice(self):
         per_class, overall = get_portfolio_caps(
-            TradePairCategory.CRYPTO, self.BUCKET, self.ACCT, TradePairCategory.CRYPTO,
+            MinerAssetClass.CRYPTO, self.BUCKET, self.ACCT, TradePairCategory.CRYPTO,
         )
         self.assertEqual(per_class, overall)
         self.assertEqual(
             per_class,
-            ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][TradePairCategory.CRYPTO],
+            ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.CRYPTO],
         )
 
     def test_multi_class_overall_from_dedicated_table(self):
         _, overall = get_portfolio_caps(
-            TradePairCategory.HL_ALL, self.BUCKET, self.ACCT, TradePairCategory.CRYPTO,
+            MinerAssetClass.HL_ALL, self.BUCKET, self.ACCT, TradePairCategory.CRYPTO,
         )
         self.assertEqual(overall, ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[2])
 
@@ -225,29 +226,30 @@ class TestGetPortfolioCaps(unittest.TestCase):
         ):
             with self.subTest(cat=cat):
                 per_class, _ = get_portfolio_caps(
-                    TradePairCategory.HL_ALL, self.BUCKET, self.ACCT, cat,
+                    MinerAssetClass.HL_ALL, self.BUCKET, self.ACCT, cat,
                 )
-                expected = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[2][cat]
+                expected = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][cat]
                 self.assertEqual(per_class, expected)
 
     def test_none_subaccount_class_uses_defensive_default(self):
         per_class, overall = get_portfolio_caps(
             None, self.BUCKET, self.ACCT, TradePairCategory.CRYPTO,
         )
-        # asset_class=None goes to single-class branch with .get(None, 1.0) = 1.0
-        self.assertEqual(per_class, 1.0)
-        self.assertEqual(overall, 1.0)
+        # asset_class=None goes to single-class branch keyed on trade_pair_category.
+        expected = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[2][TradePairCategory.CRYPTO]
+        self.assertEqual(per_class, expected)
+        self.assertEqual(overall, expected)
 
     def test_challenge_bucket_uses_tier_1(self):
         per_class, _ = get_portfolio_caps(
-            TradePairCategory.CRYPTO,
+            MinerAssetClass.CRYPTO,
             MinerBucket.SUBACCOUNT_CHALLENGE,
             self.ACCT,
             TradePairCategory.CRYPTO,
         )
         self.assertEqual(
             per_class,
-            ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[1][TradePairCategory.CRYPTO],
+            ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[1][TradePairCategory.CRYPTO],
         )
 
 

--- a/vali_objects/challenge_period/challengeperiod_manager.py
+++ b/vali_objects/challenge_period/challengeperiod_manager.py
@@ -689,7 +689,7 @@ class ChallengePeriodManager(CacheController):
         new_eliminations = [hk for hk in elimination_miners if hk in self.miner_states]
         if new_eliminations:
             btlogging.warning(f"[CHALLENGE] syncing {len(new_eliminations)} eliminated miners: {new_eliminations}")
-        return self.remove_miners(elimination_miners)
+        return self.remove_miners(new_eliminations)
 
     def _prune_hotkeys_no_positions(self, hotkeys=None) -> bool:
         """

--- a/vali_objects/challenge_period/challengeperiod_manager.py
+++ b/vali_objects/challenge_period/challengeperiod_manager.py
@@ -8,6 +8,7 @@ ChallengePeriodServer wraps this and exposes methods via RPC.
 
 This follows the same pattern as EliminationManager.
 """
+import time
 from dataclasses import asdict, dataclass, field
 
 from bittensor.utils.btlogging import logging as btlogging
@@ -208,37 +209,79 @@ class ChallengePeriodManager(CacheController):
 
         btlogging.info(f"[CHALLENGE] Starting challenge period loop {current_time_ms} iteration_epoch={iteration_epoch}")
 
-        asset_selections = self._asset_selection_client.get_asset_selections()
-        filtered_positions, hk_to_first_order_time = self._position_client.filtered_positions_for_scoring(
-            hotkeys=self._position_client.get_all_hotkeys()
-        )
+        timings: dict[str, float] = {}
+        _overall_start = time.perf_counter()
 
+        _t0 = time.perf_counter()
+        asset_selections = self._asset_selection_client.get_asset_selections()
+        timings["get_asset_selections"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
+        all_hotkeys = self._position_client.get_all_hotkeys()
+        timings["get_all_hotkeys"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
+        filtered_positions, hk_to_first_order_time = self._position_client.filtered_positions_for_scoring(
+            hotkeys=all_hotkeys
+        )
+        timings["filtered_positions_for_scoring"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         hotkeys_elimination_sync = list(self._elimination_client.get_eliminated_hotkeys())
+        timings["get_eliminated_hotkeys"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         hotkeys_plagiarism_sync = list(self._plagiarism_client.get_plagiarism_miners())
+        timings["get_plagiarism_miners"] = time.perf_counter() - _t0
 
         state_changed = False
+        _t0 = time.perf_counter()
         state_changed |= self._sync_positions(
             hotkeys=list(filtered_positions.keys()),
             eliminated_hotkeys=hotkeys_elimination_sync,
             hk_to_first_order_time_ms=hk_to_first_order_time,
             default_time=current_time_ms
         )
+        timings["_sync_positions"] = time.perf_counter() - _t0
 
+        _t0 = time.perf_counter()
         state_changed |= self.sync_plagiarism_miners(hotkeys_plagiarism_sync, current_time_ms)
+        timings["sync_plagiarism_miners"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         state_changed |= self.sync_elimination_miners(hotkeys_elimination_sync)
+        timings["sync_elimination_miners"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         state_changed |= self._prune_hotkeys_no_positions()
+        timings["_prune_hotkeys_no_positions"] = time.perf_counter() - _t0
 
         self._current_iteration_epoch = iteration_epoch
 
         evaluation_hotkeys = [hotkey for hotkey, state in self.miner_states.items() if state.current_bucket.is_active]
         rank_hotkeys = [hotkey for hotkey, state in self.miner_states.items() if state.current_bucket.is_rank_based]
 
+        _t0 = time.perf_counter()
         accounts = self._miner_account_client.get_accounts(evaluation_hotkeys)
-        ledgers = self._perf_ledger_client.filtered_ledger_for_scoring(evaluation_hotkeys)
-        positions = self._position_client.get_positions_for_hotkeys(evaluation_hotkeys)
-        self._refresh_drawdown_cache(evaluation_hotkeys, accounts, ledgers, positions, current_time_ms)
-        self._refresh_rank_cache(rank_hotkeys, ledgers, filtered_positions, accounts, asset_selections, current_time_ms)
+        timings["get_accounts"] = time.perf_counter() - _t0
 
+        _t0 = time.perf_counter()
+        ledgers = self._perf_ledger_client.filtered_ledger_for_scoring(evaluation_hotkeys)
+        timings["filtered_ledger_for_scoring"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
+        positions = self._position_client.get_positions_for_hotkeys(evaluation_hotkeys)
+        timings["get_positions_for_hotkeys"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
+        self._refresh_drawdown_cache(evaluation_hotkeys, accounts, ledgers, positions, current_time_ms)
+        timings["_refresh_drawdown_cache"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
+        self._refresh_rank_cache(rank_hotkeys, ledgers, filtered_positions, accounts, asset_selections, current_time_ms)
+        timings["_refresh_rank_cache"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         eliminations = {}
         promotions, demotions = [], []
         for hotkey, state in self.miner_states.items():
@@ -281,19 +324,43 @@ class ChallengePeriodManager(CacheController):
                 promotions.append(hotkey)
                 continue
 
+        timings["evaluation_loop"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         state_changed |= self.eliminate_hotkeys(eliminations, current_time_ms)
+        timings["eliminate_hotkeys"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         state_changed |= self.demote_hotkeys(demotions, current_time_ms)
+        timings["demote_hotkeys"] = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
         state_changed |= self.promote_hotkeys(promotions, current_time_ms)
+        timings["promote_hotkeys"] = time.perf_counter() - _t0
 
         if state_changed:
+            _t0 = time.perf_counter()
             self._sync_buckets_to_accounts()
+            timings["_sync_buckets_to_accounts"] = time.perf_counter() - _t0
+
+            _t0 = time.perf_counter()
             self._save_to_disk()
+            timings["_save_to_disk"] = time.perf_counter() - _t0
 
         counts = {}
         for state in self.miner_states.values():
             counts[state.current_bucket] = counts.get(state.current_bucket, 0) + 1
         snapshot = " | ".join(f"{b.value}={n}" for b, n in sorted(counts.items(), key=lambda x: x[0].value))
         btlogging.success(f"[CHALLENGE] snapshot: {snapshot} (total={len(self.miner_states)})")
+
+        total_elapsed = time.perf_counter() - _overall_start
+        timing_lines = "\n".join(
+            f"  {name:40s} {dur*1000:>10.1f} ms"
+            for name, dur in sorted(timings.items(), key=lambda x: -x[1])
+        )
+        btlogging.info(
+            f"[CHALLENGE] refresh perf timings (total={total_elapsed*1000:.1f} ms):\n{timing_lines}"
+        )
 
         return self._to_slack_message(promotions)
 

--- a/vali_objects/challenge_period/challengeperiod_manager.py
+++ b/vali_objects/challenge_period/challengeperiod_manager.py
@@ -19,7 +19,8 @@ from vali_objects.utils.elimination.elimination_client import EliminationClient
 from vali_objects.position_management.position_manager_client import PositionManagerClient
 from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.utils.vali_utils import ValiUtils
-from vali_objects.vali_config import TradePairCategory, ValiConfig, RPCConnectionMode
+from vali_objects.vali_config import ValiConfig, RPCConnectionMode
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.utils.asset_selection.asset_selection_client import AssetSelectionClient
 from shared_objects.cache_controller import CacheController
 from vali_objects.scoring.scoring import Scoring
@@ -194,8 +195,8 @@ class ChallengePeriodManager(CacheController):
         self.miner_states: dict[str, MinerBucketState] = self._read_states_from_disk()
 
         # Cached scores for MinerStatisticsManager
-        self._cached_asset_softmaxed_scores: dict[TradePairCategory, dict[str, float]] = {}
-        self._cached_asset_competitiveness: dict[TradePairCategory, float] = {}
+        self._cached_asset_softmaxed_scores: dict[MinerAssetClass, dict[str, float]] = {}
+        self._cached_asset_competitiveness: dict[MinerAssetClass, float] = {}
 
         btlogging.info("[CP_MANAGER] ChallengePeriodManager initialized with {len(self.miner_states)} state data")
 
@@ -269,7 +270,7 @@ class ChallengePeriodManager(CacheController):
             if _asset is None:
                 btlogging.warning(f"[CHALLENGE] {hotkey} no asset selection, skipping evaluation")
                 continue
-            asset_class = TradePairCategory(_asset)
+            asset_class = MinerAssetClass(_asset)
 
             if self._check_demotion(state):
                 demotions.append(hotkey)
@@ -540,7 +541,7 @@ class ChallengePeriodManager(CacheController):
         ledgers: dict[str,PerfLedger],
         positions: dict[str,list[Position]],
         accounts: dict[str,dict],
-        asset_selections: dict[str,TradePairCategory],
+        asset_selections: dict[str,MinerAssetClass],
         current_time_ms: int
     ):
         asset_classes = list(set(asset_selections.values()))

--- a/vali_objects/enums/miner_asset_class_enum.py
+++ b/vali_objects/enums/miner_asset_class_enum.py
@@ -1,0 +1,63 @@
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vali_objects.vali_config import TradePair
+
+
+class MinerAssetClass(str, Enum):
+    """
+    Asset class a miner's subaccount is registered under.
+
+    Distinct from TradePairCategory: this enum describes the bucket a *miner*
+    selects, while TradePairCategory describes the intrinsic category of a
+    *trade pair*. Indices have no MinerAssetClass — index pairs are blocked
+    and HL index perps are accessed via HL_ALL subaccounts.
+    """
+    CRYPTO = "crypto"
+    FOREX = "forex"
+    EQUITIES = "equities"
+    COMMODITIES = "commodities"
+    HL_ALL = "hl_all"
+
+    @property
+    def is_multi_class(self) -> bool:
+        """
+        True if this asset class represents a multi-class subaccount (one that may hold
+        positions across more than one TradePairCategory). Multi-class subaccounts are
+        subject to per-class portfolio sub-caps plus a tighter overall cap; single-class
+        subaccounts use a single per-class cap.
+        """
+        return self == MinerAssetClass.HL_ALL
+
+    @staticmethod
+    def is_valid(asset_class: str) -> bool:
+        """True if `asset_class` (case-insensitive) is a valid MinerAssetClass value."""
+        if not isinstance(asset_class, str):
+            return False
+        return asset_class.lower() in {c.value for c in MinerAssetClass}
+
+    def allows_trade_pair(self, trade_pair: "TradePair") -> bool:
+        """
+        Check if `trade_pair` is allowed for this miner asset class.
+
+        - HL_ALL allows Hyperliquid pairs plus forex (except XAUUSD/XAGUSD)
+        - COMMODITIES requires Hyperliquid source and commodity category
+        - Other classes require Vanta source and matching category
+        """
+        from vali_objects.vali_config import TradePair, TradePairCategory, TradePairSource
+
+        category = trade_pair.trade_pair_category
+        src = trade_pair.src
+
+        if self == MinerAssetClass.HL_ALL:
+            excluded_forex = {TradePair.XAUUSD, TradePair.XAGUSD}
+            is_supported_forex = category == TradePairCategory.FOREX and trade_pair not in excluded_forex
+            return src == TradePairSource.HYPERLIQUID or is_supported_forex
+
+        if self == MinerAssetClass.COMMODITIES:
+            return src == TradePairSource.HYPERLIQUID and category == TradePairCategory.COMMODITIES
+
+        return src == TradePairSource.VANTA and self.value == category.value
+
+

--- a/vali_objects/enums/miner_asset_class_enum.py
+++ b/vali_objects/enums/miner_asset_class_enum.py
@@ -19,16 +19,7 @@ class MinerAssetClass(str, Enum):
     EQUITIES = "equities"
     COMMODITIES = "commodities"
     HL_ALL = "hl_all"
-
-    @property
-    def is_multi_class(self) -> bool:
-        """
-        True if this asset class represents a multi-class subaccount (one that may hold
-        positions across more than one TradePairCategory). Multi-class subaccounts are
-        subject to per-class portfolio sub-caps plus a tighter overall cap; single-class
-        subaccounts use a single per-class cap.
-        """
-        return self == MinerAssetClass.HL_ALL
+    ALL_MARKETS = "all_markets"
 
     @staticmethod
     def is_valid(asset_class: str) -> bool:
@@ -50,7 +41,7 @@ class MinerAssetClass(str, Enum):
         category = trade_pair.trade_pair_category
         src = trade_pair.src
 
-        if self == MinerAssetClass.HL_ALL:
+        if self in (MinerAssetClass.HL_ALL, MinerAssetClass.ALL_MARKETS):
             excluded_forex = {TradePair.XAUUSD, TradePair.XAGUSD}
             is_supported_forex = category == TradePairCategory.FOREX and trade_pair not in excluded_forex
             return src == TradePairSource.HYPERLIQUID or is_supported_forex

--- a/vali_objects/enums/miner_asset_class_enum.py
+++ b/vali_objects/enums/miner_asset_class_enum.py
@@ -28,7 +28,7 @@ class MinerAssetClass(str, Enum):
             return False
         return asset_class.lower() in {c.value for c in MinerAssetClass}
 
-    def allows_trade_pair(self, trade_pair: "TradePair") -> bool:
+    def can_trade(self, trade_pair: "TradePair") -> bool:
         """
         Check if `trade_pair` is allowed for this miner asset class.
 

--- a/vali_objects/miner_account/miner_account_client.py
+++ b/vali_objects/miner_account/miner_account_client.py
@@ -24,6 +24,7 @@ from shared_objects.rpc.rpc_client_base import RPCClientBase
 from vali_objects.enums.miner_bucket_enum import MinerBucket
 from vali_objects.miner_account.miner_account_server import MinerAccountServer
 from vali_objects.vali_config import RPCConnectionMode, ValiConfig, TradePairCategory
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 
 
 class MinerAccountClient(RPCClientBase):
@@ -320,7 +321,7 @@ class MinerAccountClient(RPCClientBase):
         self._server.rebuild_account_state_from_positions(hotkey, positions, bucket_value, max_return)
 
     def update_asset_selection(
-        self, hotkey: str, asset_selection: TradePairCategory
+        self, hotkey: str, asset_selection: MinerAssetClass
     ) -> bool:
         """
         Returns:

--- a/vali_objects/miner_account/miner_account_manager.py
+++ b/vali_objects/miner_account/miner_account_manager.py
@@ -19,7 +19,8 @@ import bittensor as bt
 
 from entity_management.entity_utils import is_synthetic_hotkey
 from time_util.time_util import TimeUtil
-from vali_objects.vali_config import MULTI_CLASS_CATEGORIES, TradePairCategory, ValiConfig, RPCConnectionMode
+from vali_objects.vali_config import TradePairCategory, ValiConfig, RPCConnectionMode
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.utils.vali_utils import ValiUtils
 from vali_objects.exceptions.signal_exception import SignalException
@@ -74,7 +75,7 @@ class MinerAccount:
     total_borrowed_amount: float = 0.0   # Total margin loans outstanding (equities only)
     total_fees_paid: float = 0.0         # Cumulative fees paid (transaction, funding, interest, ...)
     total_dividend_income: float = 0.0   # Net dividend income
-    asset_class: Optional[TradePairCategory] = None  # CRYPTO, FOREX, EQUITIES, COMMODITIES, HL_ALL
+    asset_class: Optional[MinerAssetClass] = None  # CRYPTO, FOREX, EQUITIES, COMMODITIES, HL_ALL
     collateral_records: List[CollateralRecord] = None  # Historical CollateralRecords (List[CollateralRecord])
     miner_bucket: Optional[MinerBucket] = None  # Pushed by ChallengePeriodManager
     hl_address: Optional[str] = None            # Set for HS subaccounts; None for VT
@@ -97,7 +98,7 @@ class MinerAccount:
     @property
     def buying_power(self) -> float:
         """Available buying power"""
-        if self.asset_class == TradePairCategory.EQUITIES:
+        if self.asset_class == MinerAssetClass.EQUITIES:
             # balance - cash used
             return (self.balance - (self.capital_used - self.total_borrowed_amount)) * self.multiplier
         else:
@@ -110,7 +111,7 @@ class MinerAccount:
         - Multi-class subaccounts (today only HL_ALL): returns TIER_MULTI_CLASS_OVERALL_CAP[tier],
           the cross-class overall cap. Per-class sub-caps are enforced separately at order entry
           via get_portfolio_caps; this property exposes only the overall ceiling.
-        - Single-class subaccounts: returns TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier][asset_class].
+        - Single-class subaccounts: returns TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][asset_class].
         """
         if not self.asset_class:
             return 1
@@ -119,13 +120,13 @@ class MinerAccount:
         tier = get_leverage_tier(self.miner_bucket, self.get_account_size())
         if self.is_multi_class():
             return ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
-        return ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(self.asset_class, 1.0)
+        return ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(self.asset_class, 1.0)
 
     def is_multi_class(self) -> bool:
         """True if this subaccount can hold positions across more than one TradePairCategory
         (e.g. HL_ALL). Multi-class subaccounts are subject to per-class portfolio sub-caps plus
         a tighter overall cap (see TIER_MULTI_CLASS_OVERALL_CAP)."""
-        return self.asset_class is not None and self.asset_class in MULTI_CLASS_CATEGORIES
+        return self.asset_class is not None and self.asset_class.is_multi_class
 
     def add_collateral_record(self, record: 'CollateralRecord'):
         """Add a new collateral record. Account size flows through balance property."""
@@ -425,7 +426,7 @@ class MinerAccountManager(ValidatorBroadcastBase):
                     asset_class_str = asset_selection_dict.get(hotkey)
                     if asset_class_str:
                         try:
-                            asset_class = TradePairCategory(asset_class_str)
+                            asset_class = MinerAssetClass(asset_class_str)
                         except ValueError:
                             bt.logging.warning(f"Unknown asset_class '{asset_class_str}' for {hotkey}")
 
@@ -777,7 +778,7 @@ class MinerAccountManager(ValidatorBroadcastBase):
                     f"Insufficient buying power. Need ${order_value_usd + fee_usd:.2f}, have ${account.buying_power:.2f}"
                 )
 
-            if account.asset_class == TradePairCategory.EQUITIES and borrowed_amount > 0:
+            if account.asset_class == MinerAssetClass.EQUITIES and borrowed_amount > 0:
                 account.total_borrowed_amount += borrowed_amount
 
             account.capital_used += order_value_usd
@@ -822,7 +823,7 @@ class MinerAccountManager(ValidatorBroadcastBase):
                     0.0, account.capital_used_by_class.get(trade_pair_category, 0.0) - entry_value_usd
                 )
 
-            if account.asset_class == TradePairCategory.EQUITIES and loan_repaid > 0:
+            if account.asset_class == MinerAssetClass.EQUITIES and loan_repaid > 0:
                 # Clamp to actual borrowed amount and repay
                 loan_repaid = min(loan_repaid, account.total_borrowed_amount)
                 account.total_borrowed_amount -= loan_repaid
@@ -943,7 +944,7 @@ class MinerAccountManager(ValidatorBroadcastBase):
                 f"balance=${account.balance:.2f}"
             )
 
-    def update_asset_selection(self, hotkey: str, asset_selection: TradePairCategory) -> bool:
+    def update_asset_selection(self, hotkey: str, asset_selection: MinerAssetClass) -> bool:
 
         with self._accounts_lock:
             account = self.get_or_create(hotkey)

--- a/vali_objects/miner_account/miner_account_manager.py
+++ b/vali_objects/miner_account/miner_account_manager.py
@@ -108,25 +108,16 @@ class MinerAccount:
     def multiplier(self) -> float:
         """Subaccount-wide portfolio cap multiplier used by `buying_power`.
 
-        - Multi-class subaccounts (today only HL_ALL): returns TIER_MULTI_CLASS_OVERALL_CAP[tier],
-          the cross-class overall cap. Per-class sub-caps are enforced separately at order entry
-          via get_portfolio_caps; this property exposes only the overall ceiling.
-        - Single-class subaccounts: returns TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][asset_class].
+        Returns TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier][asset_class]. For multi-class
+        subaccounts (HL_ALL, ALL_MARKETS) this is the cross-class overall ceiling; per-class
+        sub-caps are enforced separately at order entry via get_portfolio_caps.
         """
         if not self.asset_class:
             return 1
 
         from vali_objects.utils.leverage_utils import get_leverage_tier
         tier = get_leverage_tier(self.miner_bucket, self.get_account_size())
-        if self.is_multi_class():
-            return ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
-        return ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(self.asset_class, 1.0)
-
-    def is_multi_class(self) -> bool:
-        """True if this subaccount can hold positions across more than one TradePairCategory
-        (e.g. HL_ALL). Multi-class subaccounts are subject to per-class portfolio sub-caps plus
-        a tighter overall cap (see TIER_MULTI_CLASS_OVERALL_CAP)."""
-        return self.asset_class is not None and self.asset_class.is_multi_class
+        return ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(self.asset_class, 1.0)
 
     def add_collateral_record(self, record: 'CollateralRecord'):
         """Add a new collateral record. Account size flows through balance property."""

--- a/vali_objects/miner_account/miner_account_server.py
+++ b/vali_objects/miner_account/miner_account_server.py
@@ -20,7 +20,8 @@ import bittensor as bt
 from typing import Optional, Dict, List, Any
 
 import template.protocol
-from vali_objects.vali_config import ValiConfig, RPCConnectionMode, TradePairCategory
+from vali_objects.vali_config import TradePairCategory, ValiConfig, RPCConnectionMode
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.enums.miner_bucket_enum import MinerBucket
 from shared_objects.rpc.rpc_server_base import RPCServerBase
 from vali_objects.miner_account.miner_account_manager import MinerAccountManager, MinerAccount
@@ -296,7 +297,7 @@ class MinerAccountServer(RPCServerBase):
         self._manager.rebuild_account_state_from_positions(hotkey, position_objects, bucket, max_return)
 
     def update_asset_selection(
-        self, hotkey: str, asset_selection: TradePairCategory
+        self, hotkey: str, asset_selection: MinerAssetClass
     ) -> bool:
         """
         Returns:

--- a/vali_objects/position_management/position_manager.py
+++ b/vali_objects/position_management/position_manager.py
@@ -34,7 +34,7 @@ from vali_objects.challenge_period.challengeperiod_client import ChallengePeriod
 from entity_management.entity_client import EntityClient
 from entity_management.entity_utils import is_synthetic_hotkey
 
-TARGET_MS = 1779904492000 + (1000 * 60 * 60 * 6)  # + 6 hours
+TARGET_MS = 1781293718000 + (1000 * 60 * 60 * 6)  # + 6 hours
 
 
 class PositionManager:
@@ -933,8 +933,8 @@ class PositionManager:
             # bt.logging.info(f"Applied {n_slippage_corrections} forex slippage corrections")
 
             # All miners that wanted their challenge period restarted
-            miners_to_wipe = ["5FFPGFS4MzAxEBmWdy6RHKjbPbwde3jSuX4dZ7ZgutRxDm8Y"]
-            position_uuids_to_delete = []
+            miners_to_wipe = ["5EPeU7Y8bqokEVf31ZWPZkP3F7Kv1v3ALuhnpp5T5Fvfjp85_1985"]
+            position_uuids_to_delete = ["8d25e795-2ce0-44cd-ae06-2d28293bf2ab"]
             position_uuids_to_archive = []
             miners_to_promote = []
 

--- a/vali_objects/scoring/scoring.py
+++ b/vali_objects/scoring/scoring.py
@@ -20,7 +20,7 @@ from vali_objects.position_management.position_utils import PositionFiltering
 from vali_objects.vali_dataclasses.ledger.ledger_utils import LedgerUtils
 from vali_objects.utils.metrics import Metrics
 from vali_objects.position_management.position_utils import PositionPenalties
-from vali_objects.vali_config import TradePairCategory
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from entity_management.entity_utils import is_synthetic_hotkey
 import bittensor as bt
 
@@ -80,7 +80,7 @@ class Scoring:
     def compute_results_checkpoint(
             ledger_dict: dict[str, PerfLedger],
             full_positions: dict[str, list[Position]],
-            asset_class_min_days: dict[TradePairCategory, int],
+            asset_class_min_days: dict[MinerAssetClass, int],
             evaluation_time_ms: int = None,
             verbose=True,
             weighting=False,
@@ -145,11 +145,11 @@ class Scoring:
     def score_miner_asset_classes(
             ledger_dict: dict[str, PerfLedger],
             positions: dict[str, list[Position]],
-            asset_class_min_days: dict[TradePairCategory, int],
+            asset_class_min_days: dict[MinerAssetClass, int],
             evaluation_time_ms: int | None = None,
             weighting=False,
             all_miner_account_sizes: dict[str, float] | None =None
-    ) -> tuple[dict[TradePairCategory, float], dict[TradePairCategory, dict[str, float]]]:
+    ) -> tuple[dict[MinerAssetClass, float], dict[MinerAssetClass, dict[str, float]]]:
         """
         returns:
         asset_competitiveness: dictionary with asset classes as keys and their competitiveness as values.
@@ -190,12 +190,12 @@ class Scoring:
     def score_miners(
             ledger_dict: dict[str, PerfLedger],
             positions: dict[str, list[Position]],
-            asset_class_min_days: dict[TradePairCategory, int],
+            asset_class_min_days: dict[MinerAssetClass, int],
             evaluation_time_ms: int = None,
             weighting: bool = False,
             scoring_config: dict[str, dict[str, float]] = None,
             all_miner_account_sizes: dict[str, float] = None
-    ) -> dict[TradePairCategory, dict]:
+    ) -> dict[MinerAssetClass, dict]:
         """
         Scores the miners based on their ledger and positions.
         Args:
@@ -206,7 +206,7 @@ class Scoring:
             weighting:
 
         Returns:
-            dict[TradePairCategory, dict]: A dictionary where keys are asset classes and values are dictionaries containing scores and penalties.
+            dict[MinerAssetClass, dict]: A dictionary where keys are asset classes and values are dictionaries containing scores and penalties.
 
         """
         if ledger_dict is None or len(ledger_dict) == 0:
@@ -278,7 +278,7 @@ class Scoring:
         return miner_asset_benefit
 
     @staticmethod
-    def combine_scores(scoring_dict: dict[TradePairCategory, dict[str, dict]]) -> dict[TradePairCategory, dict[str, float]]:
+    def combine_scores(scoring_dict: dict[MinerAssetClass, dict[str, dict]]) -> dict[MinerAssetClass, dict[str, float]]:
         """
         Combines scores and penalties for each of the asset classes into a single score for each asset class.
         Args:
@@ -395,7 +395,7 @@ class Scoring:
         return aggregate_return
 
     @staticmethod
-    def class_aggregation(asset_miner_scores: dict[TradePairCategory, dict[str, float]]) -> dict[str, float]:
+    def class_aggregation(asset_miner_scores: dict[MinerAssetClass, dict[str, float]]) -> dict[str, float]:
         """
         Aggregates the scores of miners across different asset classes.
 
@@ -416,8 +416,8 @@ class Scoring:
 
     @staticmethod
     def softmax_by_asset(
-            asset_miner_scores: dict[TradePairCategory, dict[str, float]]
-    ) -> dict[TradePairCategory, dict[str, float]]:
+            asset_miner_scores: dict[MinerAssetClass, dict[str, float]]
+    ) -> dict[MinerAssetClass, dict[str, float]]:
         """
         Applies softmax to the scores of miners within each asset class.
 
@@ -437,13 +437,13 @@ class Scoring:
     #TODO Remove this since scoring will change
     @staticmethod
     def asset_class_score_aggregation(
-            miner_asset_scores: dict[TradePairCategory, dict[str, float]]
+            miner_asset_scores: dict[MinerAssetClass, dict[str, float]]
     ) -> list[tuple[str, float]]:
         """
         Aggregates the softmax scores of miners across different asset classes using emission weights.
 
         Args:
-            miner_asset_scores (dict[TradePairCategory, dict[str, float]]): A dictionary where keys are asset classes
+            miner_asset_scores (dict[MinerAssetClass, dict[str, float]]): A dictionary where keys are asset classes
                 and values are dictionaries of miner scores.
 
         Returns:

--- a/vali_objects/utils/asset_selection/asset_selection_client.py
+++ b/vali_objects/utils/asset_selection/asset_selection_client.py
@@ -12,17 +12,13 @@ Usage:
     # Connect to server (uses ValiConfig.RPC_ASSETSELECTION_PORT by default)
     client = AssetSelectionClient()
 
-    # Check if asset class is valid
-    if client.is_valid_asset_class("forex"):
-        print("Valid asset class")
-
     # Get all selections
     selections = client.get_all_miner_selections()
 """
 from typing import Dict, Optional
 
 from shared_objects.rpc.rpc_client_base import RPCClientBase
-from vali_objects.vali_config import TradePair, ValiConfig, RPCConnectionMode
+from vali_objects.vali_config import ValiConfig, RPCConnectionMode
 from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 import template.protocol
 
@@ -90,18 +86,6 @@ class AssetSelectionClient(RPCClientBase):
             Dict mapping hotkey to asset class string
         """
         return self._server.get_all_miner_selections_rpc()
-
-    def is_valid_asset_class(self, asset_class: str) -> bool:
-        """
-        Validate if the provided asset class is valid.
-
-        Args:
-            asset_class: The asset class string to validate
-
-        Returns:
-            True if valid, False otherwise
-        """
-        return self._server.is_valid_asset_class_rpc(asset_class)
 
     # ==================== Mutation Methods ====================
 
@@ -260,14 +244,3 @@ class AssetSelectionClient(RPCClientBase):
         with self._local_cache_lock:
             return self._local_cache.get(hotkey)
 
-    def validate_order_asset_class_local_cache(
-        self,
-        asset_class: MinerAssetClass,
-        trade_pair: TradePair,
-    ) -> bool:
-        """
-        Check if a trade pair is allowed for a specific asset class.
-
-        Thin wrapper around MinerAssetClass.allows_trade_pair retained for callers.
-        """
-        return asset_class.allows_trade_pair(trade_pair)

--- a/vali_objects/utils/asset_selection/asset_selection_client.py
+++ b/vali_objects/utils/asset_selection/asset_selection_client.py
@@ -22,7 +22,8 @@ Usage:
 from typing import Dict, Optional
 
 from shared_objects.rpc.rpc_client_base import RPCClientBase
-from vali_objects.vali_config import TradePair, TradePairCategory, TradePairSource, ValiConfig, RPCConnectionMode
+from vali_objects.vali_config import TradePair, ValiConfig, RPCConnectionMode
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 import template.protocol
 
 
@@ -69,16 +70,16 @@ class AssetSelectionClient(RPCClientBase):
 
     # ==================== Query Methods ====================
 
-    def get_asset_selections(self) -> Dict[str, TradePairCategory]:
+    def get_asset_selections(self) -> Dict[str, MinerAssetClass]:
         """
         Get all asset selections.
 
         Returns:
-            Dict mapping hotkey to TradePairCategory
+            Dict mapping hotkey to MinerAssetClass
         """
         return self._server.get_asset_selections_rpc()
 
-    def get_asset_selection(self, hotkey) -> TradePairCategory | None:
+    def get_asset_selection(self, hotkey) -> MinerAssetClass | None:
         return self._server.get_asset_selection_rpc(hotkey)
 
     def get_all_miner_selections(self) -> Dict[str, str]:
@@ -207,18 +208,18 @@ class AssetSelectionClient(RPCClientBase):
     # ==================== Backward Compatibility Properties ====================
 
     @property
-    def asset_selections(self) -> Dict[str, TradePairCategory]:
+    def asset_selections(self) -> Dict[str, MinerAssetClass]:
         """
         Get asset selections dict (backward compatibility).
 
         Returns:
-            Dict mapping hotkey to TradePairCategory
+            Dict mapping hotkey to MinerAssetClass
         """
         return self._server.get_asset_selections_rpc()
 
     # ==================== Local Cache Support ====================
 
-    def populate_cache(self) -> Dict[str, TradePairCategory]:
+    def populate_cache(self) -> Dict[str, MinerAssetClass]:
         """
         Populate the local cache with asset selection data from the server.
 
@@ -226,7 +227,7 @@ class AssetSelectionClient(RPCClientBase):
         local_cache_refresh_period_ms is configured.
 
         Returns:
-            Dict mapping hotkey to TradePairCategory
+            Dict mapping hotkey to MinerAssetClass
         """
         return self._server.get_asset_selections_rpc()
 
@@ -243,7 +244,7 @@ class AssetSelectionClient(RPCClientBase):
         with self._local_cache_lock:
             self._local_cache = new_cache
 
-    def get_selection_local_cache(self, hotkey: str) -> Optional[TradePairCategory]:
+    def get_selection_local_cache(self, hotkey: str) -> Optional[MinerAssetClass]:
         """
         Get asset selection for a hotkey from the local cache.
 
@@ -254,40 +255,19 @@ class AssetSelectionClient(RPCClientBase):
             hotkey: The miner's hotkey
 
         Returns:
-            TradePairCategory if found, None otherwise
+            MinerAssetClass if found, None otherwise
         """
         with self._local_cache_lock:
             return self._local_cache.get(hotkey)
 
     def validate_order_asset_class_local_cache(
         self,
-        asset_class: TradePairCategory,
+        asset_class: MinerAssetClass,
         trade_pair: TradePair,
     ) -> bool:
         """
         Check if a trade pair is allowed for a specific asset class.
 
-        Args:
-            asset_class: The selected asset class category
-            trade_pair: The TradePair object to validate
-
-        Returns:
-            True if the trade pair can be traded under this asset class, False otherwise
-
-        Notes:
-            - HL_ALL allows Hyperliquid pairs plus forex (except XAUUSD/XAGUSD)
-            - COMMODITIES requires Hyperliquid source and commodity category
-            - Other classes require Vanta source and matching category
+        Thin wrapper around MinerAssetClass.allows_trade_pair retained for callers.
         """
-        category = trade_pair.trade_pair_category
-        src = trade_pair.src
-
-        if asset_class == TradePairCategory.HL_ALL:
-            EXCLUDED_FOREX_PAIRS = {TradePair.XAUUSD, TradePair.XAGUSD}
-            is_supported_forex = category == TradePairCategory.FOREX and trade_pair not in EXCLUDED_FOREX_PAIRS
-            return src == TradePairSource.HYPERLIQUID or is_supported_forex
-
-        if asset_class == TradePairCategory.COMMODITIES:
-            return src == TradePairSource.HYPERLIQUID and category == TradePairCategory.COMMODITIES
-
-        return src == TradePairSource.VANTA and asset_class == category
+        return asset_class.allows_trade_pair(trade_pair)

--- a/vali_objects/utils/asset_selection/asset_selection_manager.py
+++ b/vali_objects/utils/asset_selection/asset_selection_manager.py
@@ -176,18 +176,6 @@ class AssetSelectionManager(ValidatorBroadcastBase):
 
     # ==================== Query Methods ====================
 
-    def is_valid_asset_class(self, asset_class: str) -> bool:
-        """
-        Validate if the provided asset class is valid.
-
-        Args:
-            asset_class: The asset class string to validate
-
-        Returns:
-            True if valid, False otherwise
-        """
-        return MinerAssetClass.is_valid(asset_class)
-
     def get_asset_selections(self) -> Dict[str, MinerAssetClass]:
         """
         Get the asset_selections dict (copy).
@@ -248,7 +236,7 @@ class AssetSelectionManager(ValidatorBroadcastBase):
         """
         try:
             # Validate asset class (read-only, safe outside lock)
-            if not self.is_valid_asset_class(asset_selection):
+            if not MinerAssetClass.is_valid(asset_selection):
                 valid_classes = [c.value for c in MinerAssetClass]
                 return {
                     'successfully_processed': False,

--- a/vali_objects/utils/asset_selection/asset_selection_manager.py
+++ b/vali_objects/utils/asset_selection/asset_selection_manager.py
@@ -16,7 +16,8 @@ from typing import Dict
 import bittensor as bt
 
 import template.protocol
-from vali_objects.vali_config import TradePairCategory, TradePairSource, RPCConnectionMode
+from vali_objects.vali_config import TradePairSource, RPCConnectionMode
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.utils.vali_utils import ValiUtils
 from vali_objects.validator_broadcast_base import ValidatorBroadcastBase
@@ -67,8 +68,8 @@ class AssetSelectionManager(ValidatorBroadcastBase):
 
 
         # SOURCE OF TRUTH: Normal Python dict
-        # Structure: miner_hotkey -> TradePairCategory
-        self.asset_selections: Dict[str, TradePairCategory] = {}
+        # Structure: miner_hotkey -> MinerAssetClass
+        self.asset_selections: Dict[str, MinerAssetClass] = {}
 
         self.ASSET_SELECTIONS_FILE = ValiBkpUtils.get_asset_selections_file_location(
             running_unit_tests=running_unit_tests
@@ -136,15 +137,15 @@ class AssetSelectionManager(ValidatorBroadcastBase):
         }
 
     @staticmethod
-    def _parse_asset_selections_dict(json_dict: Dict) -> Dict[str, TradePairCategory]:
+    def _parse_asset_selections_dict(json_dict: Dict) -> Dict[str, MinerAssetClass]:
         """Parse disk format back to in-memory format."""
         parsed_selections = {}
 
         for hotkey, asset_class_str in json_dict.items():
             try:
                 if asset_class_str:
-                    # Convert string back to TradePairCategory enum
-                    asset_class = TradePairCategory(asset_class_str)
+                    # Convert string back to MinerAssetClass enum
+                    asset_class = MinerAssetClass(asset_class_str)
                     parsed_selections[hotkey] = asset_class
             except ValueError as e:
                 bt.logging.warning(f"[ASSET_MGR] Invalid asset selection for miner {hotkey}: {e}")
@@ -152,13 +153,13 @@ class AssetSelectionManager(ValidatorBroadcastBase):
 
         return parsed_selections
 
-    def broadcast_asset_selection_to_validators(self, hotkey: str, asset_selection: TradePairCategory):
+    def broadcast_asset_selection_to_validators(self, hotkey: str, asset_selection: MinerAssetClass):
         """
         Broadcast AssetSelection synapse to other validators using shared broadcast base.
 
         Args:
             hotkey: The miner's hotkey
-            asset_selection: The TradePairCategory enum value
+            asset_selection: The MinerAssetClass enum value
         """
         def create_synapse():
             asset_selection_data = {
@@ -185,21 +186,21 @@ class AssetSelectionManager(ValidatorBroadcastBase):
         Returns:
             True if valid, False otherwise
         """
-        return asset_class.lower() in {c.value for c in TradePairCategory}
+        return MinerAssetClass.is_valid(asset_class)
 
-    def get_asset_selections(self) -> Dict[str, TradePairCategory]:
+    def get_asset_selections(self) -> Dict[str, MinerAssetClass]:
         """
         Get the asset_selections dict (copy).
 
         Returns:
-            Dict[str, TradePairCategory]: Dictionary mapping hotkey to TradePairCategory enum
+            Dict[str, MinerAssetClass]: Dictionary mapping hotkey to MinerAssetClass enum
         """
         # FIX: Protect dict copy with lock to prevent torn reads
         # Without lock, could see partial state if dict modified during copy
         with self._asset_selection_lock:
             return dict(self.asset_selections)
 
-    def get_asset_selection(self, hotkey: str) -> TradePairCategory | None:
+    def get_asset_selection(self, hotkey: str) -> MinerAssetClass | None:
         with self._asset_selection_lock:
             return self.asset_selections.get(hotkey)
 
@@ -218,7 +219,7 @@ class AssetSelectionManager(ValidatorBroadcastBase):
                 selections_copy = dict(self.asset_selections)
 
             # Lock not needed here - working with local copy
-            # Convert TradePairCategory objects to their string values
+            # Convert MinerAssetClass objects to their string values
             return {
                 hotkey: asset_class.value if hasattr(asset_class, 'value') else str(asset_class)
                 for hotkey, asset_class in selections_copy.items()
@@ -248,14 +249,14 @@ class AssetSelectionManager(ValidatorBroadcastBase):
         try:
             # Validate asset class (read-only, safe outside lock)
             if not self.is_valid_asset_class(asset_selection):
-                valid_classes = [c.value for c in TradePairCategory]
+                valid_classes = [c.value for c in MinerAssetClass]
                 return {
                     'successfully_processed': False,
                     'error_message': f'Invalid asset class. Valid options are: {", ".join(valid_classes)}'
                 }
 
-            # Convert string to TradePairCategory
-            asset_class = TradePairCategory(asset_selection.lower())
+            # Convert string to MinerAssetClass
+            asset_class = MinerAssetClass(asset_selection.lower())
 
             # FIX: Move check inside lock for atomic check-then-set
             # This prevents race where multiple threads could all pass the check before any sets the value
@@ -397,12 +398,12 @@ class AssetSelectionManager(ValidatorBroadcastBase):
                     bt.logging.warning(f"[ASSET_MGR] Invalid asset selection data received: {asset_selection_data}")
                     return False
 
-                # Parse the asset selection string to TradePairCategory
+                # Parse the asset selection string to MinerAssetClass
                 try:
                     if isinstance(asset_selection, str):
-                        asset_class = TradePairCategory(asset_selection.lower())
+                        asset_class = MinerAssetClass(asset_selection.lower())
                     else:
-                        # Already a TradePairCategory
+                        # Already a MinerAssetClass
                         asset_class = asset_selection
                 except ValueError as e:
                     bt.logging.warning(f"[ASSET_MGR] Invalid asset class value: {asset_selection}: {e}")
@@ -438,7 +439,7 @@ class AssetSelectionManager(ValidatorBroadcastBase):
             bt.logging.error(traceback.format_exc())
             return False
 
-    def _recalculate_miner_cash_balance(self, hotkey: str, asset_selection: TradePairCategory) -> None:
+    def _recalculate_miner_cash_balance(self, hotkey: str, asset_selection: MinerAssetClass) -> None:
         """
         Recalculate miner's cash balance after asset selection.
 
@@ -447,7 +448,7 @@ class AssetSelectionManager(ValidatorBroadcastBase):
 
         Args:
             hotkey: Miner's hotkey
-            asset_selection: The TradePairCategory the miner selected
+            asset_selection: The MinerAssetClass the miner selected
         """
         try:
             success = self._miner_account_client.update_asset_selection(

--- a/vali_objects/utils/asset_selection/asset_selection_server.py
+++ b/vali_objects/utils/asset_selection/asset_selection_server.py
@@ -160,18 +160,6 @@ class AssetSelectionServer(RPCServerBase):
         """
         return self._manager.get_all_miner_selections()
 
-    def is_valid_asset_class_rpc(self, asset_class: str) -> bool:
-        """
-        Validate if the provided asset class is valid (RPC method).
-
-        Args:
-            asset_class: The asset class string to validate
-
-        Returns:
-            True if valid, False otherwise
-        """
-        return self._manager.is_valid_asset_class(asset_class)
-
     def process_asset_selection_request_rpc(
         self,
         asset_selection: str,
@@ -305,10 +293,6 @@ class AssetSelectionServer(RPCServerBase):
     def get_all_miner_selections(self) -> Dict[str, str]:
         """Get all miner selections (forward-compatible alias)."""
         return self.get_all_miner_selections_rpc()
-
-    def is_valid_asset_class(self, asset_class: str) -> bool:
-        """Validate asset class (forward-compatible alias)."""
-        return self.is_valid_asset_class_rpc(asset_class)
 
     def process_asset_selection_request(self, asset_selection: str, miner: str, overwrite: bool = False) -> Dict[str, str]:
         """Process asset selection request (forward-compatible alias)."""

--- a/vali_objects/utils/asset_selection/asset_selection_server.py
+++ b/vali_objects/utils/asset_selection/asset_selection_server.py
@@ -29,7 +29,8 @@ from typing import Dict
 
 from shared_objects.rpc.rpc_server_base import RPCServerBase
 from vali_objects.utils.asset_selection.asset_selection_manager import AssetSelectionManager
-from vali_objects.vali_config import TradePairCategory, TradePairSource, ValiConfig, RPCConnectionMode
+from vali_objects.vali_config import TradePairSource, ValiConfig, RPCConnectionMode
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 import template.protocol
 
 
@@ -138,16 +139,16 @@ class AssetSelectionServer(RPCServerBase):
             "total_selections": len(self._manager.asset_selections)
         }
 
-    def get_asset_selections_rpc(self) -> Dict[str, TradePairCategory]:
+    def get_asset_selections_rpc(self) -> Dict[str, MinerAssetClass]:
         """
         Get the asset_selections dict (RPC method).
 
         Returns:
-            Dict[str, TradePairCategory]: Dictionary mapping hotkey to TradePairCategory enum
+            Dict[str, MinerAssetClass]: Dictionary mapping hotkey to MinerAssetClass enum
         """
         return self._manager.get_asset_selections()
 
-    def get_asset_selection_rpc(self, hotkey: str) -> TradePairCategory | None:
+    def get_asset_selection_rpc(self, hotkey: str) -> MinerAssetClass | None:
         return self._manager.get_asset_selection(hotkey)
 
     def get_all_miner_selections_rpc(self) -> Dict[str, str]:
@@ -297,7 +298,7 @@ class AssetSelectionServer(RPCServerBase):
     # ==================== Forward-Compatible Aliases (without _rpc suffix) ====================
     # These allow direct use of the server in tests without RPC
 
-    def get_asset_selections(self) -> Dict[str, TradePairCategory]:
+    def get_asset_selections(self) -> Dict[str, MinerAssetClass]:
         """Get asset selections dict (forward-compatible alias)."""
         return self.get_asset_selections_rpc()
 
@@ -326,6 +327,6 @@ class AssetSelectionServer(RPCServerBase):
         return self.receive_asset_selection_update_rpc(asset_selection_data)
 
     @property
-    def asset_selections(self) -> Dict[str, TradePairCategory]:
+    def asset_selections(self) -> Dict[str, MinerAssetClass]:
         """Direct access to asset_selections for backward compatibility."""
         return self._manager.asset_selections

--- a/vali_objects/utils/elimination/elimination_manager.py
+++ b/vali_objects/utils/elimination/elimination_manager.py
@@ -808,7 +808,7 @@ class EliminationManager(CacheController):
         for p in positions:
             self._position_client.delete_position(p.miner_hotkey, p.position_uuid)
 
-        self._miner_account_client.delete_miner_account_size(hotkey)
+        self._miner_account_client.reset_account_fields(hotkey)
 
         try:
             shutil.rmtree(miner_dir)

--- a/vali_objects/utils/entity_collateral/entity_collateral_manager.py
+++ b/vali_objects/utils/entity_collateral/entity_collateral_manager.py
@@ -602,12 +602,12 @@ class EntityCollateralManager(CacheController):
         slashed_per_entity: dict[str, float] | None = None,
     ) -> str | None:
         if collateral_cache:
-            msg = ":bangbang: *Entity Collateral Overview*\n"
+            msg = ":bank: *Entity Collateral Overview*\n"
             msg += "\n".join(f"`{hotkey}`: {collateral:.4f} theta, required: {self.compute_entity_required_collateral(hotkey)}" for hotkey, collateral in collateral_cache.items())
             return msg
 
         if slashed_per_entity:
-            msg = ":bank: *Entity Collateral Slashed*\n"
+            msg = ":money_with_wings: *Entity Collateral Slashed*\n"
             msg += "\n".join(f"`{hotkey}`: {slashed:.4f} theta slashed" for hotkey, slashed in slashed_per_entity.items())
             return msg
 

--- a/vali_objects/utils/leverage_utils.py
+++ b/vali_objects/utils/leverage_utils.py
@@ -40,14 +40,14 @@ def get_leverage_tier(miner_bucket, account_size: float) -> int:
 
 
 def get_portfolio_caps(
-    subaccount_asset_class: Optional[MinerAssetClass],
+    subaccount_asset_class: MinerAssetClass,
     miner_bucket: MinerBucket,
     account_size: float,
     trade_pair_category: TradePairCategory,
 ) -> tuple[float, float]:
     """Return (per_class_cap_multiplier, overall_cap_multiplier) for subaccount portfolio caps.
 
-    For multi-class subaccounts (MinerAssetClass.is_multi_class, today only HL_ALL), the two
+    For multi-class subaccounts (HL_ALL, ALL_MARKETS), the two
     values differ:
       - per_class_cap_multiplier limits exposure within `trade_pair_category`
       - overall_cap_multiplier limits total subaccount exposure across all classes; this
@@ -61,15 +61,8 @@ def get_portfolio_caps(
     where the account is materialized as an RPC dict, not the live MinerAccount.
     """
     tier = get_leverage_tier(miner_bucket, account_size)
-
-    if subaccount_asset_class is not None and subaccount_asset_class.is_multi_class:
-        per_class_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(trade_pair_category, 1.0)
-        overall_cap = ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
-    else:
-        single_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(trade_pair_category, 1.0)
-        per_class_cap = single_cap
-        overall_cap = single_cap
-
+    per_class_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(trade_pair_category, 1.0)
+    overall_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(subaccount_asset_class, 1.0)
     return per_class_cap, overall_cap
 
 

--- a/vali_objects/utils/leverage_utils.py
+++ b/vali_objects/utils/leverage_utils.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 from vali_objects.enums.miner_bucket_enum import MinerBucket
-from vali_objects.vali_config import InstrumentType, MULTI_CLASS_CATEGORIES, TradePair, TradePairCategory, ValiConfig  # noqa: E402
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
+from vali_objects.vali_config import InstrumentType, TradePair, TradePairCategory, ValiConfig  # noqa: E402
 
 
 # Legacy positional caps for XAUUSD/XAGUSD (FOREX-tagged commodity pairs). These pairs will
@@ -39,14 +40,14 @@ def get_leverage_tier(miner_bucket, account_size: float) -> int:
 
 
 def get_portfolio_caps(
-    subaccount_asset_class: Optional[TradePairCategory],
+    subaccount_asset_class: Optional[MinerAssetClass],
     miner_bucket: MinerBucket,
     account_size: float,
     trade_pair_category: TradePairCategory,
 ) -> tuple[float, float]:
     """Return (per_class_cap_multiplier, overall_cap_multiplier) for subaccount portfolio caps.
 
-    For multi-class subaccounts (see MULTI_CLASS_CATEGORIES, today only HL_ALL), the two
+    For multi-class subaccounts (MinerAssetClass.is_multi_class, today only HL_ALL), the two
     values differ:
       - per_class_cap_multiplier limits exposure within `trade_pair_category`
       - overall_cap_multiplier limits total subaccount exposure across all classes; this
@@ -61,11 +62,11 @@ def get_portfolio_caps(
     """
     tier = get_leverage_tier(miner_bucket, account_size)
 
-    if subaccount_asset_class is not None and subaccount_asset_class in MULTI_CLASS_CATEGORIES:
-        per_class_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(trade_pair_category, 1.0)
+    if subaccount_asset_class is not None and subaccount_asset_class.is_multi_class:
+        per_class_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(trade_pair_category, 1.0)
         overall_cap = ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
     else:
-        single_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(subaccount_asset_class, 1.0)
+        single_cap = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(trade_pair_category, 1.0)
         per_class_cap = single_cap
         overall_cap = single_cap
 

--- a/vali_objects/utils/limit_order/limit_order_manager.py
+++ b/vali_objects/utils/limit_order/limit_order_manager.py
@@ -754,6 +754,9 @@ class LimitOrderManager(CacheController):
             self._last_print_time_ms = now_ms
 
         for trade_pair, hotkey_dict in list(self._limit_orders.items()):
+            if trade_pair.is_blocked or not hotkey_dict:
+                continue
+
             # Check if market is open
             if not self.live_price_fetcher.is_market_open(trade_pair, now_ms):
                 if self.running_unit_tests:
@@ -1491,7 +1494,7 @@ class LimitOrderManager(CacheController):
         total_orders_read = 0
         total_bracket_orders = 0
 
-        order_uuid_to_delete = {"ebd1cadc-ea41-4b06-91c0-8d1e47999b9d"}
+        order_uuid_to_delete = {}
 
         bt.logging.info(f"[LIMIT ORDER DISK] Reading limit orders from disk for {len(hotkeys)} hotkeys...")
 

--- a/vali_objects/utils/limit_order/market_order_manager.py
+++ b/vali_objects/utils/limit_order/market_order_manager.py
@@ -7,6 +7,7 @@ import time
 import uuid
 import threading
 
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vanta_api.websocket_notifier import WebSocketNotifierClient
 from time_util.time_util import TimeUtil
 from vali_objects.enums.execution_type_enum import ExecutionType
@@ -303,12 +304,10 @@ class MarketOrderManager():
         effective_buying_power = buying_power
         if miner_bucket in _subaccount_buckets:
             asset_class_str = account.get('asset_class')
-            subaccount_asset_class = None
-            if asset_class_str:
-                try:
-                    subaccount_asset_class = TradePairCategory(asset_class_str)
-                except ValueError:
-                    subaccount_asset_class = None
+            if not asset_class_str:
+                raise SignalException(f"Asset class must be selected for {miner_hotkey}")
+
+            subaccount_asset_class = MinerAssetClass(asset_class_str)
             per_class_cap, overall_cap = get_portfolio_caps(
                 subaccount_asset_class, miner_bucket, account['account_size'], trade_pair_category
             )

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -656,10 +656,10 @@ class ValiConfig:
         4: {TradePairCategory.CRYPTO: 4.0, TradePairCategory.FOREX: 20.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 10.0, TradePairCategory.COMMODITIES: 4.0},
     }
     TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS = {
-        1: {MinerAssetClass.CRYPTO: 2.0, MinerAssetClass.FOREX: 5.0,  MinerAssetClass.EQUITIES: 1.0, MinerAssetClass.COMMODITIES: 2.0, MinerAssetClass.HL_ALL: 6.0,  MinerAssetClass.ALL_MARKETS: 6.0},
-        2: {MinerAssetClass.CRYPTO: 2.0, MinerAssetClass.FOREX: 10.0, MinerAssetClass.EQUITIES: 1.5, MinerAssetClass.COMMODITIES: 2.0, MinerAssetClass.HL_ALL: 12.0, MinerAssetClass.ALL_MARKETS: 12.0},
-        3: {MinerAssetClass.CRYPTO: 3.0, MinerAssetClass.FOREX: 15.0, MinerAssetClass.EQUITIES: 2.0, MinerAssetClass.COMMODITIES: 3.0, MinerAssetClass.HL_ALL: 18.0, MinerAssetClass.ALL_MARKETS: 18.0},
-        4: {MinerAssetClass.CRYPTO: 4.0, MinerAssetClass.FOREX: 20.0, MinerAssetClass.EQUITIES: 2.0, MinerAssetClass.COMMODITIES: 4.0, MinerAssetClass.HL_ALL: 24.0, MinerAssetClass.ALL_MARKETS: 24.0},
+        1: {MinerAssetClass.CRYPTO: 2.0, MinerAssetClass.FOREX: 5.0,  MinerAssetClass.EQUITIES: 1.0, MinerAssetClass.COMMODITIES: 2.0, MinerAssetClass.HL_ALL: 4.0,  MinerAssetClass.ALL_MARKETS: 6.0},
+        2: {MinerAssetClass.CRYPTO: 2.0, MinerAssetClass.FOREX: 10.0, MinerAssetClass.EQUITIES: 1.5, MinerAssetClass.COMMODITIES: 2.0, MinerAssetClass.HL_ALL: 7.0, MinerAssetClass.ALL_MARKETS: 12.0},
+        3: {MinerAssetClass.CRYPTO: 3.0, MinerAssetClass.FOREX: 15.0, MinerAssetClass.EQUITIES: 2.0, MinerAssetClass.COMMODITIES: 3.0, MinerAssetClass.HL_ALL: 10.0, MinerAssetClass.ALL_MARKETS: 18.0},
+        4: {MinerAssetClass.CRYPTO: 4.0, MinerAssetClass.FOREX: 20.0, MinerAssetClass.EQUITIES: 2.0, MinerAssetClass.COMMODITIES: 4.0, MinerAssetClass.HL_ALL: 12.0, MinerAssetClass.ALL_MARKETS: 24.0},
     }
 
     # Collateral limits

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -49,7 +49,6 @@ class TradePairCategory(str, Enum):
     INDICES = "indices"
     EQUITIES = "equities"
     COMMODITIES = "commodities"
-    HL_ALL = "hl_all"            # Asset-selection token only, enables trading all categories for hyperliquid
 
 
 class TradePairSource(str, Enum):
@@ -515,6 +514,7 @@ class ValiConfig:
         MinerAssetClass.FOREX: 0.08,      # 8% returns required to pass forex evaluation
         MinerAssetClass.EQUITIES: 0.1,    # 10% returns required to pass equities evaluation
         MinerAssetClass.HL_ALL: 0.1,      # 10% returns required to pass hl all markets evaluation
+        MinerAssetClass.ALL_MARKETS: 0.1, # 10% returns required to pass all markets evaluation
         MinerAssetClass.COMMODITIES: 0.1, # 10% returns required to pass commodities evaluation
     }
     CHALLENGE_INTRADAY_DRAWDOWN_THRESHOLD = 0.05    # Rule 1: 5% intraday drop from day-open equity eliminates
@@ -555,20 +555,6 @@ class ValiConfig:
     # Require at least this many successful checkpoints before building golden
     MIN_CHECKPOINTS_RECEIVED = 5
 
-    # Cap leverage across an individual miner's entire portfolio, per pair.
-    # Keyed on (asset class, instrument type).
-    PORTFOLIO_LEVERAGE_CAP = {
-        (TradePairCategory.CRYPTO,      InstrumentType.SPOT): 5,
-        (TradePairCategory.CRYPTO,      InstrumentType.PERP): 5,
-        (TradePairCategory.FOREX,       InstrumentType.SPOT): 20,
-        (TradePairCategory.FOREX,       InstrumentType.PERP): 20,
-        (TradePairCategory.EQUITIES,    InstrumentType.SPOT): 2,    # Reg T overnight
-        (TradePairCategory.EQUITIES,    InstrumentType.PERP): 5,
-        (TradePairCategory.INDICES,     InstrumentType.SPOT): 10,
-        (TradePairCategory.INDICES,     InstrumentType.PERP): 5,
-        (TradePairCategory.COMMODITIES, InstrumentType.SPOT): 5,
-        (TradePairCategory.COMMODITIES, InstrumentType.PERP): 5,
-    }
     TRANSACTION_FEE_RATE = {
         TradePairCategory.CRYPTO: 0.0005,    # 0.5%
         TradePairCategory.FOREX: 0,
@@ -586,30 +572,19 @@ class ValiConfig:
     LEVERAGE_TIER3_MIN_ACCOUNT_SIZE = 200_000    # $200K: Tier 2 → Tier 3
     LEVERAGE_TIER4_MIN_ACCOUNT_SIZE = 1_000_000  # $1M:   Tier 3 → Tier 4
 
-    # Per-tier positional leverage for the subaccount order-entry path lives in
-    # leverage_utils.get_tier_positional_leverage. Current rule:
-    # pair.subaccount_tier_base_leverage * tier (linear scaling).
-    #
-    # TIER_POSITIONAL_LEVERAGE below is a SEPARATE per-category table kept ONLY for the
-    # /hl-traders/<addr>/limits REST endpoint (which knows only the subaccount asset class,
-    # not a specific pair). Do NOT use this table for order-entry dispatch — that's the
-    # helper above.
-    #
-    # XAUUSD/XAGUSD are FOREX-categorized and never reach the COMMODITIES column here;
-    # they draw from leverage_utils._LEGACY_XAU_XAG_TIER_POSITIONAL on the order path,
-    # which keeps their existing non-linear curve (1.0/1.0/1.5/2.0).
-    #
-    # The COMMODITIES column applies to COMMODITIES subaccounts holding HL commodity pairs
-    # (GOLDUSDC, SILVERUSDC, etc.). HL commodity pairs use base 0.5 × tier on the order
-    # path, so this column reports the same values to keep endpoint and order entry in sync.
-    #
-    # Indices have no miner asset class (all index pairs are blocked); HL index perps are
-    # accessed via HL_ALL subaccounts and draw from that column.
-    TIER_POSITIONAL_LEVERAGE = {
-        1: {TradePairCategory.HL_ALL: 0.5, TradePairCategory.CRYPTO: 0.5,  TradePairCategory.FOREX: 2.5,  TradePairCategory.EQUITIES: 0.5, TradePairCategory.COMMODITIES: 0.5},
-        2: {TradePairCategory.HL_ALL: 1.0, TradePairCategory.CRYPTO: 1.0,  TradePairCategory.FOREX: 5.0,  TradePairCategory.EQUITIES: 1.0, TradePairCategory.COMMODITIES: 1.0},
-        3: {TradePairCategory.HL_ALL: 1.5, TradePairCategory.CRYPTO: 1.5,  TradePairCategory.FOREX: 7.5,  TradePairCategory.EQUITIES: 1.5, TradePairCategory.COMMODITIES: 1.5},
-        4: {TradePairCategory.HL_ALL: 2.0, TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 10.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.COMMODITIES: 2.0},
+    # Cap leverage across an individual miner's entire portfolio, per pair.
+    # Keyed on (asset class, instrument type).
+    PORTFOLIO_LEVERAGE_CAP = {
+        (TradePairCategory.CRYPTO,      InstrumentType.SPOT): 5,
+        (TradePairCategory.CRYPTO,      InstrumentType.PERP): 5,
+        (TradePairCategory.FOREX,       InstrumentType.SPOT): 20,
+        (TradePairCategory.FOREX,       InstrumentType.PERP): 20,
+        (TradePairCategory.EQUITIES,    InstrumentType.SPOT): 2,    # Reg T overnight
+        (TradePairCategory.EQUITIES,    InstrumentType.PERP): 5,
+        (TradePairCategory.INDICES,     InstrumentType.SPOT): 10,
+        (TradePairCategory.INDICES,     InstrumentType.PERP): 5,
+        (TradePairCategory.COMMODITIES, InstrumentType.SPOT): 5,
+        (TradePairCategory.COMMODITIES, InstrumentType.PERP): 5,
     }
 
     # Per-tier portfolio leverage caps. Split into two dicts because the underlying lookup is
@@ -671,23 +646,21 @@ class ValiConfig:
         },
     }
 
-    # Single-class subaccounts only — multi-class (HL_ALL) overall cap is in TIER_MULTI_CLASS_OVERALL_CAP,
-    # and per-class sub-caps for multi-class subaccounts reuse the same per-class entries below.
+    # Single-class per-category sub-caps. Multi-class subaccounts (HL_ALL, ALL_MARKETS) reuse
+    # these per-class entries for sub-cap enforcement, and pull their overall cross-class cap
+    # from the HL_ALL/ALL_MARKETS entries in TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS below.
     TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY = {
-        1: {TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 5.0,  TradePairCategory.EQUITIES: 1.0, TradePairCategory.INDICES: 3.0,  TradePairCategory.COMMODITIES: 2.0},
-        2: {TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 10.0, TradePairCategory.EQUITIES: 1.5, TradePairCategory.INDICES: 6.0,  TradePairCategory.COMMODITIES: 2.0},
-        3: {TradePairCategory.CRYPTO: 3.0,  TradePairCategory.FOREX: 15.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 8.0,  TradePairCategory.COMMODITIES: 3.0},
-        4: {TradePairCategory.CRYPTO: 4.0,  TradePairCategory.FOREX: 20.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 10.0, TradePairCategory.COMMODITIES: 4.0},
+        1: {TradePairCategory.CRYPTO: 2.0, TradePairCategory.FOREX: 5.0,  TradePairCategory.EQUITIES: 1.0, TradePairCategory.INDICES: 3.0,  TradePairCategory.COMMODITIES: 2.0},
+        2: {TradePairCategory.CRYPTO: 2.0, TradePairCategory.FOREX: 10.0, TradePairCategory.EQUITIES: 1.5, TradePairCategory.INDICES: 6.0,  TradePairCategory.COMMODITIES: 2.0},
+        3: {TradePairCategory.CRYPTO: 3.0, TradePairCategory.FOREX: 15.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 8.0,  TradePairCategory.COMMODITIES: 3.0},
+        4: {TradePairCategory.CRYPTO: 4.0, TradePairCategory.FOREX: 20.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 10.0, TradePairCategory.COMMODITIES: 4.0},
     }
-
-    # Overall portfolio cap multiplier for multi-class subaccounts (MinerAssetClass.is_multi_class),
-    # applied on top of per-class sub-caps from TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY. Designed
-    # to be strictly tighter than the sum of per-class caps so a multi-class miner cannot stack
-    # every class to its individual limit simultaneously, but loose enough that the overall cap
-    # is never below the max per-class cap (otherwise a class would be unreachable for an
-    # all-market miner). Current values give an all-market miner ~20% diversification headroom
-    # over the highest single-class cap (Forex) at each tier.
-    TIER_MULTI_CLASS_OVERALL_CAP = {1: 6.0, 2: 12.0, 3: 18.0, 4: 24.0}
+    TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS = {
+        1: {MinerAssetClass.CRYPTO: 2.0, MinerAssetClass.FOREX: 5.0,  MinerAssetClass.EQUITIES: 1.0, MinerAssetClass.COMMODITIES: 2.0, MinerAssetClass.HL_ALL: 6.0,  MinerAssetClass.ALL_MARKETS: 6.0},
+        2: {MinerAssetClass.CRYPTO: 2.0, MinerAssetClass.FOREX: 10.0, MinerAssetClass.EQUITIES: 1.5, MinerAssetClass.COMMODITIES: 2.0, MinerAssetClass.HL_ALL: 12.0, MinerAssetClass.ALL_MARKETS: 12.0},
+        3: {MinerAssetClass.CRYPTO: 3.0, MinerAssetClass.FOREX: 15.0, MinerAssetClass.EQUITIES: 2.0, MinerAssetClass.COMMODITIES: 3.0, MinerAssetClass.HL_ALL: 18.0, MinerAssetClass.ALL_MARKETS: 18.0},
+        4: {MinerAssetClass.CRYPTO: 4.0, MinerAssetClass.FOREX: 20.0, MinerAssetClass.EQUITIES: 2.0, MinerAssetClass.COMMODITIES: 4.0, MinerAssetClass.HL_ALL: 24.0, MinerAssetClass.ALL_MARKETS: 24.0},
+    }
 
     # Collateral limits
     MIN_COLLATERAL_BALANCE_THETA = 300  # Required minimum total collateral balance per miner in Theta. Approx $150k capital account size

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -40,6 +40,9 @@ class RPCConnectionMode(int, Enum):
     RPC = 1     # Normal RPC mode - connect via network
 
 
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass  # noqa: E402,F401
+
+
 class TradePairCategory(str, Enum):
     CRYPTO = "crypto"
     FOREX = "forex"
@@ -47,13 +50,6 @@ class TradePairCategory(str, Enum):
     EQUITIES = "equities"
     COMMODITIES = "commodities"
     HL_ALL = "hl_all"            # Asset-selection token only, enables trading all categories for hyperliquid
-
-
-# Subaccount asset_class values that represent a multi-class subaccount (one that may hold
-# positions across more than one TradePairCategory). Multi-class subaccounts are subject to
-# per-class portfolio sub-caps plus a tighter overall cap; single-class subaccounts use a
-# single per-class cap.
-MULTI_CLASS_CATEGORIES = frozenset({TradePairCategory.HL_ALL})
 
 
 class TradePairSource(str, Enum):
@@ -515,12 +511,11 @@ class ValiConfig:
     # Challenge Period Configuration
     SUBACCOUNT_CHALLENGE_RETURNS_THRESHOLD_DEFAULT = 0.1  # Default fallback returns threshold
     SUBACCOUNT_CHALLENGE_RETURNS_THRESHOLD = {
-        TradePairCategory.CRYPTO: 0.1,      # 10% returns required to pass crypto evaluation
-        TradePairCategory.FOREX: 0.08,      # 8% returns required to pass forex evaluation
-        TradePairCategory.INDICES: 0.08,    # 8% returns required to pass indices evaluation
-        TradePairCategory.EQUITIES: 0.1,    # 10% returns required to pass equities evaluation
-        TradePairCategory.HL_ALL: 0.1,      # 10% returns required to pass hl all markets evaluation
-        TradePairCategory.COMMODITIES: 0.1, # 10% returns required to pass commodities evaluation
+        MinerAssetClass.CRYPTO: 0.1,      # 10% returns required to pass crypto evaluation
+        MinerAssetClass.FOREX: 0.08,      # 8% returns required to pass forex evaluation
+        MinerAssetClass.EQUITIES: 0.1,    # 10% returns required to pass equities evaluation
+        MinerAssetClass.HL_ALL: 0.1,      # 10% returns required to pass hl all markets evaluation
+        MinerAssetClass.COMMODITIES: 0.1, # 10% returns required to pass commodities evaluation
     }
     CHALLENGE_INTRADAY_DRAWDOWN_THRESHOLD = 0.05    # Rule 1: 5% intraday drop from day-open equity eliminates
     CHALLENGE_EOD_DRAWDOWN_THRESHOLD = 0.05  # Rule 2: 5% drop from highest-ever EOD equity eliminates
@@ -608,14 +603,13 @@ class ValiConfig:
     # (GOLDUSDC, SILVERUSDC, etc.). HL commodity pairs use base 0.5 × tier on the order
     # path, so this column reports the same values to keep endpoint and order entry in sync.
     #
-    # The INDICES column reports HL index perp values (SP500USDC, XYZ100USDC, EWYUSDC use
-    # base 1.5 × tier). All SPOT indices (SPX, DJI, NDX, VIX, FTSE, GDAXI) are blocked,
-    # so the endpoint never needs to report SPOT-era values here.
+    # Indices have no miner asset class (all index pairs are blocked); HL index perps are
+    # accessed via HL_ALL subaccounts and draw from that column.
     TIER_POSITIONAL_LEVERAGE = {
-        1: {TradePairCategory.HL_ALL: 0.5, TradePairCategory.CRYPTO: 0.5,  TradePairCategory.FOREX: 2.5,  TradePairCategory.EQUITIES: 0.5, TradePairCategory.INDICES: 1.5,  TradePairCategory.COMMODITIES: 0.5},
-        2: {TradePairCategory.HL_ALL: 1.0, TradePairCategory.CRYPTO: 1.0,  TradePairCategory.FOREX: 5.0,  TradePairCategory.EQUITIES: 1.0, TradePairCategory.INDICES: 3.0,  TradePairCategory.COMMODITIES: 1.0},
-        3: {TradePairCategory.HL_ALL: 1.5, TradePairCategory.CRYPTO: 1.5,  TradePairCategory.FOREX: 7.5,  TradePairCategory.EQUITIES: 1.5, TradePairCategory.INDICES: 4.5,  TradePairCategory.COMMODITIES: 1.5},
-        4: {TradePairCategory.HL_ALL: 2.0, TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 10.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 6.0,  TradePairCategory.COMMODITIES: 2.0},
+        1: {TradePairCategory.HL_ALL: 0.5, TradePairCategory.CRYPTO: 0.5,  TradePairCategory.FOREX: 2.5,  TradePairCategory.EQUITIES: 0.5, TradePairCategory.COMMODITIES: 0.5},
+        2: {TradePairCategory.HL_ALL: 1.0, TradePairCategory.CRYPTO: 1.0,  TradePairCategory.FOREX: 5.0,  TradePairCategory.EQUITIES: 1.0, TradePairCategory.COMMODITIES: 1.0},
+        3: {TradePairCategory.HL_ALL: 1.5, TradePairCategory.CRYPTO: 1.5,  TradePairCategory.FOREX: 7.5,  TradePairCategory.EQUITIES: 1.5, TradePairCategory.COMMODITIES: 1.5},
+        4: {TradePairCategory.HL_ALL: 2.0, TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 10.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.COMMODITIES: 2.0},
     }
 
     # Per-tier portfolio leverage caps. Split into two dicts because the underlying lookup is
@@ -623,7 +617,7 @@ class ValiConfig:
     #   *_BY_PAIR        : per-pair multiplier used when validating an incoming order in
     #                      market_order_manager. Keyed on (asset class, instrument type).
     #   *_BY_ASSET_CLASS : account-wide multiplier from the subaccount's own asset_class field
-    #                      (which can be HL_ALL). Keyed by single TradePairCategory.
+    #                      (which can be HL_ALL). Keyed by single MinerAssetClass.
     # XAUUSD/XAGUSD positions land in the FOREX subaccount asset_class bucket.
     # Equity portfolio cap stays 2x from Tier 3 onward in the SPOT column (Reg T overnight).
     TIER_PORTFOLIO_LEVERAGE_BY_PAIR = {
@@ -679,15 +673,15 @@ class ValiConfig:
 
     # Single-class subaccounts only — multi-class (HL_ALL) overall cap is in TIER_MULTI_CLASS_OVERALL_CAP,
     # and per-class sub-caps for multi-class subaccounts reuse the same per-class entries below.
-    TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS = {
+    TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY = {
         1: {TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 5.0,  TradePairCategory.EQUITIES: 1.0, TradePairCategory.INDICES: 3.0,  TradePairCategory.COMMODITIES: 2.0},
         2: {TradePairCategory.CRYPTO: 2.0,  TradePairCategory.FOREX: 10.0, TradePairCategory.EQUITIES: 1.5, TradePairCategory.INDICES: 6.0,  TradePairCategory.COMMODITIES: 2.0},
         3: {TradePairCategory.CRYPTO: 3.0,  TradePairCategory.FOREX: 15.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 8.0,  TradePairCategory.COMMODITIES: 3.0},
         4: {TradePairCategory.CRYPTO: 4.0,  TradePairCategory.FOREX: 20.0, TradePairCategory.EQUITIES: 2.0, TradePairCategory.INDICES: 10.0, TradePairCategory.COMMODITIES: 4.0},
     }
 
-    # Overall portfolio cap multiplier for multi-class subaccounts (see MULTI_CLASS_CATEGORIES),
-    # applied on top of per-class sub-caps from TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS. Designed
+    # Overall portfolio cap multiplier for multi-class subaccounts (MinerAssetClass.is_multi_class),
+    # applied on top of per-class sub-caps from TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY. Designed
     # to be strictly tighter than the sum of per-class caps so a multi-class miner cannot stack
     # every class to its individual limit simultaneously, but loose enough that the overall cap
     # is never below the max per-class cap (otherwise a class would be unreachable for an
@@ -977,18 +971,12 @@ class TradePair(Enum):
     VT   = ["VT",   "VT",   0.00009, ValiConfig.EQUITIES_MIN_LEVERAGE, ValiConfig.EQUITIES_MAX_LEVERAGE, TradePairCategory.EQUITIES, InstrumentType.SPOT, SubaccountTierBaseLeverage(0.5)]
 
     # indices (no longer allowed for trading as we moved to equities tickers instead)
-    SPX = ["SPX", "SPX", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE,
-           TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
-    DJI = ["DJI", "DJI", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE,
-           TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
-    NDX = ["NDX", "NDX", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE,
-           TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
-    VIX = ["VIX", "VIX", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE,
-           TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
-    FTSE = ["FTSE", "FTSE", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE,
-            TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
-    GDAXI = ["GDAXI", "GDAXI", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE,
-             TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
+    SPX = ["SPX", "SPX", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE, TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
+    DJI = ["DJI", "DJI", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE, TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
+    NDX = ["NDX", "NDX", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE, TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
+    VIX = ["VIX", "VIX", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE, TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
+    FTSE = ["FTSE", "FTSE", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE, TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
+    GDAXI = ["GDAXI", "GDAXI", 0.00009, ValiConfig.INDICES_MIN_LEVERAGE, ValiConfig.INDICES_MAX_LEVERAGE, TradePairCategory.INDICES, InstrumentType.SPOT, SubaccountTierBaseLeverage(2.5)]
 
     # Hyperliquid Trade Pairs (USDC-quoted, src=HYPERLIQUID)
     # Crypto perp futures

--- a/vali_objects/vali_dataclasses/ledger/ledger_utils.py
+++ b/vali_objects/vali_dataclasses/ledger/ledger_utils.py
@@ -6,7 +6,8 @@ from typing import Optional
 import numpy as np
 import copy
 from datetime import datetime, timezone, timedelta, date
-from vali_objects.vali_config import TradePairCategory, ValiConfig
+from vali_objects.vali_config import ValiConfig
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.vali_dataclasses.ledger.perf.perf_ledger import PerfLedger
 from time_util.time_util import ForexHolidayCalendar
 import bittensor as bt
@@ -593,8 +594,8 @@ class LedgerUtils:
     @staticmethod
     def calculate_dynamic_minimum_days_for_asset_classes(
         ledger_dict: dict[str, PerfLedger],
-        asset_classes: list[TradePairCategory]
-    ) -> dict[TradePairCategory, int]:
+        asset_classes: list[MinerAssetClass]
+    ) -> dict[MinerAssetClass, int]:
         """
         Calculates the dynamic minimum participation days for specific asset classes.
         Returns the number of days that the Nth longest participating miner has (where N is
@@ -605,7 +606,7 @@ class LedgerUtils:
 
         Args:
             ledger_dict: Dictionary mapping hotkeys to their portfolio PerfLedger
-            asset_classes: List of asset classes (TradePairCategory) to calculate dynamic minimum days for
+            asset_classes: List of asset classes (MinerAssetClass) to calculate dynamic minimum days for
 
         Returns:
             dict: Dictionary mapping asset class to min days requirement (between 7-60 days)

--- a/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_manager.py
+++ b/vali_objects/vali_dataclasses/ledger/perf/perf_ledger_manager.py
@@ -1610,7 +1610,7 @@ class PerfLedgerManager(CacheController):
         n_hotkeys = len(hotkey_to_positions)
         for hotkey_i, (hotkey, positions) in enumerate(hotkey_to_positions.items()):
             try:
-                bt.logging.info(f"Building perf ledger for {hotkey} ({hotkey_i + 1}/{n_hotkeys})")
+                # bt.logging.info(f"Building perf ledger for {hotkey} ({hotkey_i + 1}/{n_hotkeys})")
                 account_size = hotkey_to_account_size.get(hotkey) if hotkey_to_account_size else None
                 self.update_one_perf_ledger_bundle(hotkey_i, n_hotkeys, hotkey, positions, now_ms, existing_perf_ledgers,
                                                    account_size=account_size)

--- a/vanta_api/entity_miner_rest_server.py
+++ b/vanta_api/entity_miner_rest_server.py
@@ -977,6 +977,9 @@ class EntityMinerRestServer(MinerRestServer):
                 if "asset_class" not in request_data:
                     return jsonify({'status': 'error', 'message': 'Missing required field: asset_class'}), 400
                 asset_class = request_data["asset_class"]
+                # Map hl_all to all markets for non-hyperliquid TODO remove after migration
+                if asset_class == "hl_all":
+                    asset_class = "all_markets"
 
             admin = request_data.get("admin")
 

--- a/vanta_api/entity_miner_rest_server.py
+++ b/vanta_api/entity_miner_rest_server.py
@@ -988,10 +988,10 @@ class EntityMinerRestServer(MinerRestServer):
             if admin is not None and not isinstance(admin, bool):
                 return jsonify({'status': 'error', 'message': 'admin must be a boolean'}), 400
 
-            if asset_class not in ["crypto", "forex", "equities", "commodities", "hl_all"]:
+            if asset_class not in ["crypto", "forex", "equities", "commodities", "hl_all", "all_markets"]:
                 return jsonify({
                     'status': 'error',
-                    'message': f"Invalid asset_class: {asset_class}. Must be 'crypto', 'forex', 'equities', 'commodities', or 'hl_all'"
+                    'message': f"Invalid asset_class: {asset_class}. Must be one of crypto, forex, equities, commodities, hl_all, all_markets"
                 }), 400
 
             if account_size <= 0:

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -2163,7 +2163,15 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         """
         Public endpoint — no authentication required.
         Returns trading limits for a Hyperliquid subaccount: account size,
-        max position per pair, max portfolio value, and challenge period status.
+        leverage tier, asset class, per-class caps, overall portfolio cap,
+        and challenge period status.
+
+        DEPRECATED: max_position_per_pair_usd is a class-level stand-in that
+        misreports pairs whose subaccount_tier_base_leverage diverges from the
+        canonical base (e.g. GOLDUSDC at 1.0 vs 0.5). Clients should resolve
+        per-pair caps from /trade-pairs instead:
+        subaccount_positional_leverage_by_tier[tier] × account_size, using the
+        `tier` field returned here.
 
         Example:
         curl http://localhost:48888/hl-traders/0xabcd1234.../limits
@@ -2195,6 +2203,8 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             'status': 'success',
             'hl_address': hl_address,
             'account_size': account_size,
+            'tier': tier,
+            'asset_class': asset_class.value,
             'max_position_per_pair_usd': max_position_per_pair_usd,
             'in_challenge_period': in_challenge,
             'timestamp': TimeUtil.now_in_millis(),

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -1165,7 +1165,7 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if not asset_selection or not isinstance(asset_selection, str):
                 return jsonify({'error': 'Missing or invalid required field: asset_selection (string)'}), 400
 
-            if not self._asset_selection_client.is_valid_asset_class(asset_selection):
+            if not MinerAssetClass.is_valid(asset_selection):
                 return jsonify({'error': f'Invalid asset class: {asset_selection}'}), 400
 
             # Accept a single hotkey or a list of hotkeys (also accept singular miner_hotkey)

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -1426,8 +1426,8 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 rebuilt_account['balance'] = account_size + computed['total_realized_pnl'] - computed['total_fees_paid']
 
                 # Recompute buying_power using the same multiplier logic MinerAccount.multiplier
-                # applies (asset_class-keyed via TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY, with
-                # multi-class subaccounts going through TIER_MULTI_CLASS_OVERALL_CAP). This keeps
+                # applies (asset_class-keyed via TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS, whose
+                # HL_ALL/ALL_MARKETS entries hold the multi-class overall ceiling). This keeps
                 # the preview number equal to what MinerAccount.buying_power would report on the
                 # actual rebuilt state — no SPOT/PERP or per-pair-table assumption. EQUITIES
                 # accounts follow the margin-loan-adjusted formula in MinerAccount.buying_power.
@@ -1438,10 +1438,7 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                     try:
                         asset_class = MinerAssetClass(asset_class_str)
                         tier = get_leverage_tier(bucket, account_size)
-                        if asset_class.is_multi_class:
-                            multiplier = ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
-                        else:
-                            multiplier = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(asset_class, 1.0)
+                        multiplier = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(asset_class, 1.0)
                     except ValueError:
                         asset_class = None
                         multiplier = 1.0
@@ -2149,6 +2146,19 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         return jsonify(response)
 
 
+    # Per-category positional leverage stand-in for the /hl-traders limits endpoint.
+    # The endpoint only knows a subaccount's asset class, not a specific pair, so it
+    # cannot use the per-pair source of truth (leverage_utils.get_tier_positional_leverage,
+    # which is pair.subaccount_tier_base_leverage × tier). This table mirrors that result
+    # for one canonical pair per class. Keep in sync with the order-entry path; once
+    # per-pair bases diverge inside a class, switch this endpoint to per-pair reporting.
+    _ENDPOINT_TIER_POSITIONAL_LEVERAGE = {
+        1: {MinerAssetClass.HL_ALL: 0.5},
+        2: {MinerAssetClass.HL_ALL: 1.0},
+        3: {MinerAssetClass.HL_ALL: 1.5},
+        4: {MinerAssetClass.HL_ALL: 2.0},
+    }
+
     def get_hl_trader_limits(self, hl_address: str):
         """
         Public endpoint — no authentication required.
@@ -2171,23 +2181,15 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             return jsonify({'status': 'error', 'message': 'HL address not found'}), 404
 
         account_size = limits_data['account_size']
-        asset_class = limits_data['asset_class']
         challenge_bucket = limits_data['challenge_bucket']
 
-        try:
-            category = MinerAssetClass(asset_class)
-        except ValueError:
-            category = MinerAssetClass.CRYPTO
-
+        asset_class = MinerAssetClass.HL_ALL
         in_challenge = challenge_bucket is None or challenge_bucket == MinerBucket.SUBACCOUNT_CHALLENGE.value
         _bucket = MinerBucket.SUBACCOUNT_CHALLENGE if in_challenge else MinerBucket.SUBACCOUNT_FUNDED
         tier = get_leverage_tier(_bucket, account_size)
-        # TIER_POSITIONAL_LEVERAGE is a per-category stand-in for the per-pair limit the order
-        # path actually enforces (pair.subaccount_tier_base_leverage × tier). It only stays
-        # accurate while every pair in a category shares one base. TODO: once per-pair bases
-        # diverge within a category, switch this to a per-pair lookup (or report a dict /
-        # canonical pair), otherwise max_position_per_pair_usd will misreport for some pairs.
-        max_position_per_pair_usd = account_size * ValiConfig.TIER_POSITIONAL_LEVERAGE[tier][category]
+
+        ###### DEPRECATED TIER POSITIONAL LEVERAGE
+        max_position_per_pair_usd = account_size * self._ENDPOINT_TIER_POSITIONAL_LEVERAGE[tier][asset_class]
 
         response_payload = {
             'status': 'success',
@@ -2198,22 +2200,17 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             'timestamp': TimeUtil.now_in_millis(),
         }
 
-        if category.is_multi_class:
-            # Multi-class subaccount (today only HL_ALL): expose the cross-class overall cap
-            # plus a per-asset-class breakdown. The overall cap is strictly tighter than the
-            # sum of per-class caps, so traders cannot max out every class simultaneously.
-            response_payload['max_portfolio_usd'] = account_size * ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
-            response_payload['max_asset_class_usd'] = {
-                c.value: account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][c]
-                for c in (
-                    MinerAssetClass.CRYPTO,
-                    MinerAssetClass.FOREX,
-                    MinerAssetClass.EQUITIES,
-                    MinerAssetClass.COMMODITIES,
-                )
-            }
-        else:
-            response_payload['max_portfolio_usd'] = account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][category]
+        response_payload['max_portfolio_usd'] = account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier][asset_class]
+        response_payload['max_asset_class_usd'] = {
+            c.value: account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][c]
+            for c in (
+                TradePairCategory.CRYPTO,
+                TradePairCategory.FOREX,
+                TradePairCategory.EQUITIES,
+                TradePairCategory.COMMODITIES,
+                TradePairCategory.INDICES,
+            )
+        }
 
         response_body = json.dumps(response_payload, cls=CustomEncoder)
         return Response(response_body, content_type='application/json'), 200

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -36,7 +36,8 @@ from vali_objects.miner_account.miner_account_manager import MinerAccountManager
 from vali_objects.utils.limit_order.order_processor import OrderProcessor
 from vali_objects.utils.vali_bkp_utils import CustomEncoder
 from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
-from vali_objects.vali_config import MULTI_CLASS_CATEGORIES, ValiConfig, RPCConnectionMode, TradePairCategory, TradePair, HL_DYNAMIC_REGISTRY
+from vali_objects.vali_config import ValiConfig, RPCConnectionMode, TradePairCategory, TradePair, HL_DYNAMIC_REGISTRY
+from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.enums.execution_type_enum import ExecutionType
 from vali_objects.vali_dataclasses.ledger.debt.debt_ledger_client import DebtLedgerClient
 from vali_objects.vali_dataclasses.ledger.perf.perf_ledger_client import PerfLedgerClient
@@ -1425,7 +1426,7 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 rebuilt_account['balance'] = account_size + computed['total_realized_pnl'] - computed['total_fees_paid']
 
                 # Recompute buying_power using the same multiplier logic MinerAccount.multiplier
-                # applies (asset_class-keyed via TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS, with
+                # applies (asset_class-keyed via TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY, with
                 # multi-class subaccounts going through TIER_MULTI_CLASS_OVERALL_CAP). This keeps
                 # the preview number equal to what MinerAccount.buying_power would report on the
                 # actual rebuilt state — no SPOT/PERP or per-pair-table assumption. EQUITIES
@@ -1435,12 +1436,12 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 bucket = MinerBucket(bucket_str) if bucket_str else None
                 if asset_class_str:
                     try:
-                        asset_class = TradePairCategory(asset_class_str)
+                        asset_class = MinerAssetClass(asset_class_str)
                         tier = get_leverage_tier(bucket, account_size)
-                        if asset_class in MULTI_CLASS_CATEGORIES:
+                        if asset_class.is_multi_class:
                             multiplier = ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
                         else:
-                            multiplier = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier].get(asset_class, 1.0)
+                            multiplier = ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier].get(asset_class, 1.0)
                     except ValueError:
                         asset_class = None
                         multiplier = 1.0
@@ -2174,9 +2175,9 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         challenge_bucket = limits_data['challenge_bucket']
 
         try:
-            category = TradePairCategory(asset_class)
+            category = MinerAssetClass(asset_class)
         except ValueError:
-            category = TradePairCategory.CRYPTO
+            category = MinerAssetClass.CRYPTO
 
         in_challenge = challenge_bucket is None or challenge_bucket == MinerBucket.SUBACCOUNT_CHALLENGE.value
         _bucket = MinerBucket.SUBACCOUNT_CHALLENGE if in_challenge else MinerBucket.SUBACCOUNT_FUNDED
@@ -2197,23 +2198,22 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             'timestamp': TimeUtil.now_in_millis(),
         }
 
-        if category in MULTI_CLASS_CATEGORIES:
+        if category.is_multi_class:
             # Multi-class subaccount (today only HL_ALL): expose the cross-class overall cap
             # plus a per-asset-class breakdown. The overall cap is strictly tighter than the
             # sum of per-class caps, so traders cannot max out every class simultaneously.
             response_payload['max_portfolio_usd'] = account_size * ValiConfig.TIER_MULTI_CLASS_OVERALL_CAP[tier]
             response_payload['max_asset_class_usd'] = {
-                c.value: account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier][c]
+                c.value: account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][c]
                 for c in (
-                    TradePairCategory.CRYPTO,
-                    TradePairCategory.FOREX,
-                    TradePairCategory.EQUITIES,
-                    TradePairCategory.INDICES,
-                    TradePairCategory.COMMODITIES,
+                    MinerAssetClass.CRYPTO,
+                    MinerAssetClass.FOREX,
+                    MinerAssetClass.EQUITIES,
+                    MinerAssetClass.COMMODITIES,
                 )
             }
         else:
-            response_payload['max_portfolio_usd'] = account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_ASSET_CLASS[tier][category]
+            response_payload['max_portfolio_usd'] = account_size * ValiConfig.TIER_PORTFOLIO_LEVERAGE_BY_CATEGORY[tier][category]
 
         response_body = json.dumps(response_payload, cls=CustomEncoder)
         return Response(response_body, content_type='application/json'), 200


### PR DESCRIPTION
Miner asset class separated from trade pair category
- removed TradePairCategory.HL_ALL
- Created MinerAssetClass
```
class MinerAssetClass(str, Enum):
    CRYPTO = "crypto"
    FOREX = "forex"
    EQUITIES = "equities"
    COMMODITIES = "commodities"
    HL_ALL = "hl_all"
    ALL_MARKETS = "all_markets"
```