### PR TITLE
fix: metagraph daemon never engaged connection recreation on failure

### DIFF
--- a/shared_objects/subtensor_ops/subtensor_ops.py
+++ b/shared_objects/subtensor_ops/subtensor_ops.py
@@ -181,14 +181,36 @@ class SubtensorOpsManager(CacheController):
             self._live_price_client = LivePriceFetcherClient(running_unit_tests=running_unit_tests)
         else:
             self._live_price_client = None
-        # Parse out the arg for subtensor.network. If it is "finney" or "subvortex", we will roundrobin on metagraph failure
-        self.round_robin_networks = ['finney', 'subvortex']
+        # Round-robin on metagraph failure for known public networks.
+        # 'subvortex' was removed: it is absent from bittensor's NETWORKS and
+        # entrypoint-subvortex.opentensor.ai is NXDOMAIN, so rotating onto it
+        # guaranteed a wasted retry cycle. With a single network the rotation
+        # degenerates to a same-endpoint reconnect, which is the actual healing
+        # mechanism (the recreate block in update_metagraph).
+        self.round_robin_networks = ['finney']
         self.round_robin_enabled = False
         self.current_round_robin_index = 0
         if self.config.subtensor.network in self.round_robin_networks:
-            bt.logging.info(f"Using round-robin metagraph for network {self.config.subtensor.network}. ")
-            self.round_robin_enabled = True
-            self.current_round_robin_index = self.round_robin_networks.index(self.config.subtensor.network)
+            # Guard: rotation rewrites chain_endpoint with the public
+            # entrypoint template. An operator who passed a CUSTOM
+            # --subtensor.chain_endpoint (e.g. a local node) keeps the default
+            # network name ('finney'), and rotation would clobber their
+            # endpoint irrecoverably on the first failure — so only enable
+            # rotation when the configured endpoint IS a default entrypoint.
+            configured_endpoint = getattr(self.config.subtensor, 'chain_endpoint', None)
+            default_endpoints = {None, ''} | {
+                f"wss://entrypoint-{n}.opentensor.ai:443" for n in self.round_robin_networks
+            }
+            if configured_endpoint in default_endpoints:
+                bt.logging.info(f"Using round-robin metagraph for network {self.config.subtensor.network}. ")
+                self.round_robin_enabled = True
+                self.current_round_robin_index = self.round_robin_networks.index(self.config.subtensor.network)
+            else:
+                bt.logging.info(
+                    f"Custom chain_endpoint configured ({configured_endpoint}); "
+                    f"round-robin rotation disabled to preserve it. Connection "
+                    f"recreation on failure remains active."
+                )
 
         # Initialize likely validators and miners with empty dictionaries. This maps hotkey to timestamp.
         self.likely_validators = {}
@@ -239,6 +261,9 @@ class SubtensorOpsManager(CacheController):
             mock_metagraph.block_at_registration = []
             mock_metagraph.emission = []
             mock_metagraph.axons = []
+            # Must be a real list: update_metagraph iterates it when logging
+            # permitted validators (a bare Mock attribute is not iterable).
+            mock_metagraph.validator_permit = []
 
             # Mock pool data
             mock_metagraph.pool = Mock()
@@ -306,6 +331,11 @@ class SubtensorOpsManager(CacheController):
             mock_metagraph.block_at_registration = [1000] * len(hotkeys)
             mock_metagraph.emission = [1.0] * len(hotkeys)
             mock_metagraph.axons = [n.axon_info for n in neurons]
+            # Must be a real list: update_metagraph iterates it when logging
+            # permitted validators (a bare Mock attribute is not iterable).
+            mock_metagraph.validator_permit = [
+                n.validator_trust > 0 for n in neurons
+            ]
 
             # Mock pool data
             mock_metagraph.pool = Mock()
@@ -977,9 +1007,13 @@ class SubtensorOpsManager(CacheController):
                 else:
                     new_subtensor = bt.Subtensor(config=self.config)
 
-                # Only cleanup old connection after new one successfully created (prevents file descriptor leak)
-                self._cleanup_subtensor_connection()
-                self.subtensor = new_subtensor
+                # Only cleanup old connection after new one successfully created (prevents file descriptor leak).
+                # Under the subtensor lock: weight-setter RPC threads hold it
+                # while an extrinsic is in flight on the OLD connection — the
+                # close+swap must not yank the websocket out from under them.
+                with get_subtensor_lock():
+                    self._cleanup_subtensor_connection()
+                    self.subtensor = new_subtensor
                 bt.logging.info("Successfully recreated subtensor connection after previous failures")
 
             except (ConnectionRefusedError, ConnectionError, OSError) as e:
@@ -1068,6 +1102,19 @@ class SubtensorOpsManager(CacheController):
 
         # self.log_metagraph_state()
         self.set_last_update_time()
+
+        # Reset failure accounting only after a FULLY successful sync — the
+        # early returns above (refresh rate-limit, anomalous metagraph) must
+        # not clear a pending reconnect. This is the counterpart of the
+        # increment in SubtensorOpsServer.run_daemon_iteration; a non-zero
+        # counter is what arms the connection-recreation block at the top of
+        # this method on the next call.
+        if self.consecutive_failures > 0:
+            bt.logging.info(
+                f"Metagraph update recovered after {self.consecutive_failures} "
+                f"consecutive failures; resetting failure count."
+            )
+        self.consecutive_failures = 0
 
 
 # len([x for x in self.metagraph.axons if '0.0.0.0' not in x.ip]), len([x for x in self.metagraph.neurons if '0.0.0.0' not in x.axon_info.for ip])

--- a/shared_objects/subtensor_ops/subtensor_ops_server.py
+++ b/shared_objects/subtensor_ops/subtensor_ops_server.py
@@ -95,7 +95,23 @@ class SubtensorOpsServer(RPCServerBase):
         """Single metagraph update iteration."""
         if self._is_shutdown():
             return
-        self.manager.update_metagraph()
+        try:
+            self.manager.update_metagraph()
+        except Exception:
+            # Account the failure on the MANAGER, not only this daemon's own
+            # backoff counter: update_metagraph() engages its
+            # connection-recreation path (and round-robin endpoint rotation on
+            # mainnet networks) only when manager.consecutive_failures > 0.
+            # Without this, a failed iteration retried the SAME dead websocket
+            # forever — observed on testnet, where the public endpoint's load
+            # balancer mixes healthy and broken backends, so a validator that
+            # drew a sick backend at boot could never heal. The counter is
+            # reset inside update_metagraph() after a fully successful sync
+            # (not here — the wrapper cannot distinguish a real sync from the
+            # rate-limited or anomalous-metagraph early returns). Re-raise so
+            # _daemon_loop applies its normal backoff.
+            self.manager.consecutive_failures += 1
+            raise
 
     def get_daemon_name(self) -> str:
         mode = "miner" if self.is_miner else "validator"

--- a/tests/vali_tests/test_metagraph_updater.py
+++ b/tests/vali_tests/test_metagraph_updater.py
@@ -581,13 +581,33 @@ class TestSubtensorOpsManager(TestBase):
         self.assertTrue(updater.round_robin_enabled)
         self.assertEqual(updater.current_round_robin_index, 0)  # finney index
 
-        # Simulate network switch
+        # Simulate network switch. With 'subvortex' removed (NXDOMAIN, not in
+        # bittensor's NETWORKS), rotation degenerates to a same-endpoint
+        # reconnect: network and index stay on finney.
         initial_network = updater.config.subtensor.network
         updater._switch_to_next_network(cleanup_connection=False, create_new_subtensor=False)
 
-        # Verify network was switched
-        self.assertNotEqual(updater.config.subtensor.network, initial_network)
-        self.assertEqual(updater.current_round_robin_index, 1)  # subvortex index
+        self.assertEqual(updater.config.subtensor.network, initial_network)
+        self.assertEqual(updater.current_round_robin_index, 0)
+
+    def test_round_robin_disabled_for_custom_chain_endpoint(self):
+        """An operator passing only --subtensor.chain_endpoint keeps bittensor's
+        default network name ('finney'); rotation must NOT clobber the custom
+        endpoint with the public entrypoint template."""
+        config = self._create_mock_config(network="finney")
+        config.subtensor.chain_endpoint = "ws://127.0.0.1:9944"  # local node
+
+        updater = SubtensorOpsManager(
+            config=config,
+            hotkey=self.TEST_MINER_HOTKEY,
+            is_miner=True,
+            running_unit_tests=True
+        )
+
+        self.assertFalse(updater.round_robin_enabled)
+        # _switch_to_next_network must be a no-op when rotation is disabled.
+        updater._switch_to_next_network(cleanup_connection=False, create_new_subtensor=False)
+        self.assertEqual(updater.config.subtensor.chain_endpoint, "ws://127.0.0.1:9944")
 
 
 if __name__ == '__main__':

--- a/tests/vali_tests/test_subtensor_ops_retry.py
+++ b/tests/vali_tests/test_subtensor_ops_retry.py
@@ -1,0 +1,158 @@
+# developer: lp
+# Copyright (c) 2026 Taoshi Inc
+"""
+Regression tests for metagraph-update failure accounting and connection
+recreation on the LIVE daemon path (SubtensorOpsServer.run_daemon_iteration ->
+SubtensorOpsManager.update_metagraph).
+
+Bug fixed by these tests' subject: the RPC-daemon path never incremented
+manager.consecutive_failures, so the connection-recreation block in
+update_metagraph() (and round-robin endpoint rotation on mainnet networks) was
+unreachable after runtime failures — a validator that drew a sick backend from
+the chain endpoint's load balancer retried the same dead websocket forever.
+Observed on testnet, where wss://test.finney.opentensor.ai balances across
+backends at wildly different states.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from shared_objects.subtensor_ops.subtensor_ops import SubtensorOpsManager
+from shared_objects.subtensor_ops.subtensor_ops_server import SubtensorOpsServer
+
+TEST_HOTKEY = "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw"
+
+
+def _mock_config(netuid=116, network="test"):
+    """Mirror test_metagraph_updater's mock config (testnet defaults here)."""
+    config = Mock()
+    config.netuid = netuid
+    config.subtensor = Mock()
+    config.subtensor.network = network
+    config.subtensor.chain_endpoint = "wss://test.finney.opentensor.ai:443"
+    config.wallet = Mock()
+    config.wallet.name = "test_wallet"
+    config.wallet.hotkey = "test_hotkey"
+    config.wallet.path = "~/.bittensor/wallets"
+    config.logging = Mock()
+    config.logging.debug = False
+    config.logging.trace = False
+    config.logging.logging_dir = "~/.bittensor/miners"
+    return config
+
+
+def _make_manager():
+    """Real manager in unit-test mode (mock subtensor), miner mode to keep
+    dependencies minimal; the accounting under test is mode-independent."""
+    manager = SubtensorOpsManager(
+        config=_mock_config(),
+        hotkey=TEST_HOTKEY,
+        is_miner=True,
+        running_unit_tests=True,
+    )
+    # Wire a minimal metagraph client (normally done by the orchestrator).
+    manager._metagraph_client = Mock(
+        get_hotkeys=Mock(return_value=[]),
+        update_metagraph=Mock(),
+    )
+    return manager
+
+
+def _run_daemon_iteration(manager):
+    """Invoke the real wrapper logic against a minimal host object, so the
+    accounting is tested without spawning RPCServerBase machinery."""
+    host = SimpleNamespace(manager=manager, _is_shutdown=lambda: False)
+    return SubtensorOpsServer.run_daemon_iteration(host)
+
+
+class TestDaemonFailureAccounting(unittest.TestCase):
+    """The wrapper must record failures on the manager and re-raise."""
+
+    def test_failure_increments_manager_counter_and_reraises(self):
+        manager = Mock()
+        manager.consecutive_failures = 0
+        manager.update_metagraph = Mock(side_effect=RuntimeError("boom"))
+        host = SimpleNamespace(manager=manager, _is_shutdown=lambda: False)
+
+        with self.assertRaises(RuntimeError):
+            SubtensorOpsServer.run_daemon_iteration(host)
+        self.assertEqual(manager.consecutive_failures, 1)
+
+        with self.assertRaises(RuntimeError):
+            SubtensorOpsServer.run_daemon_iteration(host)
+        self.assertEqual(manager.consecutive_failures, 2)
+
+    def test_shutdown_skips_update_entirely(self):
+        manager = Mock()
+        manager.update_metagraph = Mock()
+        host = SimpleNamespace(manager=manager, _is_shutdown=lambda: True)
+
+        SubtensorOpsServer.run_daemon_iteration(host)
+        manager.update_metagraph.assert_not_called()
+
+
+class TestReconnectEngagement(unittest.TestCase):
+    """With failures pending, the next update must recreate the connection —
+    even when round-robin is disabled (network='test')."""
+
+    def test_pending_failure_recreates_connection_without_round_robin(self):
+        manager = _make_manager()
+        self.assertFalse(manager.round_robin_enabled)
+        old_subtensor = manager.subtensor
+
+        manager.consecutive_failures = 1  # as recorded by run_daemon_iteration
+        manager.update_metagraph()
+
+        # Fresh connection swapped in; old one cleaned up; endpoint untouched.
+        self.assertIsNot(manager.subtensor, old_subtensor)
+        old_subtensor.substrate.close.assert_called_once()
+        self.assertEqual(manager.config.subtensor.network, "test")
+        # Fully successful sync resets the accounting.
+        self.assertEqual(manager.consecutive_failures, 0)
+
+    def test_no_recreation_when_no_failures_pending(self):
+        manager = _make_manager()
+        old_subtensor = manager.subtensor
+
+        manager.update_metagraph()
+
+        self.assertIs(manager.subtensor, old_subtensor)
+        self.assertEqual(manager.consecutive_failures, 0)
+
+    def test_full_daemon_cycle_fail_then_heal(self):
+        """End-to-end through the real wrapper: failure arms the reconnect,
+        the next iteration recreates and resets."""
+        manager = _make_manager()
+        old_subtensor = manager.subtensor
+
+        # Iteration 1: sick backend — sync raises out of the real manager.
+        manager.subtensor.metagraph = Mock(side_effect=Exception("Internal error"))
+        with self.assertRaises(Exception):
+            _run_daemon_iteration(manager)
+        self.assertEqual(manager.consecutive_failures, 1)
+
+        # Iteration 2: reconnect engages, mock 'backend' now healthy.
+        _run_daemon_iteration(manager)
+        self.assertIsNot(manager.subtensor, old_subtensor)
+        self.assertEqual(manager.consecutive_failures, 0)
+
+    def test_anomalous_metagraph_early_return_does_not_reset_counter(self):
+        """The anomalous-loss early return is not a success: pending failure
+        accounting must survive it (reset happens only after a full sync)."""
+        manager = _make_manager()
+        # Client currently knows many hotkeys; the (mock) chain returns none —
+        # a 100% loss is rejected as anomalous and the update early-returns.
+        # (Anomaly needs BOTH an absolute count above the minimum AND a high
+        # percentage — 30 lost of 30 clears both thresholds.)
+        manager._metagraph_client.get_hotkeys = Mock(
+            return_value=[f"hk{i}" for i in range(30)]
+        )
+        manager.consecutive_failures = 2
+
+        manager.update_metagraph()  # recreates connection, then rejects sync
+
+        self.assertEqual(manager.consecutive_failures, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vali_tests/test_websocket_server_ws_stability.py
+++ b/tests/vali_tests/test_websocket_server_ws_stability.py
@@ -89,17 +89,21 @@ class TestSendDashboardUpdateBackoff(unittest.TestCase):
     def test_success_resets_backoff_and_sends(self):
         server = _bare_server()
         server._entity_client.get_subaccount_dashboard.return_value = {"ok": True}
-        server._send_message = MagicMock(return_value=MagicMock())  # sync mock → not a real coroutine
+        server._send_serialized = MagicMock(return_value=MagicMock())  # not a real coroutine
         sub = DashboardSubscription(failure_count=4, next_attempt_ms=999999999999)
+        client = MagicMock()
+        client.serialize.return_value = '{"sequence":0}'
 
         with patch("vanta_api.websocket_server.create_subaccount_dashboard",
                    return_value={"subaccount_info": {}}), \
              patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
-            server._send_dashboard_update("5Entity_1", MagicMock(), sub)
+            server._send_dashboard_update("5Entity_1", client, sub)
 
         self.assertEqual(sub.failure_count, 0)
         self.assertEqual(sub.next_attempt_ms, 0)
         self.assertGreater(sub.last_update_time_ms, 0)  # update_times stamped it
+        # Serialized in the worker (off the loop), then raw send scheduled.
+        client.serialize.assert_called_once_with({"dashboard": {"subaccount_info": {}}})
         rcs.assert_called_once()
 
     def test_build_exception_backs_off(self):
@@ -115,6 +119,38 @@ class TestSendDashboardUpdateBackoff(unittest.TestCase):
         self.assertEqual(sub.failure_count, 1)
         self.assertEqual(sub.last_update_time_ms, 0)
         rcs.assert_not_called()
+
+
+class TestClientSerialize(unittest.TestCase):
+    def _client(self):
+        ws = MagicMock()
+        return WebSocketServerClient(client_id=1, websocket=ws, api_key="k", tier=200)
+
+    def test_serialize_shape_and_sequence(self):
+        import json as _json
+        client = self._client()
+        s0 = _json.loads(client.serialize({"dashboard": {"a": 1}}))
+        s1 = _json.loads(client.serialize({"dashboard": {"a": 2}}))
+        self.assertEqual(s0["sequence"], 0)
+        self.assertEqual(s1["sequence"], 1)
+        self.assertEqual(s0["data"], {"dashboard": {"a": 1}})
+        self.assertIn("timestamp", s0)
+
+    def test_sequence_monotonic_under_concurrency(self):
+        import json as _json
+        from concurrent.futures import ThreadPoolExecutor
+        client = self._client()
+        N = 500
+
+        def one(_):
+            return _json.loads(client.serialize({"x": 1}))["sequence"]
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            seqs = list(pool.map(one, range(N)))
+
+        # No duplicates and no gaps despite concurrent worker-thread serialization.
+        self.assertEqual(sorted(seqs), list(range(N)))
+        self.assertEqual(client.sequence_number, N)
 
 
 class TestInitialSnapshot(unittest.TestCase):

--- a/tests/vali_tests/test_websocket_server_ws_stability.py
+++ b/tests/vali_tests/test_websocket_server_ws_stability.py
@@ -117,6 +117,30 @@ class TestSendDashboardUpdateBackoff(unittest.TestCase):
         rcs.assert_not_called()
 
 
+class TestInitialSnapshot(unittest.TestCase):
+    def test_submits_build_when_subscribed(self):
+        server = _bare_server()
+        server._thread_pool = MagicMock()
+        client = MagicMock()
+        sub = DashboardSubscription()
+        client.dashboard_subscriptions = {"5Entity_1": sub}
+
+        server._submit_initial_snapshot("5Entity_1", client)
+
+        server._thread_pool.submit.assert_called_once_with(
+            server._send_dashboard_update, "5Entity_1", client, sub)
+
+    def test_noop_when_not_subscribed(self):
+        server = _bare_server()
+        server._thread_pool = MagicMock()
+        client = MagicMock()
+        client.dashboard_subscriptions = {}
+
+        server._submit_initial_snapshot("5Entity_1", client)
+
+        server._thread_pool.submit.assert_not_called()
+
+
 class TestRemoveClient(unittest.TestCase):
     def _client(self, state=State.OPEN):
         ws = MagicMock()

--- a/tests/vali_tests/test_websocket_server_ws_stability.py
+++ b/tests/vali_tests/test_websocket_server_ws_stability.py
@@ -1,0 +1,168 @@
+# developer: lp
+# Copyright (c) 2026 Taoshi Inc
+"""
+Unit tests for the PTN WebSocket server stability fixes:
+  A1  _remove_client works under websockets 15 (no fail_connection / no
+      websockets.protocol.OPEN) and never raises during teardown.
+  A2  Failed/empty dashboard builds back off exponentially instead of being
+      re-hammered by the 0.1s staleness scanner.
+  A6  Frame serialization happens once, off the event loop, with a monotonic
+      per-client sequence number.
+
+These construct the server via object.__new__ and set only the attributes the
+methods under test touch — the same pattern the existing gateway tests use —
+so no RPC servers or api-keys file are needed.
+"""
+import unittest
+from collections import defaultdict, deque
+from unittest.mock import MagicMock, patch
+
+from websockets.protocol import State
+
+from vanta_api.websocket_server import (
+    WebSocketServer,
+    WebSocketServerClient,
+    DashboardSubscription,
+    SUBACCOUNT_RETRY_BASE_MS,
+    SUBACCOUNT_RETRY_MAX_MS,
+)
+
+
+def _bare_server():
+    server = object.__new__(WebSocketServer)
+    server._clients = {}
+    server._api_key_client_ids = defaultdict(deque)
+    server.api_key_to_alias = {}
+    server._event_loop = MagicMock()
+    server._event_loop.is_closed.return_value = False
+    server._entity_client = MagicMock()
+    for attr in (
+        "_challenge_period_client", "_elimination_client", "_miner_account_client",
+        "_position_client", "_limit_order_client", "_debt_ledger_client",
+        "_statistics_client",
+    ):
+        setattr(server, attr, MagicMock())
+    return server
+
+
+class TestBuildBackoff(unittest.TestCase):
+    def test_backoff_increments_and_caps(self):
+        sub = DashboardSubscription()
+        prev = 0
+        for i in range(1, 12):
+            WebSocketServer._apply_build_backoff(sub)
+            self.assertEqual(sub.failure_count, i)
+            delay = sub.next_attempt_ms  # relative to now; monotonic growth then cap
+            self.assertGreater(delay, prev - 1)
+            prev = delay
+        # After many failures the delay is capped at SUBACCOUNT_RETRY_MAX_MS.
+        # failure_count is large here, so the raw exp far exceeds the cap.
+        import time as _t
+        now = int(_t.time() * 1000)
+        self.assertLessEqual(sub.next_attempt_ms - now, SUBACCOUNT_RETRY_MAX_MS + 50)
+
+    def test_first_backoff_is_base(self):
+        sub = DashboardSubscription()
+        import time as _t
+        before = int(_t.time() * 1000)
+        WebSocketServer._apply_build_backoff(sub)
+        # first failure → base delay
+        self.assertGreaterEqual(sub.next_attempt_ms, before + SUBACCOUNT_RETRY_BASE_MS - 50)
+        self.assertLessEqual(sub.next_attempt_ms, before + SUBACCOUNT_RETRY_BASE_MS + 100)
+
+
+class TestSendDashboardUpdateBackoff(unittest.TestCase):
+    def test_none_dashboard_backs_off_and_does_not_send(self):
+        server = _bare_server()
+        server._entity_client.get_subaccount_dashboard.return_value = None
+        server._send_message = MagicMock()
+        sub = DashboardSubscription()
+
+        with patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
+            server._send_dashboard_update("5Entity_1", MagicMock(), sub)
+
+        self.assertEqual(sub.failure_count, 1)
+        self.assertGreater(sub.next_attempt_ms, 0)
+        self.assertEqual(sub.last_update_time_ms, 0)  # NOT advanced → scanner won't re-hammer
+        rcs.assert_not_called()
+
+    def test_success_resets_backoff_and_sends(self):
+        server = _bare_server()
+        server._entity_client.get_subaccount_dashboard.return_value = {"ok": True}
+        server._send_message = MagicMock(return_value=MagicMock())  # sync mock → not a real coroutine
+        sub = DashboardSubscription(failure_count=4, next_attempt_ms=999999999999)
+
+        with patch("vanta_api.websocket_server.create_subaccount_dashboard",
+                   return_value={"subaccount_info": {}}), \
+             patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
+            server._send_dashboard_update("5Entity_1", MagicMock(), sub)
+
+        self.assertEqual(sub.failure_count, 0)
+        self.assertEqual(sub.next_attempt_ms, 0)
+        self.assertGreater(sub.last_update_time_ms, 0)  # update_times stamped it
+        rcs.assert_called_once()
+
+    def test_build_exception_backs_off(self):
+        server = _bare_server()
+        server._entity_client.get_subaccount_dashboard.return_value = {"ok": True}
+        sub = DashboardSubscription()
+
+        with patch("vanta_api.websocket_server.create_subaccount_dashboard",
+                   side_effect=RuntimeError("boom")), \
+             patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
+            server._send_dashboard_update("5Entity_1", MagicMock(), sub)
+
+        self.assertEqual(sub.failure_count, 1)
+        self.assertEqual(sub.last_update_time_ms, 0)
+        rcs.assert_not_called()
+
+
+class TestRemoveClient(unittest.TestCase):
+    def _client(self, state=State.OPEN):
+        ws = MagicMock()
+        ws.state = state
+        return WebSocketServerClient(client_id=1, websocket=ws, api_key="k", tier=200)
+
+    def test_open_client_schedules_close_and_removes(self):
+        server = _bare_server()
+        client = self._client(State.OPEN)
+        server._clients[1] = client
+        server._api_key_client_ids["k"].append(1)
+
+        with patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
+            server._remove_client(1)  # must not raise
+
+        self.assertNotIn(1, server._clients)
+        rcs.assert_called_once()
+
+    def test_no_loop_does_not_raise_or_schedule(self):
+        server = _bare_server()
+        server._event_loop = None
+        client = self._client(State.OPEN)
+        server._clients[1] = client
+        server._api_key_client_ids["k"].append(1)
+
+        with patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
+            server._remove_client(1)  # must not raise
+
+        self.assertNotIn(1, server._clients)
+        rcs.assert_not_called()
+
+    def test_closed_client_no_close_scheduled(self):
+        server = _bare_server()
+        client = self._client(State.CLOSED)
+        server._clients[1] = client
+
+        with patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe") as rcs:
+            server._remove_client(1)
+
+        self.assertNotIn(1, server._clients)
+        rcs.assert_not_called()
+
+    def test_unknown_client_is_noop(self):
+        server = _bare_server()
+        server._remove_client(999)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vanta_api/websocket_server.py
+++ b/vanta_api/websocket_server.py
@@ -16,6 +16,7 @@ from typing import Dict, Any, Optional, Deque
 import websockets
 from websockets.protocol import State
 from websockets.legacy.server import WebSocketServerProtocol
+from urllib.parse import urlsplit, parse_qs
 
 import bittensor as bt
 
@@ -418,6 +419,17 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
             bt.logging.error(f"WebSocketServer: Error queueing message: {e}")
             bt.logging.error(traceback.format_exc())
 
+    def _submit_initial_snapshot(self, synthetic_hotkey: str, client: WebSocketServerClient) -> None:
+        """Push an immediate dashboard build on subscribe so the first frame
+        arrives in ~1-2s instead of waiting for the 0.1s staleness scanner to
+        reach this subaccount behind its (single-threaded) backlog. This is the
+        server-side home of the vanta-ui relay's initial-snapshot injection."""
+        subscription = client.dashboard_subscriptions.get(synthetic_hotkey)
+        if subscription is None:
+            return
+        self._thread_pool.submit(
+            self._send_dashboard_update, synthetic_hotkey, client, subscription)
+
     @staticmethod
     def _apply_build_backoff(subscription: DashboardSubscription) -> None:
         """Record a failed/empty build and push the subscription's next attempt
@@ -652,11 +664,27 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
 
             bt.logging.info(f"WebSocketServer: Client {client_id} authenticated successfully with tier {api_key_tier}")
 
+            # Clients that manage their own subscriptions — e.g. the vanta-ui SSE
+            # relay, which sends an explicit subscribe_subaccount for the one
+            # account it wants — can opt OUT of entity auto-subscribe-all with
+            # ?auto_subscribe=0. That stops them receiving (and having to filter)
+            # every other subaccount's frames, closing the cross-account leak at
+            # the source and removing the N-subaccount thundering herd at connect.
+            # Absent/unknown param keeps the default, so the entity-miner gateway
+            # and older clients are unaffected.
+            auto_subscribe_all = True
+            try:
+                qs = parse_qs(urlsplit(websocket.request.path).query)
+                if qs.get("auto_subscribe", ["1"])[0].strip().lower() in ("0", "false", "no"):
+                    auto_subscribe_all = False
+            except Exception:
+                pass
+
             # For entity clients (tier >= 200), auto-subscribe to all active subaccounts
             hl_mappings = {}
             subscribed_subaccounts = 0
 
-            if api_key_tier >= ValiConfig.SUBACCOUNT_SUBSCRIPTION_TIER:
+            if api_key_tier >= ValiConfig.SUBACCOUNT_SUBSCRIPTION_TIER and auto_subscribe_all:
                 entity_hotkey = self.api_key_to_alias.get(api_key)
                 if entity_hotkey:
                     try:
@@ -775,6 +803,7 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                                     "action": "subscribe_subaccount",
                                     "subscribed_to": synthetic_hotkey
                                 }))
+                                self._submit_initial_snapshot(synthetic_hotkey, client)
                             elif client.tier < ValiConfig.SUBACCOUNT_SUBSCRIPTION_TIER:
                                 await websocket.send(json.dumps({
                                     "type": "subscription_status",
@@ -798,6 +827,7 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                                     "action": "subscribe_subaccount",
                                     "subscribed_to": synthetic_hotkey
                                 }))
+                                self._submit_initial_snapshot(synthetic_hotkey, client)
 
                     elif message_type == "unsubscribe_subaccount":
                         synthetic_hotkey = data.get("synthetic_hotkey")

--- a/vanta_api/websocket_server.py
+++ b/vanta_api/websocket_server.py
@@ -14,7 +14,7 @@ import time
 import traceback
 from typing import Dict, Any, Optional, Deque
 import websockets
-from websockets import CloseCode
+from websockets.protocol import State
 from websockets.legacy.server import WebSocketServerProtocol
 
 import bittensor as bt
@@ -48,6 +48,11 @@ MAX_N_WS_PER_API_KEY = 5
 SUBACCOUNT_REFRESH_INTERVAL_S = 0.1
 SUBACCOUNT_REFRESH_EXPIRATION_MS = 15 * 1000
 
+# Exponential backoff for subscriptions whose build fails or returns no
+# dashboard, so the 0.1s staleness scanner doesn't re-hammer them ~10x/s.
+SUBACCOUNT_RETRY_BASE_MS = 1000
+SUBACCOUNT_RETRY_MAX_MS = 30_000
+
 
 @dataclass
 class DashboardSubscription:
@@ -56,6 +61,13 @@ class DashboardSubscription:
     checkpoints_time_ms: int = 0
     daily_returns_time_ms: int = 0
     last_update_time_ms: int = 0
+    # Backoff for failed/empty builds: on failure the staleness scanner must
+    # not re-attempt this subscription every 100ms (it left last_update_time_ms
+    # stale and re-hammered ~10x/s forever — one missing subaccount saturated
+    # the pool and the GIL). failure_count drives an exponential next_attempt_ms
+    # gate; both reset to 0 on a successful build.
+    failure_count: int = 0
+    next_attempt_ms: int = 0
     lock: Lock = field(default_factory=Lock)
 
     @staticmethod
@@ -336,8 +348,24 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                     bt.logging.info(
                         f"WebSocketServer: Removed client {client_id} from API key {api_key_alias}")
 
-            if client.websocket.state == websockets.protocol.OPEN:
-                client.websocket.fail_connection(code=CloseCode.ABNORMAL_CLOSURE)
+            # websockets 15: the handler receives an asyncio ServerConnection.
+            # `websockets.protocol.OPEN` no longer exists (use State.OPEN) and
+            # there is no sync `fail_connection()` — the previous code raised
+            # AttributeError here on every OPEN-client removal, leaking clients
+            # and hanging shutdown. Schedule the async close() on the server
+            # loop from whatever thread called us, guarding a closed/absent loop
+            # so teardown never raises.
+            if client.websocket.state == State.OPEN:
+                loop = self._event_loop
+                if loop is not None and not loop.is_closed():
+                    try:
+                        asyncio.run_coroutine_threadsafe(
+                            client.websocket.close(code=1001, reason="client removed"),
+                            loop,
+                        )
+                    except Exception as e:
+                        bt.logging.debug(
+                            f"WebSocketServer: could not schedule close for {client_id}: {e}")
 
             bt.logging.info(f"WebSocketServer: Client {client_id} removed")
 
@@ -390,18 +418,44 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
             bt.logging.error(f"WebSocketServer: Error queueing message: {e}")
             bt.logging.error(traceback.format_exc())
 
+    @staticmethod
+    def _apply_build_backoff(subscription: DashboardSubscription) -> None:
+        """Record a failed/empty build and push the subscription's next attempt
+        out exponentially. Must be called while holding subscription.lock."""
+        subscription.failure_count += 1
+        delay = min(
+            SUBACCOUNT_RETRY_BASE_MS * (2 ** (subscription.failure_count - 1)),
+            SUBACCOUNT_RETRY_MAX_MS,
+        )
+        subscription.next_attempt_ms = TimeUtil.now_in_millis() + delay
+
     def _send_dashboard_update(
         self,
         synthetic_hotkey: str,
         client: WebSocketServerClient,
         subscription: DashboardSubscription
     ) -> None:
+        # All subscription mutations happen under the lock so failure accounting
+        # and the send stay consistent with the scanner reading next_attempt_ms.
         try:
             with subscription.lock:
-                subaccount_dashboard = self._entity_client.get_subaccount_dashboard(synthetic_hotkey)
+                try:
+                    subaccount_dashboard = self._entity_client.get_subaccount_dashboard(synthetic_hotkey)
+                except Exception as e:
+                    self._apply_build_backoff(subscription)
+                    bt.logging.error(f"WebSocketServer: dashboard fetch failed for {synthetic_hotkey}: {e}")
+                    return
+
                 if subaccount_dashboard is None:
-                    bt.logging.warning(f"WebSocketServer: No dashboard found for synthetic hotkey {synthetic_hotkey}")
-                else:
+                    self._apply_build_backoff(subscription)
+                    # Log only on the first failure of a streak — backoff keeps
+                    # this from spamming once per 100ms.
+                    if subscription.failure_count <= 1:
+                        bt.logging.warning(
+                            f"WebSocketServer: No dashboard found for synthetic hotkey {synthetic_hotkey}")
+                    return
+
+                try:
                     dashboard = create_subaccount_dashboard(
                         synthetic_hotkey,
                         subaccount_dashboard,
@@ -417,13 +471,21 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                         subscription.checkpoints_time_ms,
                         subscription.daily_returns_time_ms,
                     )
+                except Exception as e:
+                    self._apply_build_backoff(subscription)
+                    bt.logging.error(f"WebSocketServer: dashboard build failed for {synthetic_hotkey}: {e}")
+                    bt.logging.error(traceback.format_exc())
+                    return
 
-                    subscription.update_times(dashboard)
+                # Success: clear backoff and advance section watermarks.
+                subscription.failure_count = 0
+                subscription.next_attempt_ms = 0
+                subscription.update_times(dashboard)
 
-                    asyncio.run_coroutine_threadsafe(
-                        self._send_message(client, {"dashboard": dashboard}),
-                        self._event_loop
-                    )
+                asyncio.run_coroutine_threadsafe(
+                    self._send_message(client, {"dashboard": dashboard}),
+                    self._event_loop
+                )
 
         except Exception as e:
             bt.logging.error(f"WebSocketServer: Error processing dashboard update: {e}")
@@ -445,11 +507,16 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
         while True:
             try:
                 time.sleep(SUBACCOUNT_REFRESH_INTERVAL_S)
-                expiration_ms = TimeUtil.now_in_millis() - SUBACCOUNT_REFRESH_EXPIRATION_MS
+                now_ms = TimeUtil.now_in_millis()
+                expiration_ms = now_ms - SUBACCOUNT_REFRESH_EXPIRATION_MS
                 for client in list(self._clients.values()):
                     subscriptions = dict(client.dashboard_subscriptions)
                     for synthetic_hotkey, subscription in subscriptions.items():
-                        if subscription.last_update_time_ms < expiration_ms:
+                        # Skip stale subscriptions still inside their failure
+                        # backoff window (next_attempt_ms), so one missing/slow
+                        # subaccount can't be rebuilt every 100ms.
+                        if (subscription.last_update_time_ms < expiration_ms
+                                and now_ms >= subscription.next_attempt_ms):
                             self._send_dashboard_update(synthetic_hotkey, client, subscription)
 
             except Exception as e:
@@ -873,6 +940,14 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                         self.host,
                         self.port,
                         compression="deflate",
+                        # Explicit keepalive: the library defaults (20s/20s) meant
+                        # a transient event-loop stall past 20s reaped EVERY
+                        # connection in the same second (the synchronized 1006
+                        # bursts). A 60s ping_timeout tolerates a stall while the
+                        # real fix (off-loop serialization) removes its cause.
+                        ping_interval=20,
+                        ping_timeout=60,
+                        close_timeout=10,
                         reuse_address=True,  # Allow reuse of the address
                         reuse_port=True  # Allow reuse of the port (on platforms that support it)
                     )

--- a/vanta_api/websocket_server.py
+++ b/vanta_api/websocket_server.py
@@ -113,19 +113,29 @@ class WebSocketServerClient:
     sequence_number: int = 0
     subscribe_broadcasts: bool = False
     dashboard_subscriptions: dict[str, DashboardSubscription] = field(default_factory=dict)
+    # Guards sequence-number assignment so worker threads can serialize frames
+    # off the event loop while keeping per-client ordering monotonic.
+    send_lock: Lock = field(default_factory=Lock)
 
-    async def send(self, message:dict) -> None:
-        serialized_message = json.dumps(
-            {
-                "sequence": self.sequence_number,
-                "timestamp": TimeUtil.now_in_millis(),
-                "data": message
-            },
+    def serialize(self, message: dict) -> str:
+        """Assign the next sequence number and produce the wire string. Safe to
+        call from a worker thread — the lock keeps sequence assignment monotonic
+        even when several dashboard builds finish concurrently. Doing the
+        json.dumps here (not on the loop) is what keeps a frame herd from
+        stalling the event loop and tripping the ping-timeout mass-reap."""
+        with self.send_lock:
+            seq = self.sequence_number
+            self.sequence_number += 1
+        return json.dumps(
+            {"sequence": seq, "timestamp": TimeUtil.now_in_millis(), "data": message},
             cls=CustomEncoder,
-            separators=(",", ":")
+            separators=(",", ":"),
         )
-        self.sequence_number += 1
-        await self.websocket.send(serialized_message)
+
+    async def send(self, message: dict) -> None:
+        # Retained for loop-side callers (broadcasts). The hot dashboard path
+        # serializes in the worker via serialize() + WebSocketServer._send_serialized.
+        await self.websocket.send(self.serialize(message))
 
 
 class WebSocketServer(APIKeyMixin, RPCServerBase):
@@ -387,6 +397,26 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
             bt.logging.error(f"WebSocketServer: Error sending to client {client_id}: {e}")
             self._remove_client(client_id)
 
+    async def _send_serialized(self, client: WebSocketServerClient, serialized: str) -> None:
+        """Loop-side raw send of an already-serialized frame (the worker did the
+        json.dumps). Same tier recheck + disconnect handling as _send_message,
+        but no serialization on the loop."""
+        client_id = client.client_id
+
+        if not self.can_access_tier(client.api_key, client.tier):
+            bt.logging.warning(f"WebSocketServer: Client {client_id} tier changed")
+            self._remove_client(client_id)
+            return
+
+        try:
+            await client.websocket.send(serialized)
+        except websockets.exceptions.ConnectionClosed:
+            bt.logging.info(f"WebSocketServer: Client {client_id} disconnected while sending")
+            self._remove_client(client_id)
+        except Exception as e:
+            bt.logging.error(f"WebSocketServer: Error sending to client {client_id}: {e}")
+            self._remove_client(client_id)
+
     async def _process_broadcast_message_queue(self) -> None:
         while True:
             try:
@@ -494,8 +524,11 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                 subscription.next_attempt_ms = 0
                 subscription.update_times(dashboard)
 
+                # Serialize in THIS worker thread (json.dumps + sequence under
+                # the per-client lock); schedule only the raw send on the loop.
+                serialized = client.serialize({"dashboard": dashboard})
                 asyncio.run_coroutine_threadsafe(
-                    self._send_message(client, {"dashboard": dashboard}),
+                    self._send_serialized(client, serialized),
                     self._event_loop
                 )
 
@@ -969,7 +1002,12 @@ class WebSocketServer(APIKeyMixin, RPCServerBase):
                         self._handle_client,
                         self.host,
                         self.port,
-                        compression="deflate",
+                        # Compression disabled: per-frame permessage-deflate ran
+                        # ON the event loop and was a primary loop-stall cost
+                        # behind the 1006 bursts. Dashboards are modest; if
+                        # bandwidth ever demands it, compress in the worker
+                        # (alongside serialize()), not here.
+                        compression=None,
                         # Explicit keepalive: the library defaults (20s/20s) meant
                         # a transient event-loop stall past 20s reaped EVERY
                         # connection in the same second (the synchronized 1006


### PR DESCRIPTION
The live daemon path (RPCServerBase._daemon_loop -> SubtensorOpsServer. run_daemon_iteration -> update_metagraph) never incremented manager.consecutive_failures, so the connection-recreation block in update_metagraph() — and round-robin rotation on mainnet — was unreachable after runtime failures. A validator whose connection landed on a sick chain-endpoint backend retried the same dead websocket forever with growing backoff. Observed on testnet, where the public endpoint's load balancer serves backends at wildly different states (~900 blocks apart measured); a validator boot that drew a bad backend could never populate its metagraph and exited. The counter was only maintained by run_update_loop, which has no callers (dead code).

Fix:
- run_daemon_iteration increments manager.consecutive_failures on exception and re-raises (daemon backoff unchanged); the counter now arms the existing recreate block on the next iteration — every retry is a fresh connection instead of the same dead socket.
- update_metagraph resets the counter only after a FULLY successful sync (after set_last_update_time). Early returns (refresh rate-limit, anomalous metagraph) do not clear a pending reconnect, and the init-failure recovery path (consecutive_failures=1 with subtensor=None) is preserved.
- The recreate close+swap now runs under get_subtensor_lock so a weight-setting extrinsic in flight on the old connection cannot have its websocket closed underneath it (race was pre-existing but unreachable on the live path before this fix armed it).
- Removed 'subvortex' from round_robin_networks: it is absent from bittensor's NETWORKS and entrypoint-subvortex.opentensor.ai is NXDOMAIN (verified), so the newly-armed mainnet rotation would have burned every other retry cycle on a dead DNS name. With a single network, rotation degenerates to the same-endpoint reconnect that is the actual healing mechanism.
- Round-robin is only enabled when the configured chain_endpoint is a default public entrypoint: an operator passing a custom --subtensor.chain_endpoint (local node) keeps network='finney' by bittensor default, and rotation would have clobbered their endpoint irrecoverably on the first failure.
- Test mocks gain validator_permit lists (the permitted-validators logging block iterates it; a bare Mock attribute is not iterable) — this also un-breaks test_metagraph_updater, which currently fails on main for that reason.

Known-and-accepted: failure attribution is deliberately broad (any update_metagraph exception arms a reconnect, matching legacy semantics); an anomalous-but-non-raising metagraph still never arms reconnection (pre-existing gap); recovery is logged but not Slack-notified.

Tests: 6 new (failure accounting, reconnect engagement incl. full daemon fail->heal cycle, anomalous-return counter preservation, custom- endpoint guard via test_metagraph_updater) plus updated rotation test; 35/35 across test_subtensor_ops_retry, test_metagraph_updater, test_validator_broadcast.

## Taoshi Pull Request

### Description
[Provide a brief description of the changes introduced by this pull request.]

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
