### PR TITLE
fix(dashboard): keep repeat fills sharing an order_uuid in v2 fo dict

### DIFF
--- a/tests/vali_tests/test_position_manager.py
+++ b/tests/vali_tests/test_position_manager.py
@@ -298,71 +298,65 @@ class TestPositionManager(TestBase):
         """
         A bracket order that fills in more than one chunk produces several fills
         sharing one order_uuid. The dashboard's fo dict must keep every fill:
-        repeat fills are keyed "{uuid}@{occurrence}", and the key must be stable
-        across incremental frames (positions_time_ms windows).
+        the first keeps the bare uuid (backward compatible), repeat fills are
+        keyed "{uuid}@{occurrence}", and each fill's key must be stable across
+        incremental frames (positions_time_ms windows).
         """
         from vali_objects.enums.order_type_enum import OrderType
         from vali_objects.vali_dataclasses.order import Order
 
         open_ms = 1000
         position = deepcopy(self.default_position)
+
+        def mk(order_type, price, leverage, uuid, ms):
+            return Order(
+                price=price,
+                slippage=0.0,
+                processed_ms=ms,
+                order_uuid=uuid,
+                trade_pair=position.trade_pair,
+                order_type=order_type,
+                leverage=leverage,
+            )
+
         position.orders = [
-            Order(
-                price=4094.0,
-                slippage=0.0,
-                processed_ms=open_ms,
-                order_uuid="open_order",
-                trade_pair=position.trade_pair,
-                order_type=OrderType.LONG,
-                leverage=0.08,
-            ),
-            Order(
-                price=3983.2683,
-                slippage=0.0,
-                processed_ms=open_ms + 1000,
-                order_uuid="sl_order",
-                trade_pair=position.trade_pair,
-                order_type=OrderType.SHORT,
-                leverage=-0.02,
-            ),
-            Order(
-                price=4013.5489,
-                slippage=0.0,
-                processed_ms=open_ms + 2000,
-                order_uuid="sl_order",
-                trade_pair=position.trade_pair,
-                order_type=OrderType.FLAT,
-                leverage=-0.02,
-            ),
+            mk(OrderType.LONG, 4094.0, 0.08, "open_order", open_ms),
+            # One stop order filling in three chunks — all share its uuid.
+            mk(OrderType.SHORT, 3983.2683, -0.02, "sl_order", open_ms + 1000),
+            mk(OrderType.SHORT, 3990.0, -0.02, "sl_order", open_ms + 2000),
+            mk(OrderType.FLAT, 4013.5489, -0.04, "sl_order", open_ms + 3000),
         ]
         position.rebuild_position_with_updated_orders(self.live_price_fetcher_client)
-        position.close_out_position(open_ms + 2000)
+        position.close_out_position(open_ms + 3000)
         self.position_client.save_miner_position(position)
 
         dashboard = self.position_client.get_dashboard(self.DEFAULT_MINER_HOTKEY, 0)
         self.assertIsNotNone(dashboard)
-        pos_dict = dashboard["positions"][position.position_uuid]
-        fo = pos_dict["fo"]
+        fo = dashboard["positions"][position.position_uuid]["fo"]
         self.assertEqual(
-            set(fo.keys()), {"open_order", "sl_order", "sl_order@1"},
-            f"Expected all three fills to survive, got keys: {sorted(fo.keys())}"
+            set(fo.keys()), {"open_order", "sl_order", "sl_order@1", "sl_order@2"},
+            f"Expected all four fills to survive, got keys: {sorted(fo.keys())}"
         )
+        # Old consumers still find the FIRST fill under the bare uuid.
         self.assertEqual(fo["sl_order"]["pr"], 3983.2683)
-        self.assertEqual(fo["sl_order@1"]["pr"], 4013.5489)
+        self.assertEqual(fo["sl_order@1"]["pr"], 3990.0)
+        self.assertEqual(fo["sl_order@2"]["pr"], 4013.5489)
 
-        # Incremental frame containing only the last fill: no in-frame uuid
-        # collision exists, but the repeat fill must keep its suffixed key so
-        # clients merging frames by key do not overwrite the first fill.
+        # Watermark falling BETWEEN repeat fills of the same uuid: the frame
+        # contains only the later chunks, with no in-frame collision — but
+        # they must keep their suffixed keys so clients merging frames by key
+        # do not overwrite the earlier fills.
         incremental = self.position_client.get_dashboard(
             self.DEFAULT_MINER_HOTKEY, open_ms + 1500
         )
         self.assertIsNotNone(incremental)
         inc_fo = incremental["positions"][position.position_uuid]["fo"]
         self.assertEqual(
-            set(inc_fo.keys()), {"sl_order@1"},
-            f"Repeat fill must keep its stable key in incremental frames, got: {sorted(inc_fo.keys())}"
+            set(inc_fo.keys()), {"sl_order@1", "sl_order@2"},
+            f"Repeat fills must keep stable keys in incremental frames, got: {sorted(inc_fo.keys())}"
         )
-        self.assertEqual(inc_fo["sl_order@1"]["pr"], 4013.5489)
+        self.assertEqual(inc_fo["sl_order@1"]["pr"], 3990.0)
+        self.assertEqual(inc_fo["sl_order@2"]["pr"], 4013.5489)
 
     # ==================== RACE CONDITION TESTS ====================
     # These tests demonstrate race conditions in PositionManager when accessed concurrently.

--- a/tests/vali_tests/test_position_manager.py
+++ b/tests/vali_tests/test_position_manager.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 from shared_objects.rpc.server_orchestrator import ServerOrchestrator, ServerMode
 from tests.vali_tests.base_objects.test_base import TestBase
 
+from vali_objects.enums.order_type_enum import OrderType
 from vali_objects.vali_dataclasses.position import Position
 from vali_objects.position_management.position_manager_client import PositionManagerClient
 from vali_objects.utils.vali_utils import ValiUtils
@@ -99,6 +100,8 @@ class TestPositionManager(TestBase):
             position_uuid=self.DEFAULT_POSITION_UUID,
             open_ms=self.DEFAULT_OPEN_MS,
             trade_pair=self.DEFAULT_TRADE_PAIR,
+            position_type=OrderType.LONG,
+            account_size=self.DEFAULT_ACCOUNT_SIZE,
         )
 
     def _find_disk_position_from_memory_position(self, position):
@@ -290,6 +293,76 @@ class TestPositionManager(TestBase):
         all_disk_positions = self.position_client.get_positions_for_one_hotkey(self.DEFAULT_MINER_HOTKEY,
                                                                                 sort_positions=True)
         self.assertEqual(len(all_disk_positions), 2 * len(TradePair))
+
+    def test_get_dashboard_keeps_repeat_fills_sharing_order_uuid(self):
+        """
+        A bracket order that fills in more than one chunk produces several fills
+        sharing one order_uuid. The dashboard's fo dict must keep every fill:
+        repeat fills are keyed "{uuid}@{occurrence}", and the key must be stable
+        across incremental frames (positions_time_ms windows).
+        """
+        from vali_objects.enums.order_type_enum import OrderType
+        from vali_objects.vali_dataclasses.order import Order
+
+        open_ms = 1000
+        position = deepcopy(self.default_position)
+        position.orders = [
+            Order(
+                price=4094.0,
+                slippage=0.0,
+                processed_ms=open_ms,
+                order_uuid="open_order",
+                trade_pair=position.trade_pair,
+                order_type=OrderType.LONG,
+                leverage=0.08,
+            ),
+            Order(
+                price=3983.2683,
+                slippage=0.0,
+                processed_ms=open_ms + 1000,
+                order_uuid="sl_order",
+                trade_pair=position.trade_pair,
+                order_type=OrderType.SHORT,
+                leverage=-0.02,
+            ),
+            Order(
+                price=4013.5489,
+                slippage=0.0,
+                processed_ms=open_ms + 2000,
+                order_uuid="sl_order",
+                trade_pair=position.trade_pair,
+                order_type=OrderType.FLAT,
+                leverage=-0.02,
+            ),
+        ]
+        position.rebuild_position_with_updated_orders(self.live_price_fetcher_client)
+        position.close_out_position(open_ms + 2000)
+        self.position_client.save_miner_position(position)
+
+        dashboard = self.position_client.get_dashboard(self.DEFAULT_MINER_HOTKEY, 0)
+        self.assertIsNotNone(dashboard)
+        pos_dict = dashboard["positions"][position.position_uuid]
+        fo = pos_dict["fo"]
+        self.assertEqual(
+            set(fo.keys()), {"open_order", "sl_order", "sl_order@1"},
+            f"Expected all three fills to survive, got keys: {sorted(fo.keys())}"
+        )
+        self.assertEqual(fo["sl_order"]["pr"], 3983.2683)
+        self.assertEqual(fo["sl_order@1"]["pr"], 4013.5489)
+
+        # Incremental frame containing only the last fill: no in-frame uuid
+        # collision exists, but the repeat fill must keep its suffixed key so
+        # clients merging frames by key do not overwrite the first fill.
+        incremental = self.position_client.get_dashboard(
+            self.DEFAULT_MINER_HOTKEY, open_ms + 1500
+        )
+        self.assertIsNotNone(incremental)
+        inc_fo = incremental["positions"][position.position_uuid]["fo"]
+        self.assertEqual(
+            set(inc_fo.keys()), {"sl_order@1"},
+            f"Repeat fill must keep its stable key in incremental frames, got: {sorted(inc_fo.keys())}"
+        )
+        self.assertEqual(inc_fo["sl_order@1"]["pr"], 4013.5489)
 
     # ==================== RACE CONDITION TESTS ====================
     # These tests demonstrate race conditions in PositionManager when accessed concurrently.

--- a/vali_objects/position_management/position_manager.py
+++ b/vali_objects/position_management/position_manager.py
@@ -522,10 +522,20 @@ class PositionManager:
                 new_closed_positions = True
 
             dashboard_filled_orders = {}
+            # A bracket order that fills in more than one chunk produces several
+            # fills sharing one order_uuid; keying the dict by the raw uuid would
+            # silently drop all but the last such fill. Repeat fills get an
+            # "@{occurrence}" suffix. The occurrence count runs over ALL of the
+            # position's orders (not just those past the watermark) so a fill
+            # keeps the same key in every incremental frame that includes it.
+            fill_counts = {}
             for order in position.orders:
+                occurrence = fill_counts.get(order.order_uuid, 0)
+                fill_counts[order.order_uuid] = occurrence + 1
                 if order.processed_ms > positions_time_ms:
                     snapshot_time_ms = max(snapshot_time_ms, order.processed_ms)
-                    dashboard_filled_orders[order.order_uuid] = order.to_dashboard()
+                    key = order.order_uuid if occurrence == 0 else f"{order.order_uuid}@{occurrence}"
+                    dashboard_filled_orders[key] = order.to_dashboard()
 
             dashboard_unfilled_orders = {
                 order.order_uuid: order.to_dashboard()

--- a/vali_objects/position_management/position_manager.py
+++ b/vali_objects/position_management/position_manager.py
@@ -36,6 +36,20 @@ from shared_objects.log import logger
 TARGET_MS = 1782417600000 + (1000 * 60 * 60 * 6)  # + 6 hours
 
 
+def dashboard_fill_key(order_uuid: str, occurrence: int) -> str:
+    """Key for a fill in the dashboard's `fo` dict.
+
+    A bracket order that fills in more than one chunk produces several fills
+    sharing one order_uuid, so the uuid alone cannot key the dict. The first
+    fill keeps the bare order_uuid (backward compatible — existing consumers
+    still find it); each repeat fill gets an "@{occurrence}" suffix.
+
+    Client contract: everything after '@' is an opaque discriminator — strip
+    it to recover the order_uuid, and never interpret the number's value.
+    """
+    return order_uuid if occurrence == 0 else f"{order_uuid}@{occurrence}"
+
+
 class PositionManager:
     """
     Core business logic for position management.
@@ -522,19 +536,20 @@ class PositionManager:
                 new_closed_positions = True
 
             dashboard_filled_orders = {}
-            # A bracket order that fills in more than one chunk produces several
-            # fills sharing one order_uuid; keying the dict by the raw uuid would
-            # silently drop all but the last such fill. Repeat fills get an
-            # "@{occurrence}" suffix. The occurrence count runs over ALL of the
-            # position's orders (not just those past the watermark) so a fill
-            # keeps the same key in every incremental frame that includes it.
+            # See dashboard_fill_key: repeat fills of one order_uuid get an
+            # "@{occurrence}" suffix so none is silently dropped. The running
+            # count covers ALL of the position's orders (not just those past
+            # the watermark) so a fill keeps the same key in every incremental
+            # frame that includes it. position.orders is the chronological
+            # fill sequence (fills are only ever appended), which makes each
+            # fill's ordinal stable across calls.
             fill_counts = {}
             for order in position.orders:
                 occurrence = fill_counts.get(order.order_uuid, 0)
                 fill_counts[order.order_uuid] = occurrence + 1
                 if order.processed_ms > positions_time_ms:
                     snapshot_time_ms = max(snapshot_time_ms, order.processed_ms)
-                    key = order.order_uuid if occurrence == 0 else f"{order.order_uuid}@{occurrence}"
+                    key = dashboard_fill_key(order.order_uuid, occurrence)
                     dashboard_filled_orders[key] = order.to_dashboard()
 
             dashboard_unfilled_orders = {


### PR DESCRIPTION
A bracket order that fills in more than one chunk produces several fills sharing one order_uuid (e.g. a partial stop-loss that triggers twice). get_dashboard keyed the fo dict by the raw uuid, so the later fill silently overwrote the earlier one: consumers saw an order list that no longer nets to zero and a close price that contradicts the position's own realized_pnl (observed live: GOLDUSDC position c67b2e8a on subaccount 548 — the v2 dashboard served 3 of 4 fills while the v1 endpoint returned all 4).

Repeat fills are now keyed "{uuid}@{occurrence}", where the occurrence ordinal is counted over ALL of the position's orders — not just those past the positions_time_ms watermark — so a fill keeps the same key in every incremental frame and frame-merging clients cannot collapse them.

Also repairs the test fixture in test_position_manager.py, which constructed Position without the now-required position_type and crashed every test in the file at setUp.

## Taoshi Pull Request

### Description
[Provide a brief description of the changes introduced by this pull request.]

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
