### PR TITLE
test: fix pre-existing entity-collateral drift + miner_config import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,11 @@ setup(
     url="https://github.com/taoshidev/prop-net",
     author="taoshidev",
     packages=find_packages(),
+    # Top-level single-file modules imported by packaged code (e.g. the
+    # entity-miner gateway does `from miner_config import MinerConfig`).
+    # find_packages() only picks up packages (dirs with __init__.py), so these
+    # must be declared explicitly or they're missing from an editable/wheel install.
+    py_modules=["miner_config"],
     include_package_data=True,
     package_data={
         "meta": ["meta.json"],  # include meta.json in the root of the package

--- a/tests/run_vali_testing_suite.py
+++ b/tests/run_vali_testing_suite.py
@@ -6,6 +6,14 @@ import unittest
 
 from vali_objects.vali_config import ValiConfig
 
+# Ensure the repo root is importable. This script's sys.path[0] is the tests/
+# dir, and the editable install only exposes packages (dirs with __init__.py),
+# not top-level modules like miner_config.py — so tests that import code which
+# does `from miner_config import MinerConfig` (e.g. the entity-miner gateway)
+# otherwise fail with ModuleNotFoundError under this runner.
+if ValiConfig.BASE_DIR not in sys.path:
+    sys.path.insert(0, ValiConfig.BASE_DIR)
+
 if __name__ == '__main__':
     # Create a test loader
     loader = unittest.TestLoader()

--- a/tests/run_vali_testing_suite.py
+++ b/tests/run_vali_testing_suite.py
@@ -6,15 +6,17 @@ import unittest
 
 from vali_objects.vali_config import ValiConfig
 
-# Ensure the repo root is importable. This script's sys.path[0] is the tests/
-# dir, and the editable install only exposes packages (dirs with __init__.py),
-# not top-level modules like miner_config.py — so tests that import code which
-# does `from miner_config import MinerConfig` (e.g. the entity-miner gateway)
-# otherwise fail with ModuleNotFoundError under this runner.
-if ValiConfig.BASE_DIR not in sys.path:
-    sys.path.insert(0, ValiConfig.BASE_DIR)
-
 if __name__ == '__main__':
+    # Ensure the repo root is importable. This script's sys.path[0] is the tests/
+    # dir, and an editable install that predates the py_modules=["miner_config"]
+    # declaration in setup.py doesn't expose top-level modules — so tests that
+    # import code doing `from miner_config import MinerConfig` (e.g. the
+    # entity-miner gateway) otherwise fail with ModuleNotFoundError under this
+    # runner. Guarded under __main__ so merely importing this file never
+    # mutates sys.path.
+    if ValiConfig.BASE_DIR not in sys.path:
+        sys.path.insert(0, ValiConfig.BASE_DIR)
+
     # Create a test loader
     loader = unittest.TestLoader()
 

--- a/tests/vali_tests/test_challengeperiod_integration.py
+++ b/tests/vali_tests/test_challengeperiod_integration.py
@@ -22,6 +22,7 @@ The two tiers are complementary:
   - Tier-1 integration tests check the RPC boundary and cross-process state.
 """
 import contextlib
+import math
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -31,6 +32,7 @@ from time_util.time_util import TimeUtil, MS_IN_24_HOURS
 from vali_objects.enums.elimination_reason_enum import EliminationReason
 from vali_objects.enums.miner_asset_class_enum import MinerAssetClass
 from vali_objects.enums.miner_bucket_enum import BucketEntry, MinerBucket
+from vali_objects.enums.drawdown_criteria_enum import DrawdownCriteria
 from vali_objects.challenge_period.challengeperiod_manager import (
     ChallengePeriodManager,
     DrawdownStats,
@@ -51,7 +53,7 @@ INTRADAY_DD_PCT = ValiConfig.CHALLENGE_INTRADAY_DRAWDOWN_THRESHOLD * 100
 EOD_DD_PCT = ValiConfig.CHALLENGE_EOD_DRAWDOWN_THRESHOLD * 100
 STATIC_DD_PCT = ValiConfig.SUBACCOUNT_STATIC_DRAWDOWN_THRESHOLD * 100
 STATIC_EOD_DD_PCT = ValiConfig.SUBACCOUNT_STATIC_EOD_DRAWDOWN_THRESHOLD * 100
-STATIC_EFFECTIVE_MS = ValiConfig.SUBACCOUNT_STATIC_RULES_EFFECTIVE_MS
+STATIC_EFFECTIVE_MS = TimeUtil.formatted_date_str_to_millis("2026-09-05 00:00:00")
 
 _CLIENT_PATHS = [
     "vali_objects.challenge_period.challengeperiod_manager.PerfLedgerClient",
@@ -209,8 +211,8 @@ class TestChallengePeriodRPC(TestBase):
         """sync_challenge_period_data → get_miner_bucket preserves bucket and start time."""
         now = TimeUtil.now_in_millis()
         states = {
-            "hk_a": MinerBucketState("hk_a", [BucketEntry(MinerBucket.CHALLENGE, now)]).to_json(),
-            "hk_b": MinerBucketState("hk_b", [BucketEntry(MinerBucket.MAINCOMP, now - DAILY_MS)]).to_json(),
+            "hk_a": MinerBucketState("hk_a", [BucketEntry(MinerBucket.CHALLENGE, now)]).to_checkpoint_dict(),
+            "hk_b": MinerBucketState("hk_b", [BucketEntry(MinerBucket.MAINCOMP, now - DAILY_MS)]).to_checkpoint_dict(),
         }
         self.challenge_period_client.sync_challenge_period_data(states)
 
@@ -238,7 +240,7 @@ class TestChallengePeriodRPC(TestBase):
             BucketEntry(MinerBucket.CHALLENGE, now - DAILY_MS * 70),
             BucketEntry(MinerBucket.MAINCOMP, now - DAILY_MS * 5),
         ])
-        self.challenge_period_client.sync_challenge_period_data({"hk_hist": state.to_json()})
+        self.challenge_period_client.sync_challenge_period_data({"hk_hist": state.to_checkpoint_dict()})
 
         checkpoint = self.challenge_period_client.to_checkpoint_dict()
         parsed = ChallengePeriodManager.parse_checkpoint_dict(checkpoint)
@@ -323,7 +325,7 @@ class TestChallengePeriodManagerLogic(TestBase):
             self.assertFalse(changed)
 
     def test_sync_elimination_miners_removes_targeted_hotkey(self):
-        """Eliminated miners are removed from state; unaffected miners remain."""
+        """Eliminated miners are moved to the ELIMINATED bucket (retained in state); unaffected miners remain."""
         now = TimeUtil.now_in_millis()
         mgr, stack = self._make_manager()
         with stack:
@@ -332,7 +334,7 @@ class TestChallengePeriodManagerLogic(TestBase):
 
             changed = mgr.sync_elimination_miners(["hk_elim"], now)
             self.assertTrue(changed)
-            self.assertFalse(mgr.has_miner("hk_elim"))
+            self.assertEqual(mgr.get_miner_bucket("hk_elim"), MinerBucket.ELIMINATED)
             self.assertTrue(mgr.has_miner("hk_safe"))
 
     def test_sync_elimination_miners_empty_list_is_noop(self):
@@ -428,7 +430,7 @@ class TestChallengePeriodManagerLogic(TestBase):
             ):
                 mgr.refresh(current_time_ms=now)
 
-        self.assertFalse(mgr.has_miner(hk))
+        self.assertEqual(mgr.get_miner_bucket(hk), MinerBucket.ELIMINATED)
 
     def test_refresh_demotes_maincomp_miner_with_bad_rank(self):
         """MAINCOMP miner with rank beyond threshold is demoted to PROBATION."""
@@ -477,13 +479,12 @@ class TestChallengePeriodManagerLogic(TestBase):
 
     def test_refresh_eliminates_intraday_drawdown(self):
         """Miner whose intraday drawdown exceeds the threshold is eliminated during refresh."""
-        now = TimeUtil.now_in_millis()
+        now = ChallengePeriodManager.DRAWDOWN_ACTIVATION_MS + DAILY_MS  # after activation so the legacy intraday rule fires for a regular miner
         hk = "hk_intraday"
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 3)
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                intraday_drawdown_pct=INTRADAY_DD_PCT + 1.0,
                 current_equity=1.0 - (INTRADAY_DD_PCT + 1.0) / 100,
                 current_balance=1.0,
                 daily_open_equity=1.0,
@@ -498,17 +499,16 @@ class TestChallengePeriodManagerLogic(TestBase):
             ):
                 mgr.refresh(current_time_ms=now)
 
-        self.assertFalse(mgr.has_miner(hk))
+        self.assertEqual(mgr.get_miner_bucket(hk), MinerBucket.ELIMINATED)
 
     def test_refresh_eliminates_eod_drawdown(self):
         """Miner whose EOD trailing drawdown exceeds the threshold is eliminated during refresh."""
-        now = TimeUtil.now_in_millis()
+        now = ChallengePeriodManager.DRAWDOWN_ACTIVATION_MS + DAILY_MS  # after activation so the legacy EOD rule fires for a regular miner
         hk = "hk_eod"
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 5)
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                eod_drawdown_pct=EOD_DD_PCT + 1.0,
                 eod_hwm=1.1,
                 last_eod_equity=1.1 * (1 - (EOD_DD_PCT + 1.0) / 100),
             )
@@ -522,10 +522,11 @@ class TestChallengePeriodManagerLogic(TestBase):
             ):
                 mgr.refresh(current_time_ms=now)
 
-        self.assertFalse(mgr.has_miner(hk))
+        self.assertEqual(mgr.get_miner_bucket(hk), MinerBucket.ELIMINATED)
 
     def test_refresh_healthy_miner_unchanged_no_disk_write(self):
-        """Brand-new miner with no issues triggers no state change and no disk write."""
+        """Brand-new miner with no issues triggers no bucket change and no account sync
+        (the end-of-cycle disk save still runs unconditionally)."""
         now = TimeUtil.now_in_millis()
         hk = "hk_healthy"
         mgr, stack = self._make_manager()
@@ -544,8 +545,8 @@ class TestChallengePeriodManagerLogic(TestBase):
                 mgr.refresh(current_time_ms=now)
 
             self.assertEqual(mgr.get_miner_bucket(hk), MinerBucket.CHALLENGE)
-            mock_save.assert_not_called()
-            mock_sync.assert_not_called()
+            mock_save.assert_called_once()  # refresh() always persists at end of cycle
+            mock_sync.assert_not_called()   # no bucket change → no account sync
 
     def test_demotion_then_re_promotion_full_cycle(self):
         """MAINCOMP → PROBATION → MAINCOMP bucket progression works end-to-end."""
@@ -607,12 +608,22 @@ class TestChallengePeriodManagerLogic(TestBase):
         ])
 
         intraday_drop = 0.07
-        accounts = {hk: {'account_size': account_size, 'balance': account_size * (1 - intraday_drop)}}
-        positions = {hk: []}  # no open positions → equity = balance / account_size
+        # Live equity 7% below account size; a non-empty position list is required for the cache
+        # to update (production skips hotkeys with no open positions).
+        accounts = {hk: SimpleNamespace(
+            account_size=account_size,
+            balance=account_size * (1 - intraday_drop),
+            equity=account_size * (1 - intraday_drop),
+            daily_open_snapshot=None,
+        )}
+        positions = {hk: [SimpleNamespace()]}
 
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 5)
+            # First refresh locks today's EOD/open snapshot from the ledger; the second updates the
+            # live intraday equity (the two-phase cadence a real per-day refresh loop follows).
+            mgr._refresh_drawdown_cache([hk], accounts, {hk: ledger}, positions, now)
             mgr._refresh_drawdown_cache([hk], accounts, {hk: ledger}, positions, now)
 
             dd = mgr.miner_states[hk].drawdown
@@ -635,12 +646,18 @@ class TestChallengePeriodManagerLogic(TestBase):
                            accum_ms=DAILY_MS, equity_ret=1.04, gain=0.0, loss=0.0, mdd=1.0),
         ])
 
-        accounts = {hk: {'account_size': account_size, 'balance': account_size * 1.04}}
-        positions = {hk: []}
+        accounts = {hk: SimpleNamespace(
+            account_size=account_size,
+            balance=account_size * 1.04,
+            equity=account_size * 1.04,
+            daily_open_snapshot=None,
+        )}
+        positions = {hk: [SimpleNamespace()]}
 
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 10)
+            # EOD fields (last_eod_equity / eod_hwm) are locked on the first refresh of the day.
             mgr._refresh_drawdown_cache([hk], accounts, {hk: ledger}, positions, now)
 
             dd = mgr.miner_states[hk].drawdown
@@ -652,13 +669,19 @@ class TestChallengePeriodManagerLogic(TestBase):
         now = TimeUtil.now_in_millis()
         hk = "hk_no_ledger"
         account_size = 100_000.0
-        accounts = {hk: {'account_size': account_size, 'balance': account_size}}
+        accounts = {hk: SimpleNamespace(
+            account_size=account_size,
+            balance=account_size,
+            equity=account_size,
+            daily_open_snapshot=None,
+        )}
 
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 3)
             default_dd = DrawdownStats()
-            mgr._refresh_drawdown_cache([hk], accounts, {}, {hk: []}, now)
+            # Non-empty positions so evaluation reaches the ledger lookup, which is missing → skipped.
+            mgr._refresh_drawdown_cache([hk], accounts, {}, {hk: [SimpleNamespace()]}, now)
 
             dd = mgr.miner_states[hk].drawdown
             self.assertEqual(dd.intraday_drawdown_pct, default_dd.intraday_drawdown_pct)
@@ -681,10 +704,9 @@ class TestChallengePeriodManagerLogic(TestBase):
         hk = "hk_static_funded"
         mgr, stack = self._make_manager()
         with stack:
-            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3)
+            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3, drawdown_criteria=DrawdownCriteria.STATIC)
             mgr.miner_states[hk].drawdown = DrawdownStats(
                 current_balance=1.0 - (STATIC_DD_PCT + 1.0) / 100,
-                static_drawdown_pct=STATIC_DD_PCT + 1.0,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
             self._refresh_with_patched_caches(mgr, now)
@@ -700,8 +722,8 @@ class TestChallengePeriodManagerLogic(TestBase):
         hk = "hk_static_challenge"
         mgr, stack = self._make_manager()
         with stack:
-            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_CHALLENGE, now - DAILY_MS * 3)
-            mgr.miner_states[hk].drawdown = DrawdownStats(static_drawdown_pct=STATIC_DD_PCT + 1.0)
+            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_CHALLENGE, now - DAILY_MS * 3, drawdown_criteria=DrawdownCriteria.STATIC)
+            mgr.miner_states[hk].drawdown = DrawdownStats(current_balance=1.0 - (STATIC_DD_PCT + 1.0) / 100)
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
             self._refresh_with_patched_caches(mgr, now)
 
@@ -717,10 +739,9 @@ class TestChallengePeriodManagerLogic(TestBase):
         hk = "hk_static_eod"
         mgr, stack = self._make_manager()
         with stack:
-            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3)
+            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3, drawdown_criteria=DrawdownCriteria.STATIC)
             mgr.miner_states[hk].drawdown = DrawdownStats(
                 last_eod_equity=1.0 - (STATIC_EOD_DD_PCT + 1.0) / 100,
-                static_eod_drawdown_pct=STATIC_EOD_DD_PCT + 1.0,
                 last_eod_checked_ms=midnight_ms,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
@@ -740,14 +761,14 @@ class TestChallengePeriodManagerLogic(TestBase):
         hk = "hk_deep_dip"
         mgr, stack = self._make_manager()
         with stack:
-            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3)
+            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3, drawdown_criteria=DrawdownCriteria.STATIC)
+            # Deep legacy dips (intraday ≈ 12%, EOD-trailing ≈ 9%) that would have died under the
+            # legacy rules, while both static measures stay well within the 5% limits (1% and 2%).
             mgr.miner_states[hk].drawdown = DrawdownStats(
                 current_equity=0.88,
                 current_balance=0.99,
-                intraday_drawdown_pct=12.0,
-                eod_drawdown_pct=9.0,
-                static_drawdown_pct=1.0,
-                static_eod_drawdown_pct=2.0,
+                eod_hwm=1.08,
+                last_eod_equity=0.98,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
             self._refresh_with_patched_caches(mgr, now)
@@ -761,12 +782,13 @@ class TestChallengePeriodManagerLogic(TestBase):
         hk = "hk_boundary"
         mgr, stack = self._make_manager()
         with stack:
-            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3)
+            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3, drawdown_criteria=DrawdownCriteria.STATIC)
+            # Exactly at the 5% static limits. The (1 - balance) * 100 property cannot represent the
+            # threshold float exactly, so nudge one ULP toward 1.0 to sit on the surviving side of the
+            # strict > check (equivalently: right at the limit, not past it).
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                current_balance=1.0 - STATIC_DD_PCT / 100,
-                last_eod_equity=1.0 - STATIC_EOD_DD_PCT / 100,
-                static_drawdown_pct=STATIC_DD_PCT,
-                static_eod_drawdown_pct=STATIC_EOD_DD_PCT,
+                current_balance=math.nextafter(1.0 - STATIC_DD_PCT / 100, 1.0),
+                last_eod_equity=math.nextafter(1.0 - STATIC_EOD_DD_PCT / 100, 1.0),
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
             self._refresh_with_patched_caches(mgr, now)
@@ -781,9 +803,12 @@ class TestChallengePeriodManagerLogic(TestBase):
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 3)
+            # Bad static stats (50% each) that a TRAILING miner ignores; eod_hwm == last_eod_equity
+            # keeps the legacy EOD rule clean (0%) so only the static stats are "bad".
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                static_drawdown_pct=50.0,
-                static_eod_drawdown_pct=50.0,
+                current_balance=0.5,
+                eod_hwm=0.5,
+                last_eod_equity=0.5,
             )
             mgr.miner_states[hk].rank = 1
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
@@ -800,7 +825,7 @@ class TestChallengePeriodManagerLogic(TestBase):
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 3)
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                intraday_drawdown_pct=INTRADAY_DD_PCT + 1.0,
+                current_equity=1.0 - (INTRADAY_DD_PCT + 1.0) / 100,
                 daily_open_equity=1.0,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
@@ -817,7 +842,7 @@ class TestChallengePeriodManagerLogic(TestBase):
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.CHALLENGE, now - DAILY_MS * 3)
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                intraday_drawdown_pct=INTRADAY_DD_PCT + 1.0,
+                current_equity=1.0 - (INTRADAY_DD_PCT + 1.0) / 100,
                 daily_open_equity=1.0,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
@@ -849,7 +874,11 @@ class TestChallengePeriodManagerLogic(TestBase):
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 5)
-            mgr._refresh_drawdown_cache([hk], {hk: account}, {hk: ledger}, {hk: []}, now)
+            # First refresh locks the midnight equity (static EOD = 7%); the second refresh, via the
+            # fast path, records the live balance (static drawdown = 4%). Positions must be non-empty.
+            positions = {hk: [SimpleNamespace()]}
+            mgr._refresh_drawdown_cache([hk], {hk: account}, {hk: ledger}, positions, now)
+            mgr._refresh_drawdown_cache([hk], {hk: account}, {hk: ledger}, positions, now)
 
             dd = mgr.miner_states[hk].drawdown
             self.assertAlmostEqual(dd.static_drawdown_pct, 4.0, delta=1e-6)
@@ -862,20 +891,20 @@ class TestChallengePeriodManagerLogic(TestBase):
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now)
-            mgr.miner_states[hk].drawdown = DrawdownStats(static_drawdown_pct=1.5, static_eod_drawdown_pct=2.5)
+            mgr.miner_states[hk].drawdown = DrawdownStats(current_balance=1.0 - 1.5 / 100, last_eod_equity=1.0 - 2.5 / 100)
             mgr._asset_selection_client.get_asset_selection.return_value = MinerAssetClass.CRYPTO
 
             stats = mgr.get_drawdown_stats(hk)
-            self.assertEqual(stats["static_drawdown_pct"], 1.5)
-            self.assertEqual(stats["static_eod_drawdown_pct"], 2.5)
+            self.assertAlmostEqual(stats["static_drawdown_pct"], 1.5)
+            self.assertAlmostEqual(stats["static_eod_drawdown_pct"], 2.5)
             self.assertEqual(stats["static_drawdown_threshold"], ValiConfig.SUBACCOUNT_STATIC_DRAWDOWN_THRESHOLD)
             self.assertEqual(stats["static_eod_drawdown_threshold"], ValiConfig.SUBACCOUNT_STATIC_EOD_DRAWDOWN_THRESHOLD)
 
-    # ── Section 7: Static rules effective-time gate ───────────────────────────
+    # ── Section 7: Static vs legacy rules by stored drawdown_criteria ──────────
 
     def test_refresh_pre_effective_subaccount_keeps_legacy_rules(self):
-        """Subaccounts registered before the effective time still eliminate immediately
-        on the legacy intraday rule (no activation gate for subaccounts)."""
+        """A subaccount whose stored drawdown_criteria is TRAILING eliminates immediately
+        on the legacy intraday rule — subaccounts bypass the regular-miner activation gate."""
         now = STATIC_EFFECTIVE_MS - DAILY_MS  # also before DRAWDOWN_ACTIVATION_MS
         hk = "hk_pre_effective_legacy"
         mgr, stack = self._make_manager()
@@ -885,7 +914,7 @@ class TestChallengePeriodManagerLogic(TestBase):
                 BucketEntry(MinerBucket.SUBACCOUNT_FUNDED, STATIC_EFFECTIVE_MS - DAILY_MS * 10),
             ])
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                intraday_drawdown_pct=INTRADAY_DD_PCT + 1.0,
+                current_equity=1.0 - (INTRADAY_DD_PCT + 1.0) / 100,
                 daily_open_equity=1.0,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 30)
@@ -896,7 +925,7 @@ class TestChallengePeriodManagerLogic(TestBase):
             self.assertEqual(kwargs["reason"], EliminationReason.FAILED_FUNDED_PERIOD_INTRADAY_DRAWDOWN)
 
     def test_refresh_pre_effective_subaccount_ignores_static_stats(self):
-        """Subaccounts registered before the effective time are not evaluated against the static rules."""
+        """A subaccount whose stored drawdown_criteria is TRAILING is not evaluated against the static rules."""
         now = STATIC_EFFECTIVE_MS + DAILY_MS
         hk = "hk_pre_effective_static"
         mgr, stack = self._make_manager()
@@ -905,9 +934,12 @@ class TestChallengePeriodManagerLogic(TestBase):
                 BucketEntry(MinerBucket.SUBACCOUNT_CHALLENGE, STATIC_EFFECTIVE_MS - DAILY_MS * 30),
                 BucketEntry(MinerBucket.SUBACCOUNT_FUNDED, STATIC_EFFECTIVE_MS - DAILY_MS * 10),
             ])
+            # Bad static stats (50% each) that a TRAILING subaccount ignores; eod_hwm == last_eod_equity
+            # keeps the legacy EOD rule clean so it does not eliminate on the legacy path either.
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                static_drawdown_pct=50.0,
-                static_eod_drawdown_pct=50.0,
+                current_balance=0.5,
+                eod_hwm=0.5,
+                last_eod_equity=0.5,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 30)
             self._refresh_with_patched_caches(mgr, now)
@@ -916,13 +948,13 @@ class TestChallengePeriodManagerLogic(TestBase):
             mgr._elimination_client.append_elimination_row.assert_not_called()
 
     def test_refresh_subaccount_registered_at_effective_uses_static_rules(self):
-        """Registration exactly at the effective time uses the static rules (>= comparison)."""
+        """A subaccount whose stored drawdown_criteria is STATIC is evaluated under the static rules."""
         now = STATIC_EFFECTIVE_MS + DAILY_MS
         hk = "hk_at_effective"
         mgr, stack = self._make_manager()
         with stack:
-            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_CHALLENGE, STATIC_EFFECTIVE_MS)
-            mgr.miner_states[hk].drawdown = DrawdownStats(static_drawdown_pct=STATIC_DD_PCT + 1.0)
+            mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_CHALLENGE, STATIC_EFFECTIVE_MS, drawdown_criteria=DrawdownCriteria.STATIC)
+            mgr.miner_states[hk].drawdown = DrawdownStats(current_balance=1.0 - (STATIC_DD_PCT + 1.0) / 100)
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS)
             self._refresh_with_patched_caches(mgr, now)
 
@@ -931,8 +963,8 @@ class TestChallengePeriodManagerLogic(TestBase):
             self.assertEqual(kwargs["reason"], EliminationReason.FAILED_CHALLENGE_PERIOD_STATIC_DRAWDOWN)
 
     def test_refresh_funded_promoted_after_effective_keeps_legacy_rules(self):
-        """The gate keys on SUBACCOUNT_CHALLENGE registration time, not the promotion time:
-        a miner registered before the effective time keeps legacy rules even when promoted after it."""
+        """A subaccount whose stored drawdown_criteria is TRAILING keeps the legacy rules
+        regardless of when it was promoted, eliminating immediately on the intraday rule."""
         now = STATIC_EFFECTIVE_MS + DAILY_MS * 8
         hk = "hk_promoted_after"
         mgr, stack = self._make_manager()
@@ -941,10 +973,11 @@ class TestChallengePeriodManagerLogic(TestBase):
                 BucketEntry(MinerBucket.SUBACCOUNT_CHALLENGE, STATIC_EFFECTIVE_MS - DAILY_MS * 30),
                 BucketEntry(MinerBucket.SUBACCOUNT_FUNDED, STATIC_EFFECTIVE_MS + DAILY_MS * 5),
             ])
+            # Trips the legacy intraday rule; the bad static balance (50%) is ignored under TRAILING.
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                intraday_drawdown_pct=INTRADAY_DD_PCT + 1.0,
+                current_equity=1.0 - (INTRADAY_DD_PCT + 1.0) / 100,
+                current_balance=0.5,
                 daily_open_equity=1.0,
-                static_drawdown_pct=50.0,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 30)
             self._refresh_with_patched_caches(mgr, now)
@@ -954,16 +987,19 @@ class TestChallengePeriodManagerLogic(TestBase):
             self.assertEqual(kwargs["reason"], EliminationReason.FAILED_FUNDED_PERIOD_INTRADAY_DRAWDOWN)
 
     def test_refresh_hyperscaled_subaccount_ignores_static_rules(self):
-        """Hyperscaled (HL_ALL) subaccounts are excluded from the static rules even when
-        registered after the effective time."""
+        """Hyperscaled (HL_ALL) subaccounts opt out of the static rules upstream at creation, so
+        their stored drawdown_criteria stays TRAILING and refresh ignores the static stats."""
         now = STATIC_EFFECTIVE_MS + DAILY_MS * 4
         hk = "hk_hyperscaled_static"
         mgr, stack = self._make_manager()
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3)
+            # Bad static stats (50% each) ignored under TRAILING; eod_hwm == last_eod_equity keeps
+            # the legacy EOD rule clean so it does not eliminate on the legacy path either.
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                static_drawdown_pct=50.0,
-                static_eod_drawdown_pct=50.0,
+                current_balance=0.5,
+                eod_hwm=0.5,
+                last_eod_equity=0.5,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)
             mgr._asset_selection_client.get_asset_selections.return_value = {hk: MinerAssetClass.HL_ALL}
@@ -980,7 +1016,7 @@ class TestChallengePeriodManagerLogic(TestBase):
         with stack:
             mgr.set_miner_bucket(hk, MinerBucket.SUBACCOUNT_FUNDED, now - DAILY_MS * 3)
             mgr.miner_states[hk].drawdown = DrawdownStats(
-                intraday_drawdown_pct=INTRADAY_DD_PCT + 1.0,
+                current_equity=1.0 - (INTRADAY_DD_PCT + 1.0) / 100,
                 daily_open_equity=1.0,
             )
             _wire_refresh_clients(mgr, hk, now, elapsed_ms=DAILY_MS * 3)

--- a/tests/vali_tests/test_challengeperiod_integration.py
+++ b/tests/vali_tests/test_challengeperiod_integration.py
@@ -53,6 +53,14 @@ INTRADAY_DD_PCT = ValiConfig.CHALLENGE_INTRADAY_DRAWDOWN_THRESHOLD * 100
 EOD_DD_PCT = ValiConfig.CHALLENGE_EOD_DRAWDOWN_THRESHOLD * 100
 STATIC_DD_PCT = ValiConfig.SUBACCOUNT_STATIC_DRAWDOWN_THRESHOLD * 100
 STATIC_EOD_DD_PCT = ValiConfig.SUBACCOUNT_STATIC_EOD_DRAWDOWN_THRESHOLD * 100
+# A test-local clock anchor for the static-drawdown scenarios. Deliberately NOT
+# a ValiConfig constant: production has no global "static rules effective time" —
+# the validator branches purely on the per-subaccount drawdown_criteria stored at
+# creation (see ChallengePeriodManager.refresh), so the only thing these tests
+# need is a stable timestamp to build bucket histories around. Canonical
+# DrawdownStats initialization: set the underlying fields (current_equity,
+# current_balance, eod_hwm, last_eod_equity); every *_drawdown_pct is a computed
+# @property, never a constructor argument.
 STATIC_EFFECTIVE_MS = TimeUtil.formatted_date_str_to_millis("2026-09-05 00:00:00")
 
 _CLIENT_PATHS = [
@@ -525,8 +533,12 @@ class TestChallengePeriodManagerLogic(TestBase):
         self.assertEqual(mgr.get_miner_bucket(hk), MinerBucket.ELIMINATED)
 
     def test_refresh_healthy_miner_unchanged_no_disk_write(self):
-        """Brand-new miner with no issues triggers no bucket change and no account sync
-        (the end-of-cycle disk save still runs unconditionally)."""
+        """Brand-new miner with no issues triggers no bucket change and no account sync.
+
+        Note: refresh() persists to disk unconditionally at the end of every cycle
+        (ChallengePeriodManager.refresh -> _save_to_disk), so unlike the pre-#866
+        behavior this test asserts the save IS called; "no state change" is still
+        enforced via the untouched bucket and the absence of an account sync."""
         now = TimeUtil.now_in_millis()
         hk = "hk_healthy"
         mgr, stack = self._make_manager()

--- a/tests/vali_tests/test_entity_collateral.py
+++ b/tests/vali_tests/test_entity_collateral.py
@@ -21,6 +21,12 @@ from vali_objects.utils.vali_utils import ValiUtils
 from vali_objects.vali_config import ValiConfig
 from time_util.time_util import TimeUtil
 
+# The slash cap is account_size * FUNDED_INTRADAY_DRAWDOWN_THRESHOLD. Derive it
+# from the config rather than hardcoding a percentage so these tests stay
+# correct when the threshold changes (it moved 0.10 -> 0.08 -> 0.05; the old
+# tests hardcoded the 0.08 era's $8K values for a $100K account).
+MAX_SLASH_100K = 100_000 * ValiConfig.FUNDED_INTRADAY_DRAWDOWN_THRESHOLD
+
 
 class TestEntityCollateral(TestBase):
     """
@@ -321,21 +327,21 @@ class TestEntityCollateral(TestBase):
         )
         self._set_collateral_cache(entity_hotkey, 100.0)
 
-        # max_slash = $100K * 8% = $8K
+        # max_slash = MAX_SLASH_100K (account_size * MDD)
 
         # Trade 1: Lose $3K
         slashed_1 = self.entity_collateral_client.slash_on_realized_loss(
             entity_hotkey, synthetic_hotkey, 3_000.0
         )
-        self.assertAlmostEqual(slashed_1, 3_000.0)
+        self.assertAlmostEqual(slashed_1, min(3_000.0, MAX_SLASH_100K))
 
-        # Trade 2: Lose $4K (cumulative_loss = $7K, still under max $8K).
-        # Returns total pending slash (7K = min(7K, 8K) - 0), not incremental (4K),
+        # Trade 2: Lose $4K (cumulative_loss = $7K). Returns total pending slash
+        # (min(cumulative_loss, max_slash) - cumulative_slashed), not incremental,
         # because cumulative_slashed stays 0 until process_pending_slashes runs.
         slashed_2 = self.entity_collateral_client.slash_on_realized_loss(
             entity_hotkey, synthetic_hotkey, 4_000.0
         )
-        self.assertAlmostEqual(slashed_2, 7_000.0)
+        self.assertAlmostEqual(slashed_2, min(7_000.0, MAX_SLASH_100K))
 
         # Verify cumulative tracking
         tracking = self._get_slash_tracking(synthetic_hotkey)
@@ -349,21 +355,21 @@ class TestEntityCollateral(TestBase):
         )
         self._set_collateral_cache(entity_hotkey, 100.0)
 
-        # max_slash = $100K * 8% = $8K
+        # max_slash = MAX_SLASH_100K (account_size * MDD)
 
-        # Trade 1: Lose $8K → exactly at cap, slash $8K
+        # Trade 1: Lose $8K (>= cap) → slash is capped at max_slash
         slashed_1 = self.entity_collateral_client.slash_on_realized_loss(
             entity_hotkey, synthetic_hotkey, 8_000.0
         )
-        self.assertAlmostEqual(slashed_1, 8_000.0)
+        self.assertAlmostEqual(slashed_1, MAX_SLASH_100K)
 
-        # Trade 2: Lose $5K → still returns 8K (total pending, capped at max_slash).
-        # cumulative_slashed stays 0 until process_pending_slashes runs, so the
-        # pending remains at the cap (8K) rather than going to 0.
+        # Trade 2: Lose $5K more → still returns the cap (total pending, capped
+        # at max_slash). cumulative_slashed stays 0 until process_pending_slashes
+        # runs, so the pending remains at the cap rather than going to 0.
         slashed_2 = self.entity_collateral_client.slash_on_realized_loss(
             entity_hotkey, synthetic_hotkey, 5_000.0
         )
-        self.assertAlmostEqual(slashed_2, 8_000.0)
+        self.assertAlmostEqual(slashed_2, MAX_SLASH_100K)
 
         # cumulative_realized_loss tracks all losses; cumulative_slashed stays 0
         # until process_pending_slashes commits the on-chain slash.
@@ -644,15 +650,15 @@ class TestEntityCollateral(TestBase):
         )
         self._set_collateral_cache(entity_hotkey, 100.0)
 
-        # max_slash = $8K, loss exactly $8K
+        # loss exactly max_slash
         slashed = self.entity_collateral_client.slash_on_realized_loss(
-            entity_hotkey, synthetic_hotkey, 8_000.0
+            entity_hotkey, synthetic_hotkey, MAX_SLASH_100K
         )
-        self.assertAlmostEqual(slashed, 8_000.0)
+        self.assertAlmostEqual(slashed, MAX_SLASH_100K)
 
-        # cumulative_realized_loss = 8K; cumulative_slashed stays 0 until process_pending_slashes
+        # cumulative_realized_loss = max_slash; cumulative_slashed stays 0 until process_pending_slashes
         tracking = self._get_slash_tracking(synthetic_hotkey)
-        self.assertAlmostEqual(tracking["cumulative_realized_loss"], 8_000.0)
+        self.assertAlmostEqual(tracking["cumulative_realized_loss"], MAX_SLASH_100K)
         self.assertAlmostEqual(tracking["cumulative_slashed"], 0.0)
 
     def test_slash_loss_exceeds_max_slash_single_trade(self):
@@ -662,11 +668,11 @@ class TestEntityCollateral(TestBase):
         )
         self._set_collateral_cache(entity_hotkey, 100.0)
 
-        # max_slash = $8K, loss = $50K → only slash $8K
+        # loss = $50K >> max_slash → capped at max_slash
         slashed = self.entity_collateral_client.slash_on_realized_loss(
             entity_hotkey, synthetic_hotkey, 50_000.0
         )
-        self.assertAlmostEqual(slashed, 8_000.0)
+        self.assertAlmostEqual(slashed, MAX_SLASH_100K)
 
         tracking = self._get_slash_tracking(synthetic_hotkey)
         self.assertAlmostEqual(tracking["cumulative_realized_loss"], 50_000.0)
@@ -690,8 +696,8 @@ class TestEntityCollateral(TestBase):
                 entity_hotkey, synthetic_hotkey, float(loss)
             )
 
-        # Total losses = $15K > max_slash = $8K → last call returns 8K (at cap)
-        self.assertAlmostEqual(last_slash, 8_000.0)
+        # Total losses = $15K > max_slash → last call returns the cap
+        self.assertAlmostEqual(last_slash, MAX_SLASH_100K)
 
         # All losses are tracked; cumulative_slashed stays 0 until process_pending_slashes
         tracking = self._get_slash_tracking(synthetic_hotkey)
@@ -737,13 +743,16 @@ class TestEntityCollateral(TestBase):
         self.assertIn("_entity_client", source)
 
     def test_validator_contract_manager_withdrawal_blocking_code_exists(self):
-        """Test that process_withdrawal_request contains entity withdrawal blocking logic."""
+        """The withdrawal path blocks a withdrawal that would drop below the
+        entity's required cross-margin collateral. That logic lives in
+        query_withdrawal_request (called by process_withdrawal_request); it was
+        refactored out of process_withdrawal_request, so inspect the method that
+        actually holds it now."""
         from vali_objects.contract.validator_contract_manager import ValidatorContractManager
         import inspect
-        source = inspect.getsource(ValidatorContractManager.process_withdrawal_request)
-        self.assertIn("entity_data", source)
-        self.assertIn("required_theta", source)
-        self.assertIn("subaccount", source.lower())
+        source = inspect.getsource(ValidatorContractManager.query_withdrawal_request)
+        self.assertIn("compute_entity_required_collateral", source)
+        self.assertIn("required_min_theta", source)
 
     # ==================== Validator.py Wiring Tests ====================
 

--- a/tests/vali_tests/test_entity_miner_gateway.py
+++ b/tests/vali_tests/test_entity_miner_gateway.py
@@ -15,8 +15,8 @@ import asyncio
 import json
 import time
 import unittest
-from collections import defaultdict, deque
-from unittest.mock import MagicMock, AsyncMock, patch
+from collections import defaultdict
+from unittest.mock import MagicMock
 
 from tests.vali_tests.base_objects.test_base import TestBase
 
@@ -161,350 +161,6 @@ class TestOrderEventStore(TestBase):
         self.assertEqual(store.get_events(addr2)[0]["trade_pair"], "ETHUSD")
 
 
-# ==================== WebSocket Server Entity Auth Tests ====================
-
-class TestWebSocketEntityAuth(unittest.IsolatedAsyncioTestCase):
-    """Tests for the WebSocket server entity authentication flow."""
-
-    def _make_server(self):
-        """Create a minimal WebSocketServer-like object for testing auth methods."""
-        from vanta_api.websocket_server import (
-            WebSocketServer
-        )
-
-        server = object.__new__(WebSocketServer)
-        # Initialize only the state we need
-        server.connected_clients = {}
-        server.client_auth = {}
-        server.api_key_clients = defaultdict(deque)
-        server.entity_clients = defaultdict(deque)
-        server._entity_auth_nonces = defaultdict(dict)
-        server._entity_nonce_lock = asyncio.Lock()
-        server.subscribed_clients = set()
-        server.subaccount_subscriptions = defaultdict(set)
-        server.subaccount_last_broadcast_ms = {}
-        server._subaccount_poll_tasks = {}
-        server.sequence_number = 0
-        server.loop = asyncio.get_event_loop()
-        server._entity_client = MagicMock()
-        server.api_key_to_alias = {}
-        return server
-
-    def _mock_websocket(self):
-        """Create a mock WebSocket with async send/close."""
-        ws = MagicMock()
-        ws.send = AsyncMock()
-        ws.close = AsyncMock()
-        return ws
-
-    # --- Nonce Cleanup ---
-
-    def test_cleanup_expired_nonces(self):
-        """Expired nonces are removed during cleanup."""
-        from vanta_api.websocket_server import ENTITY_AUTH_TIMESTAMP_TTL_MS
-
-        server = self._make_server()
-        entity = "5EntityHotkey"
-        now = 10_000_000
-
-        # Add nonces: some expired, some valid
-        server._entity_auth_nonces[entity] = {
-            "old1": now - ENTITY_AUTH_TIMESTAMP_TTL_MS - 1000,  # expired
-            "old2": now - ENTITY_AUTH_TIMESTAMP_TTL_MS - 500,   # expired
-            "new1": now - 1000,                                  # valid
-            "new2": now - 500,                                   # valid
-        }
-
-        server._cleanup_expired_nonces(entity, now)
-
-        self.assertEqual(len(server._entity_auth_nonces[entity]), 2)
-        self.assertIn("new1", server._entity_auth_nonces[entity])
-        self.assertIn("new2", server._entity_auth_nonces[entity])
-        self.assertNotIn("old1", server._entity_auth_nonces[entity])
-
-    def test_cleanup_nonces_bounded(self):
-        """Nonce set is bounded to ENTITY_AUTH_MAX_NONCES."""
-        from vanta_api.websocket_server import ENTITY_AUTH_MAX_NONCES
-
-        server = self._make_server()
-        entity = "5EntityHotkey"
-        now = 10_000_000
-
-        # Add more than max nonces, all valid
-        for i in range(ENTITY_AUTH_MAX_NONCES + 100):
-            server._entity_auth_nonces[entity][f"nonce_{i}"] = now - i
-
-        server._cleanup_expired_nonces(entity, now)
-
-        self.assertEqual(len(server._entity_auth_nonces[entity]), ENTITY_AUTH_MAX_NONCES)
-
-    def test_cleanup_nonces_empty(self):
-        """Cleanup on empty nonce set is a no-op."""
-        server = self._make_server()
-        server._cleanup_expired_nonces("nonexistent", 10000)
-        # Should not raise
-
-    # --- _authenticate_entity ---
-
-    async def test_entity_auth_missing_fields(self):
-        """Auth fails when required fields are missing."""
-        server = self._make_server()
-        ws = self._mock_websocket()
-
-        result = await server._authenticate_entity("c1", ws, {
-            "entity_hotkey": "5abc",
-            # Missing timestamp, nonce, signature
-        })
-
-        self.assertFalse(result)
-        ws.send.assert_called_once()
-        msg = json.loads(ws.send.call_args[0][0])
-        self.assertEqual(msg["status"], "error")
-        self.assertIn("requires", msg["message"])
-
-    async def test_entity_auth_expired_timestamp(self):
-        """Auth fails when timestamp is outside the TTL window."""
-        server = self._make_server()
-        ws = self._mock_websocket()
-
-        old_timestamp = int(time.time() * 1000) - 10 * 60 * 1000  # 10 min ago
-
-        result = await server._authenticate_entity("c1", ws, {
-            "entity_hotkey": "5abc",
-            "timestamp": old_timestamp,
-            "nonce": "unique-nonce",
-            "signature": "deadbeef"
-        })
-
-        self.assertFalse(result)
-        msg = json.loads(ws.send.call_args[0][0])
-        self.assertIn("expired", msg["message"].lower())
-
-    async def test_entity_auth_nonce_replay(self):
-        """Auth fails when nonce has already been used."""
-        server = self._make_server()
-        ws = self._mock_websocket()
-        entity = "5EntityKey"
-        now_ms = int(time.time() * 1000)
-
-        # Pre-register a nonce
-        server._entity_auth_nonces[entity]["used-nonce"] = now_ms
-
-        result = await server._authenticate_entity("c1", ws, {
-            "entity_hotkey": entity,
-            "timestamp": now_ms,
-            "nonce": "used-nonce",
-            "signature": "deadbeef"
-        })
-
-        self.assertFalse(result)
-        msg = json.loads(ws.send.call_args[0][0])
-        self.assertIn("Nonce already used", msg["message"])
-
-    async def test_entity_auth_unregistered_entity(self):
-        """Auth fails when entity is not registered."""
-        server = self._make_server()
-        ws = self._mock_websocket()
-        now_ms = int(time.time() * 1000)
-
-        server._entity_client.get_entity_data.return_value = None
-
-        result = await server._authenticate_entity("c1", ws, {
-            "entity_hotkey": "5Unregistered",
-            "timestamp": now_ms,
-            "nonce": "fresh-nonce",
-            "signature": "deadbeef"
-        })
-
-        self.assertFalse(result)
-        msg = json.loads(ws.send.call_args[0][0])
-        self.assertIn("not registered", msg["message"])
-
-    async def test_entity_auth_invalid_signature(self):
-        """Auth fails when signature doesn't verify."""
-        server = self._make_server()
-        ws = self._mock_websocket()
-        now_ms = int(time.time() * 1000)
-
-        server._entity_client.get_entity_data.return_value = {"subaccounts": {}}
-
-        # Use a valid-looking but wrong signature
-        result = await server._authenticate_entity("c1", ws, {
-            "entity_hotkey": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            "timestamp": now_ms,
-            "nonce": "fresh-nonce",
-            "signature": "00" * 64  # Wrong signature
-        })
-
-        self.assertFalse(result)
-        # Should fail at signature verification
-        msg = json.loads(ws.send.call_args[0][0])
-        self.assertEqual(msg["status"], "error")
-
-    async def test_entity_auth_success(self):
-        """Full entity auth succeeds with valid signature."""
-        server = self._make_server()
-        ws = self._mock_websocket()
-
-        try:
-            from bittensor_wallet import Keypair
-        except ImportError:
-            self.skipTest("bittensor_wallet not installed")
-
-        # Generate a real keypair for testing
-        keypair = Keypair.create_from_mnemonic(Keypair.generate_mnemonic())
-        entity_hotkey = keypair.ss58_address
-        now_ms = int(time.time() * 1000)
-        nonce = "test-nonce-123"
-
-        # Sign the auth message
-        message_dict = {
-            "entity_hotkey": entity_hotkey,
-            "nonce": nonce,
-            "timestamp": now_ms
-        }
-        message_bytes = json.dumps(message_dict, sort_keys=True).encode('utf-8')
-        signature = keypair.sign(message_bytes).hex()
-
-        # Mock entity data with one active subaccount
-        server._entity_client.get_entity_data.return_value = {
-            "subaccounts": {
-                "0": {
-                    "status": "active",
-                    "synthetic_hotkey": f"{entity_hotkey}_0"
-                }
-            }
-        }
-
-        # Mock _ensure_subaccount_poll_task to avoid event loop issues
-        server._ensure_subaccount_poll_task = MagicMock()
-
-        result = await server._authenticate_entity("c1", ws, {
-            "entity_hotkey": entity_hotkey,
-            "timestamp": now_ms,
-            "nonce": nonce,
-            "signature": signature
-        })
-
-        self.assertTrue(result)
-        # Client should be registered
-        self.assertIn("c1", server.connected_clients)
-        self.assertEqual(server.client_auth["c1"]["auth_type"], "entity")
-        self.assertEqual(server.client_auth["c1"]["entity_hotkey"], entity_hotkey)
-        # Should be in entity_clients
-        self.assertIn("c1", server.entity_clients[entity_hotkey])
-        # Should be auto-subscribed to the subaccount
-        self.assertIn("c1", server.subaccount_subscriptions[f"{entity_hotkey}_0"])
-
-        # Auth success message sent
-        last_send = ws.send.call_args_list[-1]
-        msg = json.loads(last_send[0][0])
-        self.assertEqual(msg["status"], "success")
-        self.assertEqual(msg["auth_type"], "entity")
-        self.assertEqual(msg["subscribed_subaccounts"], 1)
-
-    async def test_entity_auth_fifo_eviction(self):
-        """Oldest entity client is evicted when MAX_N_WS_PER_ENTITY is reached."""
-        from vanta_api.websocket_server import MAX_N_WS_PER_ENTITY
-
-        server = self._make_server()
-        entity = "5EntityKey"
-
-        try:
-            from bittensor_wallet import Keypair
-        except ImportError:
-            self.skipTest("bittensor_wallet not installed")
-
-        keypair = Keypair.create_from_mnemonic(Keypair.generate_mnemonic())
-        entity = keypair.ss58_address
-
-        server._entity_client.get_entity_data.return_value = {"subaccounts": {}}
-        server._ensure_subaccount_poll_task = MagicMock()
-
-        # Fill up to max connections
-        for i in range(MAX_N_WS_PER_ENTITY):
-            client_id = f"client_{i}"
-            mock_ws = self._mock_websocket()
-            server.connected_clients[client_id] = mock_ws
-            server.client_auth[client_id] = {"auth_type": "entity", "entity_hotkey": entity}
-            server.entity_clients[entity].append(client_id)
-
-        self.assertEqual(len(server.entity_clients[entity]), MAX_N_WS_PER_ENTITY)
-
-        # Now authenticate a new client — should evict client_0
-        new_ws = self._mock_websocket()
-        now_ms = int(time.time() * 1000)
-        nonce = "eviction-nonce"
-        msg_dict = {"entity_hotkey": entity, "nonce": nonce, "timestamp": now_ms}
-        sig = keypair.sign(json.dumps(msg_dict, sort_keys=True).encode()).hex()
-
-        result = await server._authenticate_entity("new_client", new_ws, {
-            "entity_hotkey": entity, "timestamp": now_ms, "nonce": nonce, "signature": sig
-        })
-
-        self.assertTrue(result)
-        self.assertNotIn("client_0", server.connected_clients)
-        self.assertIn("new_client", server.entity_clients[entity])
-        self.assertEqual(len(server.entity_clients[entity]), MAX_N_WS_PER_ENTITY)
-
-
-# ==================== Auto-Subscribe Tests ====================
-
-class TestAutoSubscribeEntitySubaccounts(unittest.IsolatedAsyncioTestCase):
-    """Tests for _auto_subscribe_entity_subaccounts."""
-
-    def _make_server(self):
-        from vanta_api.websocket_server import WebSocketServer
-        server = object.__new__(WebSocketServer)
-        server.subaccount_subscriptions = defaultdict(set)
-        server._subaccount_poll_tasks = {}
-        server._ensure_subaccount_poll_task = MagicMock()
-        return server
-
-    async def test_subscribe_active_subaccounts(self):
-        """Auto-subscribes to active and admin subaccounts."""
-        server = self._make_server()
-        entity = "5Entity"
-        entity_data = {
-            "subaccounts": {
-                "0": {"status": "active", "synthetic_hotkey": f"{entity}_0"},
-                "1": {"status": "admin", "synthetic_hotkey": f"{entity}_1"},
-                "2": {"status": "eliminated", "synthetic_hotkey": f"{entity}_2"},
-                "3": {"status": "failed", "synthetic_hotkey": f"{entity}_3"},
-            }
-        }
-
-        count = await server._auto_subscribe_entity_subaccounts("c1", entity, entity_data)
-
-        self.assertEqual(count, 2)  # only active + admin
-        self.assertIn("c1", server.subaccount_subscriptions[f"{entity}_0"])
-        self.assertIn("c1", server.subaccount_subscriptions[f"{entity}_1"])
-        self.assertNotIn(f"{entity}_2", server.subaccount_subscriptions)
-        self.assertNotIn(f"{entity}_3", server.subaccount_subscriptions)
-        self.assertEqual(server._ensure_subaccount_poll_task.call_count, 2)
-
-    async def test_subscribe_no_subaccounts(self):
-        """Zero subscriptions when entity has no subaccounts."""
-        server = self._make_server()
-        count = await server._auto_subscribe_entity_subaccounts("c1", "5Entity", {"subaccounts": {}})
-        self.assertEqual(count, 0)
-
-    async def test_subscribe_generates_synthetic_hotkey(self):
-        """Generates synthetic_hotkey from entity+id if not in subaccount data."""
-        server = self._make_server()
-        entity = "5Entity"
-        entity_data = {
-            "subaccounts": {
-                "0": {"status": "active"}  # No synthetic_hotkey field
-            }
-        }
-
-        count = await server._auto_subscribe_entity_subaccounts("c1", entity, entity_data)
-
-        self.assertEqual(count, 1)
-        self.assertIn("c1", server.subaccount_subscriptions[f"{entity}_0"])
-
-
 # ==================== Scope Enforcement Tests ====================
 
 class TestEntityScopeEnforcement(TestBase):
@@ -538,76 +194,55 @@ class TestEntityScopeEnforcement(TestBase):
         self.assertEqual(parsed_entity, "5Alice")
 
 
-# ==================== Remove Client Entity Cleanup Tests ====================
+# ==================== Remove Client Tests ====================
 
-class TestRemoveClientEntityCleanup(TestBase):
-    """Tests for _remove_client cleaning up entity tracking."""
+class TestRemoveClient(TestBase):
+    """Tests for _remove_client on the WebSocket server (api-key/tier client model)."""
 
     def _make_server(self):
         from vanta_api.websocket_server import WebSocketServer
         server = object.__new__(WebSocketServer)
-        server.connected_clients = {}
-        server.client_auth = {}
-        server.api_key_clients = defaultdict(deque)
-        server.entity_clients = defaultdict(deque)
-        server.subscribed_clients = set()
-        server.subaccount_subscriptions = defaultdict(set)
-        server._subaccount_poll_tasks = {}
+        server._clients = {}
+        server._api_key_client_ids = defaultdict(list)
         server.api_key_to_alias = {}
-        server._cancel_subaccount_poll_task = MagicMock()
+        server._event_loop = None
         return server
 
-    def test_remove_entity_client(self):
-        """Removing an entity client cleans up entity_clients tracking."""
+    def test_remove_api_key_client(self):
+        """Removing a client drops it from _clients and its api-key client list."""
         server = self._make_server()
-        entity = "5EntityKey"
-        ws = MagicMock()
+        client = MagicMock()
+        client.api_key = "key123"
+        client.websocket.state = "CLOSED"  # != State.OPEN, so no async close is scheduled
+        server._clients["c1"] = client
+        server._api_key_client_ids["key123"] = ["c1"]
 
-        # Register client
-        server.connected_clients["c1"] = ws
-        server.client_auth["c1"] = {"auth_type": "entity", "entity_hotkey": entity}
-        server.entity_clients[entity].append("c1")
-        server.subaccount_subscriptions[f"{entity}_0"].add("c1")
-
-        # Remove
         server._remove_client("c1")
 
-        self.assertNotIn("c1", server.connected_clients)
-        self.assertNotIn("c1", server.client_auth)
-        self.assertNotIn(entity, server.entity_clients)  # Empty deque removed
-        self.assertNotIn("c1", server.subaccount_subscriptions.get(f"{entity}_0", set()))
+        self.assertNotIn("c1", server._clients)
+        self.assertNotIn("c1", server._api_key_client_ids["key123"])
 
-    def test_remove_entity_client_preserves_others(self):
-        """Removing one entity client doesn't affect other clients for the same entity."""
+    def test_remove_client_preserves_others(self):
+        """Removing one client leaves the api-key's other clients registered."""
         server = self._make_server()
-        entity = "5EntityKey"
-
-        # Register two clients
         for cid in ["c1", "c2"]:
-            server.connected_clients[cid] = MagicMock()
-            server.client_auth[cid] = {"auth_type": "entity", "entity_hotkey": entity}
-            server.entity_clients[entity].append(cid)
+            client = MagicMock()
+            client.api_key = "key123"
+            client.websocket.state = "CLOSED"
+            server._clients[cid] = client
+        server._api_key_client_ids["key123"] = ["c1", "c2"]
 
         server._remove_client("c1")
 
-        self.assertNotIn("c1", server.connected_clients)
-        self.assertIn("c2", server.connected_clients)
-        self.assertEqual(len(server.entity_clients[entity]), 1)
-        self.assertIn("c2", server.entity_clients[entity])
+        self.assertNotIn("c1", server._clients)
+        self.assertIn("c2", server._clients)
+        self.assertEqual(server._api_key_client_ids["key123"], ["c2"])
 
-    def test_remove_api_key_client_no_entity_side_effects(self):
-        """Removing an API key client doesn't touch entity_clients."""
+    def test_remove_unknown_client_is_noop(self):
+        """Removing an unknown client id does not raise."""
         server = self._make_server()
-
-        server.connected_clients["c1"] = MagicMock()
-        server.client_auth["c1"] = {"auth_type": "api_key", "api_key": "key123", "tier": 100}
-        server.api_key_clients["key123"].append("c1")
-
-        server._remove_client("c1")
-
-        self.assertNotIn("c1", server.connected_clients)
-        # entity_clients should be untouched (empty)
-        self.assertEqual(len(server.entity_clients), 0)
+        server._remove_client("does-not-exist")
+        self.assertEqual(len(server._clients), 0)
 
 
 # ==================== Notify New Subaccount RPC Tests ====================
@@ -618,37 +253,49 @@ class TestNotifyNewSubaccount(TestBase):
     def _make_server(self):
         from vanta_api.websocket_server import WebSocketServer
         server = object.__new__(WebSocketServer)
-        server.connected_clients = {}
-        server.entity_clients = defaultdict(deque)
-        server.subaccount_subscriptions = defaultdict(set)
-        server.subaccount_last_broadcast_ms = {}
-        server._subaccount_poll_tasks = {}
-        server.sequence_number = 0
-        server.loop = None  # Will prevent actual async send
-        server._ensure_subaccount_poll_task = MagicMock()
+        server.api_key_to_alias = {}
+        server._api_key_client_ids = defaultdict(list)
+        server._clients = {}
+        server._event_loop = None  # skips the async subscription-status send
+        server.broadcast_subaccount_dashboard_rpc = MagicMock()
         return server
 
     def test_notify_subscribes_connected_clients(self):
-        """Connected entity clients are auto-subscribed to new subaccount."""
+        """Connected entity clients are dashboard-subscribed to the new subaccount."""
         server = self._make_server()
         entity = "5Entity"
-
-        # Register two clients for this entity
-        server.entity_clients[entity] = deque(["c1", "c2"])
+        api_key = "key-1"
+        server.api_key_to_alias[api_key] = entity
+        server._api_key_client_ids[api_key] = ["c1", "c2"]
+        for cid in ["c1", "c2"]:
+            client = MagicMock()
+            client.dashboard_subscriptions = {}
+            server._clients[cid] = client
 
         result = server.notify_new_subaccount_rpc(entity, f"{entity}_5")
 
         self.assertTrue(result)
-        self.assertIn("c1", server.subaccount_subscriptions[f"{entity}_5"])
-        self.assertIn("c2", server.subaccount_subscriptions[f"{entity}_5"])
-        server._ensure_subaccount_poll_task.assert_called_once_with(f"{entity}_5")
+        self.assertIn(f"{entity}_5", server._clients["c1"].dashboard_subscriptions)
+        self.assertIn(f"{entity}_5", server._clients["c2"].dashboard_subscriptions)
+        server.broadcast_subaccount_dashboard_rpc.assert_called_once_with(f"{entity}_5")
 
     def test_notify_no_connected_clients(self):
-        """Returns True (no-op) when entity has no connected clients."""
+        """Returns True (no-op) and does not broadcast when the entity has no clients."""
         server = self._make_server()
+        server.api_key_to_alias["key-off"] = "5Offline"
+        server._api_key_client_ids["key-off"] = []
+
         result = server.notify_new_subaccount_rpc("5Offline", "5Offline_0")
+
         self.assertTrue(result)
-        self.assertEqual(len(server.subaccount_subscriptions), 0)
+        server.broadcast_subaccount_dashboard_rpc.assert_not_called()
+
+    def test_notify_unknown_entity(self):
+        """Returns True (no-op) when the entity has no api-key mapping yet."""
+        server = self._make_server()
+        result = server.notify_new_subaccount_rpc("5Unmapped", "5Unmapped_0")
+        self.assertTrue(result)
+        server.broadcast_subaccount_dashboard_rpc.assert_not_called()
 
 
 # ==================== WebSocketNotifierClient Tests ====================
@@ -689,85 +336,70 @@ class TestWebSocketNotifierClientNewMethod(TestBase):
 # ==================== HyperliquidTracker Rejection Broadcast Tests ====================
 
 class TestHLTrackerRejectionBroadcasts(TestBase):
-    """Tests for rejection broadcast calls in HyperliquidTracker._process_fill."""
+    """Tests for rejection/acceptance broadcast calls in HyperliquidTracker."""
 
-    def _make_tracker(self):
+    def _make_tracker(self, ws_notifier_client="__default__"):
         """Create a HyperliquidTracker with all dependencies mocked."""
         from entity_management.hyperliquid_tracker import HyperliquidTracker
+        from vali_objects.vali_config import RPCConnectionMode
 
-        tracker = HyperliquidTracker(
+        notifier = MagicMock() if ws_notifier_client == "__default__" else ws_notifier_client
+        return HyperliquidTracker(
             entity_client=MagicMock(),
-            elimination_client=MagicMock(),
             price_fetcher_client=MagicMock(),
-            asset_selection_client=MagicMock(),
-            limit_order_client=MagicMock(),
-            ws_notifier_client=MagicMock(),
+            order_processor=MagicMock(),
+            ws_notifier_client=notifier,
+            connection_mode=RPCConnectionMode.LOCAL,
         )
-        return tracker
 
     def _make_fill(self, coin="BTC", side="B", sz="1.0", px="50000"):
         return {"coin": coin, "side": side, "sz": sz, "px": px}
 
-    def _setup_valid_fill_path(self, tracker, synthetic="5Entity_0"):
-        """Configure mocks so fill passes coin/hotkey resolution but hits fail-early checks."""
-        from vali_objects.vali_config import TradePair
-
-        # Coin resolves to a valid trade pair via static registry
-        tracker._hl_universe = {
-            "BTC": TradePair.BTCUSDC,
-        }
+    def _setup_order_path(self, tracker, synthetic="5Entity_0"):
+        """Mock every dependency so a fill reaches _order_processor.validate / _dispatch_order."""
         tracker._entity_client.get_synthetic_hotkey_for_hl_address.return_value = synthetic
-        tracker._entity_client.get_subaccount_info_for_synthetic.return_value = {
-            "account_size": 100_000
-        }
+        tracker._entity_client.get_subaccount_info_for_synthetic.return_value = {"account_size": 100_000}
+        tracker._rate_limiter = MagicMock()
+        tracker._rate_limiter.is_allowed.return_value = (True, 0)
+        tracker._fetch_hl_account_state = MagicMock(return_value={
+            "total_portfolio_value": 100_000,
+            "positions": {"BTC": {"weight": 0.3}},
+        })
+        tracker._position_client = MagicMock()
+        tracker._position_client.get_open_position_for_trade_pair.return_value = None
+        tracker._miner_account_client = MagicMock()
+        tracker._miner_account_client.get_balance.return_value = 100_000
+        price = MagicMock()
+        price.close = 50_000.0
+        tracker._price_fetcher_client.get_sorted_price_sources_for_trade_pair.return_value = [price]
+        tracker._compute_fill_price = MagicMock(return_value=50_000.0)
 
     def test_broadcast_rejection_calls_notifier(self):
-        """_broadcast_rejection sends error via ws_notifier_client."""
+        """_broadcast_rejection broadcasts the subaccount dashboard."""
         tracker = self._make_tracker()
-
         tracker._broadcast_rejection("5Entity_0", "Test error message")
-
-        tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once_with(
-            "5Entity_0"
-        )
+        tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once_with("5Entity_0")
 
     def test_broadcast_rejection_no_notifier(self):
         """_broadcast_rejection is a no-op when ws_notifier_client is None."""
-        from entity_management.hyperliquid_tracker import HyperliquidTracker
-
-        tracker = HyperliquidTracker(
-            entity_client=MagicMock(),
-            elimination_client=MagicMock(),
-            price_fetcher_client=MagicMock(),
-            asset_selection_client=MagicMock(),
-            limit_order_client=MagicMock(),
-            uuid_tracker=MagicMock(),
-            ws_notifier_client=None,
-        )
-        # Should not raise
-        tracker._broadcast_rejection("5Entity_0", "No crash")
+        tracker = self._make_tracker(ws_notifier_client=None)
+        tracker._broadcast_rejection("5Entity_0", "No crash")  # must not raise
 
     def test_broadcast_accepted_fill_calls_notifier(self):
-        """Accepted fills are broadcast as order_event payloads."""
+        """Accepted fills broadcast the subaccount dashboard."""
         tracker = self._make_tracker()
-
         tracker._broadcast_accepted_fill(
             synthetic_hotkey="5Entity_0",
             trade_pair="BTCUSD",
             order_type="LONG",
             fill_hash="0xabc123",
         )
-
-        tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once_with(
-            "5Entity_0"
-        )
+        tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once_with("5Entity_0")
 
     def test_rate_limit_rejection_broadcasts(self):
-        """Rate limiting rejection triggers broadcast with wait time."""
+        """A rate-limited fill triggers a rejection broadcast."""
         tracker = self._make_tracker()
-        self._setup_valid_fill_path(tracker)
-
-        # Rate limiter rejects
+        tracker._entity_client.get_synthetic_hotkey_for_hl_address.return_value = "5Entity_0"
         tracker._rate_limiter = MagicMock()
         tracker._rate_limiter.is_allowed.return_value = (False, 5.0)
 
@@ -775,71 +407,37 @@ class TestHLTrackerRejectionBroadcasts(TestBase):
 
         tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once()
 
-    def test_elimination_rejection_broadcasts(self):
-        """Eliminated miner rejection triggers broadcast."""
+    def test_validate_rejection_broadcasts(self):
+        """A fill rejected by the order processor's pre-trade validation broadcasts."""
         tracker = self._make_tracker()
-        self._setup_valid_fill_path(tracker)
-
-        # Rate limiter allows
-        tracker._rate_limiter = MagicMock()
-        tracker._rate_limiter.is_allowed.return_value = (True, 0)
-
-        # Elimination check returns data (eliminated)
-        tracker._elimination_client.get_elimination_local_cache.return_value = {"reason": "mdd"}
+        self._setup_order_path(tracker)
+        tracker._order_processor.validate.return_value = (False, "Miner eliminated", None)
 
         tracker._process_fill("0xaddr", self._make_fill())
 
         tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once()
 
     def test_signal_exception_rejection_broadcasts(self):
-        """SignalException during order processing triggers broadcast."""
+        """A SignalException raised while dispatching the order broadcasts a rejection."""
         from vali_objects.exceptions.signal_exception import SignalException
 
         tracker = self._make_tracker()
-        self._setup_valid_fill_path(tracker)
+        self._setup_order_path(tracker)
+        tracker._order_processor.validate.return_value = (True, "", None)
+        tracker._order_processor.process_hyperliquid_order.side_effect = SignalException("Leverage too high")
 
-        tracker._rate_limiter = MagicMock()
-        tracker._rate_limiter.is_allowed.return_value = (True, 0)
-        tracker._elimination_client.get_elimination_local_cache.return_value = None
-        tracker._entity_client.validate_hotkey_for_orders.return_value = {"is_valid": True}
-
-        tracker._price_fetcher_client.is_market_open.return_value = True
-        tracker._fetch_hl_account_state = MagicMock(return_value={
-            "total_portfolio_value": 100_000,
-            "positions": {"BTC": {"weight": 0.3}},
-        })
-        tracker._position_client = MagicMock()
-        tracker._position_client.get_open_position_for_trade_pair.return_value = None
-
-        with patch('entity_management.hyperliquid_tracker.OrderProcessor') as mock_op:
-            mock_op.process_order.side_effect = SignalException("Leverage too high")
-
-            tracker._process_fill("0xaddr", self._make_fill())
+        tracker._process_fill("0xaddr", self._make_fill())
 
         tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once()
 
     def test_unexpected_exception_rejection_broadcasts(self):
-        """Unexpected exceptions during order processing also trigger rejection broadcast."""
+        """An unexpected exception while dispatching the order also broadcasts a rejection."""
         tracker = self._make_tracker()
-        self._setup_valid_fill_path(tracker)
+        self._setup_order_path(tracker)
+        tracker._order_processor.validate.return_value = (True, "", None)
+        tracker._order_processor.process_hyperliquid_order.side_effect = ValueError("boom")
 
-        tracker._rate_limiter = MagicMock()
-        tracker._rate_limiter.is_allowed.return_value = (True, 0)
-        tracker._elimination_client.get_elimination_local_cache.return_value = None
-        tracker._entity_client.validate_hotkey_for_orders.return_value = {"is_valid": True}
-
-        tracker._price_fetcher_client.is_market_open.return_value = True
-        tracker._fetch_hl_account_state = MagicMock(return_value={
-            "total_portfolio_value": 100_000,
-            "positions": {"BTC": {"weight": 0.3}},
-        })
-        tracker._position_client = MagicMock()
-        tracker._position_client.get_open_position_for_trade_pair.return_value = None
-
-        with patch('entity_management.hyperliquid_tracker.OrderProcessor') as mock_op:
-            mock_op.process_order.side_effect = ValueError("Position at max $1000.00 (limit: $1000.00)")
-
-            tracker._process_fill("0xaddr", self._make_fill())
+        tracker._process_fill("0xaddr", self._make_fill())
 
         tracker._ws_notifier_client.broadcast_subaccount_dashboard.assert_called_once()
 
@@ -1170,6 +768,10 @@ class TestEntityManagerNotification(TestBase):
         )
         manager._websocket_client = MagicMock()
         manager._websocket_client.notify_new_subaccount = MagicMock(return_value=True)
+        manager._entity_collateral_client = MagicMock()
+        # Admin create still reads cached collateral for the result message (slashing is skipped).
+        manager._entity_collateral_client.get_cached_collateral.return_value = 1_000_000.0
+        manager._entity_collateral_client.compute_entity_required_collateral.return_value = 0.0
 
         # Mock RPC clients that are called during register/create
         manager._position_client = MagicMock()
@@ -1186,6 +788,14 @@ class TestEntityManagerNotification(TestBase):
 
         # Register entity
         manager.register_entity(entity_hotkey=entity_hotkey)
+
+        # The WS-notification path runs only outside unit-test mode; enable it for
+        # this create call while stubbing the disk write and dashboard broadcasts so
+        # the create stays fully in-memory.
+        manager._write_entities_from_memory_to_disk = MagicMock()
+        manager.broadcast_subaccount_registration = MagicMock()
+        manager.broadcast_subaccount_dashboard = MagicMock()
+        manager.running_unit_tests = False
 
         # Create admin subaccount (skips slashing, synchronous path)
         success, info, msg = manager.create_subaccount(

--- a/tests/vali_tests/test_entity_miner_gateway.py
+++ b/tests/vali_tests/test_entity_miner_gateway.py
@@ -5,11 +5,15 @@ Tests for Entity Miner Gateway implementation.
 
 Covers:
 - OrderEvent / OrderEventStore (ring buffer)
-- WebSocket Server entity auth (signature, nonce, scope enforcement)
-- HyperliquidTracker rejection broadcasts
-- EntityMinerRestServer WS message handling
-- Dynamic subaccount subscription
-- _remove_client entity cleanup
+- Synthetic-hotkey scope enforcement
+- WebSocket Server client removal + new-subaccount dashboard subscription
+- HyperliquidTracker rejection/acceptance broadcasts
+- EntityMinerRestServer WS message handling + dashboard cache reconciliation
+- EntityManager new-subaccount WS notification
+
+(WS-level entity signature auth and nonce replay protection were removed in the
+Dashboard-v2 refactor; nonce handling now lives in NonceManager — see
+test_nonce_manager.py.)
 """
 import asyncio
 import json

--- a/tests/vali_tests/test_entity_miner_gateway.py
+++ b/tests/vali_tests/test_entity_miner_gateway.py
@@ -801,12 +801,12 @@ class TestEntityManagerNotification(TestBase):
         manager.broadcast_subaccount_dashboard = MagicMock()
         manager.running_unit_tests = False
 
-        # Create admin subaccount (skips slashing, synchronous path)
+        # Create a collateral-exempt subaccount (skips slashing, synchronous path)
         success, info, msg = manager.create_subaccount(
             entity_hotkey=entity_hotkey,
             account_size=10_000,
             asset_class="crypto",
-            admin=True
+            collateral_exempt=True
         )
 
         self.assertTrue(success)

--- a/tests/vali_tests/test_hyperliquid.py
+++ b/tests/vali_tests/test_hyperliquid.py
@@ -234,19 +234,19 @@ class TestHyperliquidSubaccounts(TestBase):
         self.assertFalse(success)
         self.assertIn("not registered", message.lower())
 
-    def test_create_hl_subaccount_admin_flag(self):
-        """Test HL subaccount creation with admin flag."""
+    def test_create_hl_subaccount_collateral_exempt_flag(self):
+        """Test HL subaccount creation with the collateral_exempt flag."""
         self.entity_client.register_entity(entity_hotkey=self.ENTITY_HOTKEY_1)
 
         success, subaccount_info, _ = self.entity_client.create_hl_subaccount(
             entity_hotkey=self.ENTITY_HOTKEY_1,
             account_size=50_000,
             hl_address=VALID_HL_ADDRESS,
-            admin=True
+            collateral_exempt=True
         )
 
         self.assertTrue(success)
-        self.assertEqual(subaccount_info['status'], 'admin')
+        self.assertEqual(subaccount_info['status'], 'active')
 
     # ==================== Payout Address ====================
 

--- a/tests/vali_tests/test_nonce_manager.py
+++ b/tests/vali_tests/test_nonce_manager.py
@@ -1,0 +1,159 @@
+# developer: Taoshidev
+# Copyright (c) 2025 Taoshi Inc
+"""
+Tests for vanta_api.nonce_manager.NonceManager — the REST replay-attack guard
+used by ValidatorRestServer (signed-request nonce + timestamp validation).
+
+Coverage moved here from the deleted WebSocket entity-auth tests: the WS server
+no longer performs its own nonce handling, so NonceManager is now the sole home
+for this logic.
+"""
+import unittest
+from unittest.mock import patch
+
+from vanta_api.nonce_manager import NonceManager
+
+
+# A fixed "now" so timestamp math is fully deterministic. All tests that reach
+# the freshness/future checks patch NonceManager's clock to this value.
+NOW_MS = 1_700_000_000_000
+TTL_MS = 5 * 60 * 1000  # NonceManager default
+
+
+def _patch_now(*values):
+    """Patch NonceManager's clock. One value per is_valid_request() call
+    (each call reads the clock exactly once)."""
+    return patch(
+        "vanta_api.nonce_manager.TimeUtil.now_in_millis",
+        side_effect=list(values),
+    )
+
+
+class TestNonceManagerValidation(unittest.TestCase):
+    """is_valid_request: freshness, future-dating, and replay detection."""
+
+    def setUp(self):
+        self.mgr = NonceManager()
+        self.addr = "5FreshAddress"
+
+    def test_fresh_request_accepted_and_recorded(self):
+        with _patch_now(NOW_MS):
+            ok, err = self.mgr.is_valid_request(self.addr, "n1", NOW_MS)
+        self.assertTrue(ok)
+        self.assertEqual(err, "")
+        # Nonce is now tracked for replay detection.
+        self.assertIn("n1", self.mgr.used_nonces[self.addr])
+        self.assertEqual(self.mgr.nonce_timestamps[self.addr]["n1"], NOW_MS)
+
+    def test_replayed_nonce_rejected(self):
+        with _patch_now(NOW_MS, NOW_MS):
+            ok1, _ = self.mgr.is_valid_request(self.addr, "n1", NOW_MS)
+            ok2, err2 = self.mgr.is_valid_request(self.addr, "n1", NOW_MS)
+        self.assertTrue(ok1)
+        self.assertFalse(ok2)
+        self.assertEqual(err2, "Nonce already used")
+
+    def test_expired_timestamp_rejected_and_not_recorded(self):
+        stale_ts = NOW_MS - TTL_MS - 1  # just past the window
+        with _patch_now(NOW_MS):
+            ok, err = self.mgr.is_valid_request(self.addr, "n1", stale_ts)
+        self.assertFalse(ok)
+        self.assertIn("expired", err.lower())
+        # Rejected before the mark step — must not be tracked.
+        self.assertNotIn("n1", self.mgr.used_nonces[self.addr])
+
+    def test_expired_boundary_is_inclusive(self):
+        # current_time - timestamp == ttl is NOT expired (check is strict >).
+        with _patch_now(NOW_MS):
+            ok, err = self.mgr.is_valid_request(self.addr, "n1", NOW_MS - TTL_MS)
+        self.assertTrue(ok, err)
+
+    def test_future_timestamp_rejected(self):
+        future_ts = NOW_MS + 60 * 1000 + 1  # just past the 1-minute tolerance
+        with _patch_now(NOW_MS):
+            ok, err = self.mgr.is_valid_request(self.addr, "n1", future_ts)
+        self.assertFalse(ok)
+        self.assertIn("future", err.lower())
+        self.assertNotIn("n1", self.mgr.used_nonces[self.addr])
+
+    def test_future_within_tolerance_accepted(self):
+        # Exactly at the tolerance edge is allowed (check is strict >).
+        with _patch_now(NOW_MS):
+            ok, err = self.mgr.is_valid_request(self.addr, "n1", NOW_MS + 60 * 1000)
+        self.assertTrue(ok, err)
+
+    def test_same_nonce_across_addresses_is_independent(self):
+        # Nonces are namespaced per address; identical nonce on two addresses is fine.
+        with _patch_now(NOW_MS, NOW_MS):
+            ok1, _ = self.mgr.is_valid_request("5AddrA", "shared", NOW_MS)
+            ok2, _ = self.mgr.is_valid_request("5AddrB", "shared", NOW_MS)
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
+
+    def test_expired_nonce_can_be_reused_after_cleanup(self):
+        # First use at NOW; second attempt a full TTL later. The stale entry is
+        # cleaned inside is_valid_request, so the same nonce is accepted again.
+        later = NOW_MS + TTL_MS + 1
+        with _patch_now(NOW_MS, later):
+            ok1, _ = self.mgr.is_valid_request(self.addr, "n1", NOW_MS)
+            ok2, err2 = self.mgr.is_valid_request(self.addr, "n1", later)
+        self.assertTrue(ok1)
+        self.assertTrue(ok2, err2)
+
+
+class TestNonceManagerCleanup(unittest.TestCase):
+    """_cleanup_expired_nonces: prunes stale entries from both tracking dicts."""
+
+    def setUp(self):
+        self.mgr = NonceManager()
+        self.addr = "5CleanupAddr"
+
+    def _seed(self, **nonce_to_ts):
+        for nonce, ts in nonce_to_ts.items():
+            self.mgr.used_nonces[self.addr].add(nonce)
+            self.mgr.nonce_timestamps[self.addr][nonce] = ts
+
+    def test_removes_only_expired(self):
+        self._seed(old=NOW_MS - TTL_MS - 1, fresh=NOW_MS)
+        self.mgr._cleanup_expired_nonces(self.addr, NOW_MS)
+        # Expired one gone from both structures; fresh one kept.
+        self.assertNotIn("old", self.mgr.used_nonces[self.addr])
+        self.assertNotIn("old", self.mgr.nonce_timestamps[self.addr])
+        self.assertIn("fresh", self.mgr.used_nonces[self.addr])
+        self.assertIn("fresh", self.mgr.nonce_timestamps[self.addr])
+
+    def test_boundary_nonce_is_kept(self):
+        # Exactly TTL old is not expired (strict >).
+        self._seed(edge=NOW_MS - TTL_MS)
+        self.mgr._cleanup_expired_nonces(self.addr, NOW_MS)
+        self.assertIn("edge", self.mgr.used_nonces[self.addr])
+
+    def test_empty_address_is_noop(self):
+        # Never-seen address must not raise.
+        self.mgr._cleanup_expired_nonces("5NeverSeen", NOW_MS)
+        self.assertEqual(len(self.mgr.nonce_timestamps["5NeverSeen"]), 0)
+
+    def test_all_expired_clears_address(self):
+        self._seed(a=NOW_MS - TTL_MS - 10, b=NOW_MS - TTL_MS - 5)
+        self.mgr._cleanup_expired_nonces(self.addr, NOW_MS)
+        self.assertEqual(len(self.mgr.used_nonces[self.addr]), 0)
+        self.assertEqual(len(self.mgr.nonce_timestamps[self.addr]), 0)
+
+
+class TestNonceManagerConfig(unittest.TestCase):
+    """Constructor wiring."""
+
+    def test_default_ttl(self):
+        self.assertEqual(NonceManager().ttl_ms, 5 * 60 * 1000)
+
+    def test_custom_ttl_enforced(self):
+        mgr = NonceManager(ttl_ms=1000)
+        stale_ts = NOW_MS - 1001
+        with _patch_now(NOW_MS):
+            ok, err = mgr.is_valid_request("5Addr", "n1", stale_ts)
+        self.assertFalse(ok)
+        self.assertIn("1000ms", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vali_tests/test_positions.py
+++ b/tests/vali_tests/test_positions.py
@@ -48,6 +48,7 @@ class TestPositions(TestBase):
         open_ms=DEFAULT_OPEN_MS,
         trade_pair=DEFAULT_TRADE_PAIR,
         account_size=DEFAULT_ACCOUNT_SIZE,
+        position_type=OrderType.FLAT,
     )
 
     @classmethod


### PR DESCRIPTION
Fixes pre-existing test failures (present on `main`, not caused by any feature work) — split out from the client_ref PR (#888). Four commits, each an independent pre-existing issue.

## 1. Entity collateral slash tests (`test_entity_collateral.py`)
The slash cap is `account_size × FUNDED_INTRADAY_DRAWDOWN_THRESHOLD`. That threshold moved `0.10 → 0.08 → 0.05`, but 6 tests hardcoded the `0.08`-era `$8K` value for a `$100K` account.

- Derive expected values from `MAX_SLASH_100K = 100_000 × ValiConfig.FUNDED_INTRADAY_DRAWDOWN_THRESHOLD`.
- Repoint `test_validator_contract_manager_withdrawal_blocking_code_exists` at `query_withdrawal_request`, where the entity cross-margin blocking logic now lives.
- **Result: `test_entity_collateral` 40/40.**

## 2. `miner_config` import (`run_vali_testing_suite.py`, `setup.py`)
`from miner_config import MinerConfig` (in the entity-miner gateway) failed under `run_vali_testing_suite.py` with `ModuleNotFoundError`: the runner's `sys.path[0]` is `tests/`, and the editable install only exposes packages, not top-level modules.

- Insert the repo root into `sys.path` in the runner.
- Declare `miner_config` in `setup.py` `py_modules` so it ships in editable/wheel installs.
- **Result: `test_entity_miner_gateway` import errors 46 → 0.**

## 3. `test_entity_miner_gateway` repair (Dashboard-v2 WS refactor)
Fixing the import surfaced 26 failures: the tests still targeted the WebSocket server's **pre-#711 ("Websockets Dashboard v2") entity-auth model**. Reconciled with the current implementation:

**Removed** (feature deleted in the refactor — no code path remains):
- `TestWebSocketEntityAuth` — WS-level entity signature auth + per-entity nonce replay protection. WS clients now authenticate by API key + tier; nonce handling moved to `NonceManager` (REST).
- `TestAutoSubscribeEntitySubaccounts` — per-subaccount poll tasks.

**Rewritten** against surviving code:
- `TestRemoveClient` — `_remove_client` now uses the `_clients` / `_api_key_client_ids` model.
- `TestNotifyNewSubaccount` — `notify_new_subaccount_rpc` now dashboard-subscribes connected clients instead of spawning poll tasks.
- `TestHLTrackerRejectionBroadcasts` — new `HyperliquidTracker` constructor; pre-trade checks now funnel through `_order_processor.validate()` and dispatch through `_dispatch_order()`.
- `TestEntityManagerNotification` — mock the entity collateral client (now read on every create) and exercise the WS-notify branch (production-only).

- **Result: `test_entity_miner_gateway` 41/41 pass (was 27 pass / 26 fail).**

## 4. `NonceManager` coverage (`test_nonce_manager.py`, new)
Removing `TestWebSocketEntityAuth` in commit 3 dropped the only (stale) tests touching nonce logic. The live replay-protection code now lives in `vanta_api.nonce_manager.NonceManager` (used by `ValidatorRestServer` for signed requests) and had **no** coverage. Added 14 tests:

- `is_valid_request`: fresh-accept + record, replay rejection, expired/future-dated rejection (both boundary edges, checks are strict `>`), per-address nonce namespacing, reuse-after-expiry.
- `_cleanup_expired_nonces`: prunes only expired entries from both dicts, keeps the TTL boundary, no-ops on an unseen address, clears an all-expired address.
- Constructor: default + custom TTL enforcement.

Also refreshed the now-stale `test_entity_miner_gateway` module docstring.

- **Result: `test_nonce_manager` 14/14 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)