### PR TITLE
Hardening: fix 16 confirmed defects from the order-HA adversarial review

### DIFF
--- a/entity_management/hyperliquid_tracker.py
+++ b/entity_management/hyperliquid_tracker.py
@@ -1415,10 +1415,19 @@ class HyperliquidTracker:
             return
         with self._fill_retry_lock:
             self._pending_fill_retries.append({"kwargs": dispatch_kwargs, "attempts": attempts})
+            backlog = len(self._pending_fill_retries)
         logger.warning(
             f"[HL_TRACKER] Transient dispatch failure for fill {fill_hash} ({hotkey}) — queued "
             f"for replay (attempt {attempts}/{self._FILL_RETRY_MAX_ATTEMPTS}): {err}"
         )
+        # No maxlen on the queue by design — evicting would LOSE fills, the exact bug this queue
+        # exists to fix; entries self-expire via the attempt cap instead. But a large backlog
+        # means a sustained state-tier outage with live entity trading: alert loudly.
+        if backlog > 1_000 and backlog % 500 == 1:
+            logger.error(
+                f"[HL_TRACKER] Fill replay backlog abnormal: {backlog} queued fills — state tier "
+                f"has been unreachable for an extended period while entities trade"
+            )
 
     def _drain_pending_fill_retries(self) -> None:
         """Replay transiently-failed fills, oldest first (order matters for position deltas).

--- a/entity_management/hyperliquid_tracker.py
+++ b/entity_management/hyperliquid_tracker.py
@@ -23,7 +23,7 @@ import threading
 import time
 import traceback
 import uuid
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from typing import Dict, List, Optional, Set
 
 import requests
@@ -364,6 +364,15 @@ class HyperliquidTracker:
         # Dedup: ordered dict of fill_hash -> True (bounded, oldest evicted first)
         self._processed_hashes: OrderedDict[str, bool] = OrderedDict()
 
+        # Fills whose dispatch hit a TRANSIENT infra failure (vanta-state restarting), queued for
+        # replay. Without this the fill was dropped forever: its hash is recorded pre-dispatch,
+        # HL WS fills are push-once, and the backup poll advances its watermark unconditionally —
+        # so a state-tier deploy while an entity trades silently diverged the tracked position
+        # from the real HL account. Drained from the orchestrator loop (every
+        # ADDRESS_REFRESH_INTERVAL_S). Guarded by _fill_retry_lock.
+        self._pending_fill_retries: deque = deque()
+        self._fill_retry_lock = threading.Lock()
+
         # Shard state
         self._shards: Dict[int, HyperliquidTracker._WebSocketShard] = {}
         self._address_to_shard: Dict[str, int] = {}
@@ -575,6 +584,7 @@ class HyperliquidTracker:
                     self._assign_addresses_to_shards()
                     self._ensure_shard_tasks()
                     self._probe_unhealthy_ports()
+                    self._drain_pending_fill_retries()
                 except Exception as e:
                     logger.error(f"[HL_TRACKER] Orchestrator error: {e}")
                     logger.error(traceback.format_exc())
@@ -1305,6 +1315,7 @@ class HyperliquidTracker:
         trade_pair_id: str,
         fill_hash: str,
         on_failure_clear_szi: Optional[tuple] = None,
+        retry_attempt: int = 0,
     ) -> bool:
         """Submit one order leg and handle broadcast + errors. Returns True on success.
 
@@ -1342,6 +1353,30 @@ class HyperliquidTracker:
             logger.warning(f"[HL_TRACKER] Signal rejected for {synthetic_hotkey}: {e}")
             self._broadcast_rejection(synthetic_hotkey, f"Order rejected: {e}")
         except Exception as e:
+            from shared_objects.error_utils import ErrorUtils
+            if ErrorUtils.is_transient_rpc_error(e):
+                # TRANSIENT infra failure (state tier restarting): this fill is push-once and its
+                # hash is already recorded, so dropping it here loses it forever. Queue for replay
+                # instead of rejecting; no szi-clear (the fill WILL apply).
+                self._enqueue_fill_retry(
+                    dict(
+                        synthetic_hotkey=synthetic_hotkey,
+                        order_uuid=order_uuid,
+                        trade_pair=trade_pair,
+                        order_type_enum=order_type_enum,
+                        quantity=quantity,
+                        fill_price=fill_price,
+                        price_sources=price_sources,
+                        is_taker=is_taker,
+                        now_ms=now_ms,
+                        trade_pair_id=trade_pair_id,
+                        fill_hash=fill_hash,
+                        on_failure_clear_szi=on_failure_clear_szi,
+                    ),
+                    retry_attempt,
+                    e,
+                )
+                return False
             logger.error(f"[HL_TRACKER] Order processing error for {synthetic_hotkey}: {e}")
             logger.error(traceback.format_exc())
             self._broadcast_rejection(synthetic_hotkey, f"Order rejected: {e}")
@@ -1353,6 +1388,56 @@ class HyperliquidTracker:
                     del cached[coin]
                     self._save_observed_szi()
         return False
+
+    # Replay budget for transiently-failed fills: one attempt per orchestrator cycle (60s),
+    # so 60 attempts ≈ 1 hour of state-tier outage tolerance before a fill is declared lost.
+    _FILL_RETRY_MAX_ATTEMPTS = 60
+
+    def _enqueue_fill_retry(self, dispatch_kwargs: dict, prior_attempts: int, err: Exception) -> None:
+        attempts = prior_attempts + 1
+        hotkey = dispatch_kwargs.get("synthetic_hotkey")
+        fill_hash = dispatch_kwargs.get("fill_hash")
+        if attempts > self._FILL_RETRY_MAX_ATTEMPTS:
+            # Terminal: give up loudly (mirrors the non-transient failure branch).
+            logger.error(
+                f"[HL_TRACKER] Giving up on fill {fill_hash} for {hotkey} after "
+                f"{prior_attempts} replay attempts: {err}"
+            )
+            self._broadcast_rejection(hotkey, f"Order rejected after retries: {err}")
+            on_failure_clear_szi = dispatch_kwargs.get("on_failure_clear_szi")
+            if on_failure_clear_szi:
+                addr, coin = on_failure_clear_szi
+                key = addr.lower() if isinstance(addr, str) else addr
+                cached = self._last_observed_szi.get(key)
+                if cached and coin in cached:
+                    del cached[coin]
+                    self._save_observed_szi()
+            return
+        with self._fill_retry_lock:
+            self._pending_fill_retries.append({"kwargs": dispatch_kwargs, "attempts": attempts})
+        logger.warning(
+            f"[HL_TRACKER] Transient dispatch failure for fill {fill_hash} ({hotkey}) — queued "
+            f"for replay (attempt {attempts}/{self._FILL_RETRY_MAX_ATTEMPTS}): {err}"
+        )
+
+    def _drain_pending_fill_retries(self) -> None:
+        """Replay transiently-failed fills, oldest first (order matters for position deltas).
+        A still-failing replay re-enqueues itself via _dispatch_order's transient branch."""
+        with self._fill_retry_lock:
+            n = len(self._pending_fill_retries)
+        if n == 0:
+            return
+        logger.info(f"[HL_TRACKER] Replaying {n} queued fill(s) after transient dispatch failure")
+        for _ in range(n):
+            with self._fill_retry_lock:
+                if not self._pending_fill_retries:
+                    return
+                entry = self._pending_fill_retries.popleft()
+            ok = self._dispatch_order(**entry["kwargs"], retry_attempt=entry["attempts"])
+            if not ok:
+                # Dispatch failed again (re-enqueued or terminal); stop this cycle — the state
+                # tier is likely still down, and later entries would just churn.
+                return
 
     def _process_fill(self, hl_address: str, fill: dict, account_state: Optional[dict] = None):
         """

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -310,7 +310,29 @@ class Validator(ValidatorBase):
             logger.info("[INIT] --no-axon: HL tracker not started here (runs in vanta-orders app)")
 
         # Verify hotkey is registered (via metagraph_client — available in all roles).
-        logger.info(f"Metagraph n_entries: {len(self.metagraph_client.get_hotkeys())}")
+        #
+        # The metagraph server binds its RPC port at spawn but serves EMPTY data until core's
+        # subtensor daemon pushes the chain metagraph (minutes on mainnet: perf-ledger load runs
+        # first). The monolith/core paths block on wait_for_initial_update before reaching here;
+        # the orders app has no such gate, so it must WAIT for population rather than read the
+        # empty metagraph as "not registered" and exit() — that crash-looped vanta-orders into
+        # PM2 'errored' on every full-split deploy, silently dropping all order reception.
+        _mg_wait_deadline = time.time() + 600  # generous: core's boot is minutes on mainnet
+        while True:
+            hotkeys = self.metagraph_client.get_hotkeys()
+            if hotkeys:
+                break
+            if time.time() > _mg_wait_deadline:
+                # Still empty after the deadline — core is not populating. Crash loudly (PM2
+                # restarts us and the wait restarts with a fresh window); do NOT claim the
+                # hotkey is unregistered, we never saw the real metagraph.
+                raise RuntimeError(
+                    "Metagraph still empty after 600s — core has not populated it; cannot "
+                    "verify hotkey registration. Will retry on restart."
+                )
+            logger.info("[INIT] Metagraph empty (core still booting) — waiting to verify hotkey registration...")
+            time.sleep(5)
+        logger.info(f"Metagraph n_entries: {len(hotkeys)}")
         if not self.metagraph_client.has_hotkey(self.wallet.hotkey.ss58_address):
             logger.error(
                 f"\nYour validator hotkey: {self.wallet.hotkey.ss58_address} (wallet: {self.wallet.name}, hotkey: {self.wallet.hotkey_str}) "

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -669,10 +669,15 @@ class Validator(ValidatorBase):
                 # Set synapse response (centralized - single line instead of 4)
                 synapse.order_json = result.get_response_json()
 
-                # The claim was taken before we knew the result; drop it if this order isn't tracked.
+                # The claim was taken before we knew the result; drop it if this order isn't tracked,
+                # else promote it to permanent (a provisional claim expires after
+                # ORDER_UUID_CLAIM_TTL_MS so a hard-killed apply can't strand it — see
+                # CommonDataServer.confirm_order_uuid_rpc).
                 if claimed and not result.should_track_uuid:
                     self.uuid_tracker.release(order_uuid)
                     claimed = False
+                elif claimed:
+                    self.uuid_tracker.confirm(order_uuid)
 
                 # For logging (used in the ack below)
                 order = result.order_for_logging

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -106,13 +106,18 @@ class Validator(ValidatorBase):
         self.split_state = getattr(self.config, 'split_state', False)
         self.is_mainnet = self.config.netuid == 8
 
-        # Migrations + tmp clear mutate on-disk state, which the client-only orders app does not own.
-        if not self.orders_app:
+        # Migrations + tmp clear mutate on-disk state, which the client-only orders app does not
+        # own. Under --split-state, MIGRATIONS belong to vanta-state (run_state_server.py): it
+        # starts first and its servers load the migrated files — core migrating afterwards would
+        # rewrite files underneath the live state tier, whose next save would silently undo the
+        # migration (while migrations_completed.txt marks it done).
+        if not self.orders_app and not self.split_state:
             print("Checking for pending migrations...")
             if not run_migrations():
                 print("ERROR: Migration failed. Starting validator without executing migrations")
             else:
                 print("Migrations completed successfully.")
+        if not self.orders_app:
             ValiBkpUtils.clear_tmp_dir()
 
         # OrderUuidDedupClient is server-authoritative (survives a restart, holds across instances);

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -733,8 +733,17 @@ class Validator(ValidatorBase):
                     synapse.should_retry = ErrorUtils.is_transient_rpc_error(order_exc)
 
                 # TODO Review overlap with serving in market order manager
+                # Best-effort: the entity server lives in CORE — during a core restart this call
+                # raising inside `finally` would REPLACE the fully-crafted success synapse with an
+                # axon error, and the still-claimed uuid would turn the miner's retry into a hard
+                # duplicate rejection for an order that is live on their account.
                 if is_synthetic_hotkey(miner_hotkey):
-                    self.entity_client.broadcast_subaccount_dashboard(miner_hotkey)
+                    try:
+                        self.entity_client.broadcast_subaccount_dashboard(miner_hotkey)
+                    except Exception as broadcast_err:
+                        logger.warning(
+                            f"Entity dashboard broadcast failed for {miner_hotkey} (ack unaffected): {broadcast_err}"
+                        )
 
                 processing_time_ms = TimeUtil.now_in_millis() - now_ms
                 logger.info(f"Sending ack back to miner [{miner_hotkey}]. Synapse Message: {synapse.error_message}. "

--- a/run.sh
+++ b/run.sh
@@ -250,6 +250,13 @@ orders_split_enabled=false
 wallet_name_value=""
 wallet_hotkey_value=""
 wallet_path_value="$HOME/.bittensor/wallets"
+# API bind forwarding: the standalone REST/WS apps must bind exactly where the in-core spawn
+# would have (default 127.0.0.1, --api-host/--api-*-port honored) — NOT their own defaults —
+# else a relaunch silently moves the API (breaking any reverse proxy pointed at the old bind)
+# and exposes a loopback-only API on all interfaces.
+api_host_value="127.0.0.1"
+api_rest_port_value=""
+api_ws_port_value=""
 for ((i = 0; i < ${#args[@]}; i++)); do
     case "${args[$i]}" in
         --serve)
@@ -291,6 +298,24 @@ for ((i = 0; i < ${#args[@]}; i++)); do
         --wallet.path=*)
             wallet_path_value="${args[$i]#*=}"
             ;;
+        --api-host)
+            api_host_value="${args[$((i + 1))]}"
+            ;;
+        --api-host=*)
+            api_host_value="${args[$i]#*=}"
+            ;;
+        --api-rest-port)
+            api_rest_port_value="${args[$((i + 1))]}"
+            ;;
+        --api-rest-port=*)
+            api_rest_port_value="${args[$i]#*=}"
+            ;;
+        --api-ws-port)
+            api_ws_port_value="${args[$((i + 1))]}"
+            ;;
+        --api-ws-port=*)
+            api_ws_port_value="${args[$i]#*=}"
+            ;;
     esac
 done
 
@@ -303,6 +328,15 @@ if [ "$serve_enabled" = true ]; then
     if [ -n "$slack_webhook_value" ]; then
         rest_args+=("--slack-webhook-url" "$slack_webhook_value")
         ws_args+=("--slack-webhook-url" "$slack_webhook_value")
+    fi
+    # Bind parity with the in-core spawn (see api_host_value comment above).
+    rest_args+=("--host" "$api_host_value")
+    ws_args+=("--host" "$api_host_value")
+    if [ -n "$api_rest_port_value" ]; then
+        rest_args+=("--port" "$api_rest_port_value")
+    fi
+    if [ -n "$api_ws_port_value" ]; then
+        ws_args+=("--port" "$api_ws_port_value")
     fi
 fi
 
@@ -417,10 +451,38 @@ check_and_restart_pm2() {
     pm2 start $proc_name.app.config.js
 }
 
+# delete_pm2_if_running proc_name — tear down a split app whose flag is no longer set. Without
+# this, rolling back (dropping --split-state / --no-axon / --serve) leaves the OLD app running
+# and auto-restarting, and it fights the monolith core for the same RPC ports (mutual SIGKILL
+# loop until PM2 marks both errored).
+delete_pm2_if_running() {
+    local proc_name=$1
+    if pm2 status | grep -q "$proc_name"; then
+        echo "Flag for $proc_name is not set but the app is running — deleting stale PM2 app $proc_name"
+        pm2 delete "$proc_name"
+    fi
+}
+
+# Tear down split apps whose flags were dropped BEFORE starting anything, so a rollback can't
+# leave two owners of the order-write servers.
+teardown_disabled_split_apps() {
+    if [ "$split_state_enabled" != true ]; then
+        delete_pm2_if_running "$state_proc_name"
+    fi
+    if [ "$orders_split_enabled" != true ]; then
+        delete_pm2_if_running "$orders_proc_name"
+    fi
+    if [ "$serve_enabled" != true ]; then
+        delete_pm2_if_running "$rest_proc_name"
+        delete_pm2_if_running "$ws_proc_name"
+    fi
+}
+
 # Start order: vanta-state FIRST (owns the order-write state servers core connects to), then core,
 # then the API apps. Under --split-state this ordering matters — core's clients target vanta-state's
 # servers; the readiness watchdogs tolerate transient absence and alert on sustained un-readiness.
 pip_install_if_requirements_changed
+teardown_disabled_split_apps
 if [ "$split_state_enabled" = true ]; then
     check_and_restart_pm2 "$state_proc_name" "$state_script" state_args 10000
 fi
@@ -501,6 +563,7 @@ while true; do
                 # models, RPC serialization) needs ALL tiers restarted together to avoid skew.
                 # RPC is pickle with no version handshake, so vanta-state MUST restart with core
                 # (matched-pair rule); vanta-state first to mirror the startup order.
+                teardown_disabled_split_apps
                 if [ "$split_state_enabled" = true ]; then
                     check_and_restart_pm2 "$state_proc_name" "$state_script" state_args 10000
                 fi

--- a/shared_objects/locks/position_lock_client.py
+++ b/shared_objects/locks/position_lock_client.py
@@ -76,18 +76,19 @@ class PositionLockClient(RPCClientBase):
         """
         return self._server.acquire_rpc(miner_hotkey, trade_pair_id, timeout)
 
-    def release(self, miner_hotkey: str, trade_pair_id: str) -> bool:
+    def release(self, miner_hotkey: str, trade_pair_id: str, token: int = None) -> bool:
         """
         Release lock directly (without context manager).
 
         Args:
             miner_hotkey: Miner's hotkey
             trade_pair_id: Trade pair ID
+            token: Owner token from acquire(); when given, only the actual holder releases.
 
         Returns:
             bool: True if released successfully, False if error
         """
-        return self._server.release_rpc(miner_hotkey, trade_pair_id)
+        return self._server.release_rpc(miner_hotkey, trade_pair_id, token)
 
     # ==================== Health Check ====================
 

--- a/shared_objects/locks/position_lock_server.py
+++ b/shared_objects/locks/position_lock_server.py
@@ -66,9 +66,12 @@ class PositionLockServer(RPCServerBase):
         # Use threading.Lock since all RPC access goes through this server process
         self.locks: Dict[Tuple[str, str], threading.Lock] = {}
         self.locks_dict_lock = threading.Lock()  # Protect dict mutations
-        # Wall-clock ms when each currently-held lock was acquired (for lease reclaim). Absent = not
-        # held (or already released). Guarded by locks_dict_lock.
-        self.lock_held_at: Dict[Tuple[str, str], float] = {}
+        # Current owner of each held lock: key -> (owner_token, held_at_ms). Absent = not held.
+        # The token gives releases holder identity: threading.Lock has none, so without it a
+        # lease-reclaimed holder's eventual release would free the RECLAIMER's lock, cascading to
+        # multiple concurrent writers on one (hotkey, trade_pair). Guarded by locks_dict_lock.
+        self.lock_owner: Dict[Tuple[str, str], Tuple[int, float]] = {}
+        self._next_owner_token = 0
         self._lock_lease_ms = ValiConfig.POSITION_LOCK_LEASE_MS
 
         # Initialize base class
@@ -144,7 +147,7 @@ class PositionLockServer(RPCServerBase):
 
             return lock
 
-    def acquire_rpc(self, miner_hotkey: str, trade_pair_id: str, timeout: float = 10.0) -> bool:
+    def acquire_rpc(self, miner_hotkey: str, trade_pair_id: str, timeout: float = 10.0):
         """
         Acquire lock for the given key (blocks until available or timeout).
 
@@ -154,7 +157,9 @@ class PositionLockServer(RPCServerBase):
             timeout: Maximum time to wait in seconds
 
         Returns:
-            bool: True if lock was acquired, False if timeout
+            int owner token (truthy) if acquired — pass it back to release_rpc so only the
+            actual holder can release; False if timeout. Truthiness preserves the legacy
+            bool contract for callers that only check success.
         """
         lock_key = (miner_hotkey, trade_pair_id)
         lock = self._get_or_create_lock(miner_hotkey, trade_pair_id)
@@ -162,45 +167,53 @@ class PositionLockServer(RPCServerBase):
         # Lease reclaim (never-release protection): if this lock has been HELD past the lease, the
         # holder is presumed dead (crashed between acquire and release — a real hazard now that the
         # holder is the crashable vanta-orders process, not core). Force-release so the (hotkey,
-        # trade_pair) is not wedged forever. The lease is FAR above any real hold, so a live-but-slow
-        # holder is never reclaimed. Serialized under locks_dict_lock so only one reclaim fires.
+        # trade_pair) is not wedged forever. The lease is FAR above any real hold (see
+        # POSITION_LOCK_LEASE_MS), so a live-but-slow holder is never reclaimed. Serialized under
+        # locks_dict_lock so only one reclaim fires; dropping the owner entry first makes the dead
+        # holder's late release (if it ever arrives) a token-mismatch no-op.
         now_ms = TimeUtil.now_in_millis()
         with self.locks_dict_lock:
-            held_at = self.lock_held_at.get(lock_key)
-            if held_at is not None and (now_ms - held_at) > self._lock_lease_ms:
+            owner = self.lock_owner.get(lock_key)
+            if owner is not None and (now_ms - owner[1]) > self._lock_lease_ms:
+                self.lock_owner.pop(lock_key, None)
                 try:
                     lock.release()
                     logger.warning(
                         f"[LOCK_SERVER] Reclaimed stale lock for {miner_hotkey}.../{trade_pair_id} "
-                        f"held {(now_ms - held_at) / 1000:.1f}s (> {self._lock_lease_ms / 1000:.0f}s lease) "
+                        f"held {(now_ms - owner[1]) / 1000:.1f}s (> {self._lock_lease_ms / 1000:.0f}s lease) "
                         f"— presumed crashed holder"
                     )
                 except RuntimeError:
                     pass  # already free; nothing to reclaim
-                self.lock_held_at.pop(lock_key, None)
 
         acquired = lock.acquire(timeout=timeout)
 
         if acquired:
             with self.locks_dict_lock:
-                self.lock_held_at[lock_key] = TimeUtil.now_in_millis()
-        else:
-            logger.warning(
-                f"[LOCK_SERVER] Failed to acquire lock for {miner_hotkey}.../{trade_pair_id} after {timeout}s"
-            )
+                self._next_owner_token += 1
+                token = self._next_owner_token
+                self.lock_owner[lock_key] = (token, TimeUtil.now_in_millis())
+            return token
 
-        return acquired
+        logger.warning(
+            f"[LOCK_SERVER] Failed to acquire lock for {miner_hotkey}.../{trade_pair_id} after {timeout}s"
+        )
+        return False
 
-    def release_rpc(self, miner_hotkey: str, trade_pair_id: str) -> bool:
+    def release_rpc(self, miner_hotkey: str, trade_pair_id: str, token: int = None) -> bool:
         """
         Release lock for the given key.
 
         Args:
             miner_hotkey: Miner's hotkey
             trade_pair_id: Trade pair ID
+            token: Owner token from acquire_rpc. When provided, the release is a no-op unless
+                the token matches the current owner — a lease-reclaimed holder's late release
+                must not free the lock its reclaimer now holds. None = legacy unconditional
+                release (version-skew tolerance only).
 
         Returns:
-            bool: True if released successfully, False if error
+            bool: True if released successfully, False if error/stale
         """
         lock_key = (miner_hotkey, trade_pair_id)
         lock = self.locks.get(lock_key)
@@ -211,19 +224,25 @@ class PositionLockServer(RPCServerBase):
             )
             return False
 
-        try:
-            lock.release()
-            with self.locks_dict_lock:
-                self.lock_held_at.pop(lock_key, None)  # no longer held → not eligible for reclaim
-            return True
-        except RuntimeError as e:
-            # Lock was not held (already released — possibly reclaimed by the lease above)
-            with self.locks_dict_lock:
-                self.lock_held_at.pop(lock_key, None)
-            logger.warning(
-                f"[LOCK_SERVER] Error releasing lock for {miner_hotkey}.../{trade_pair_id}: {e}"
-            )
-            return False
+        with self.locks_dict_lock:
+            owner = self.lock_owner.get(lock_key)
+            if token is not None and (owner is None or owner[0] != token):
+                logger.warning(
+                    f"[LOCK_SERVER] Stale release for {miner_hotkey}.../{trade_pair_id} "
+                    f"(token {token}, current owner {owner[0] if owner else None}) — ignored; "
+                    f"the lock was lease-reclaimed and is (or will be) held by a newer owner"
+                )
+                return False
+            self.lock_owner.pop(lock_key, None)
+            try:
+                lock.release()
+                return True
+            except RuntimeError as e:
+                # Lock was not held (already released — possibly reclaimed by the lease above)
+                logger.warning(
+                    f"[LOCK_SERVER] Error releasing lock for {miner_hotkey}.../{trade_pair_id}: {e}"
+                )
+                return False
 
     def get_lock_count_rpc(self) -> int:
         """Get the number of locks currently tracked."""
@@ -253,10 +272,12 @@ class PositionLockProxy:
         self.trade_pair_id = trade_pair_id
         self.timeout = timeout
         self.acquired = False
+        self.token = None
 
     def __enter__(self):
-        """Acquire lock via RPC."""
-        self.acquired = self.server.acquire_rpc(self.miner_hotkey, self.trade_pair_id, self.timeout)
+        """Acquire lock via RPC. Keeps the owner token so only THIS holder's exit releases."""
+        self.token = self.server.acquire_rpc(self.miner_hotkey, self.trade_pair_id, self.timeout)
+        self.acquired = bool(self.token)
         if not self.acquired:
             raise TimeoutError(
                 f"Failed to acquire lock for {self.miner_hotkey}/{self.trade_pair_id} after {self.timeout}s"
@@ -264,9 +285,9 @@ class PositionLockProxy:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Release lock via RPC."""
+        """Release lock via RPC (token-checked: a lease-reclaimed hold releases as a no-op)."""
         if self.acquired:
-            self.server.release_rpc(self.miner_hotkey, self.trade_pair_id)
+            self.server.release_rpc(self.miner_hotkey, self.trade_pair_id, self.token)
         return False  # Don't suppress exceptions
 
 

--- a/shared_objects/rpc/common_data_client.py
+++ b/shared_objects/rpc/common_data_client.py
@@ -135,6 +135,10 @@ class CommonDataClient(RPCClientBase):
         """Atomic claim: True if newly claimed (apply the order), False if duplicate (reject)."""
         return self.call("check_and_add_order_uuid_rpc", uuid)
 
+    def confirm_order_uuid(self, uuid) -> None:
+        """Promote a provisional claim to the permanent dedup set (order committed)."""
+        self.call("confirm_order_uuid_rpc", uuid)
+
     def release_order_uuid(self, uuid) -> None:
         """Undo a claim after an apply failure so the retry can re-claim."""
         self.call("release_order_uuid_rpc", uuid)

--- a/shared_objects/rpc/common_data_client.py
+++ b/shared_objects/rpc/common_data_client.py
@@ -121,6 +121,10 @@ class CommonDataClient(RPCClientBase):
         """Block until in-flight orders drain to 0; returns False on timeout."""
         return self.call("wait_for_orders_rpc", timeout_seconds)
 
+    def renew_sync_lease(self) -> bool:
+        """Heartbeat the sync gate's lease (sync owner only). False => the gate is no longer held."""
+        return self.call("renew_sync_lease_rpc")
+
     def mark_sync_complete(self) -> None:
         """Clear sync_waiting (orders may resume)."""
         self.call("mark_sync_complete_rpc")

--- a/shared_objects/rpc/common_data_server.py
+++ b/shared_objects/rpc/common_data_server.py
@@ -117,6 +117,13 @@ class CommonDataServer(RPCServerBase):
         self._order_uuids_deque = deque()
         self._order_uuids_set = set()
         self._order_uuid_capacity = ValiConfig.ORDER_UUID_DEDUP_CAPACITY
+        # Two-phase claims: check_and_add records a PROVISIONAL claim (uuid -> claimed_at_ms);
+        # confirm promotes it to the permanent FIFO set post-commit, release drops it on apply
+        # failure. A claimant hard-killed mid-apply (SIGKILL/OOM — release never runs) leaves a
+        # provisional claim that simply expires after ORDER_UUID_CLAIM_TTL_MS, so the miner's
+        # retry of a never-committed order is not permanently rejected as a duplicate.
+        self._order_uuid_provisional = {}   # uuid -> claimed_at_ms
+        self._order_uuid_claim_ttl_ms = ValiConfig.ORDER_UUID_CLAIM_TTL_MS  # instance attr so tests can shrink it
 
         self._sync_waiting = False
         self._last_sync_start_ms = 0
@@ -410,11 +417,35 @@ class CommonDataServer(RPCServerBase):
         """
         if not uuid:
             return True
+        now_ms = TimeUtil.now_in_millis()
         with self._state_lock:
             if uuid in self._order_uuids_set:
                 return False
-            self._add_order_uuid_locked(uuid)
+            claimed_at = self._order_uuid_provisional.get(uuid)
+            if claimed_at is not None:
+                if now_ms - claimed_at <= self._order_uuid_claim_ttl_ms:
+                    return False  # live claim held by another (or a hung) apply
+                # Expired provisional: the claimant died mid-apply without release; let this
+                # retry re-claim rather than rejecting an order that never committed.
+                logger.warning(
+                    f"[COMMON_DATA] Reclaiming expired provisional order-uuid claim {uuid} "
+                    f"(claimed {(now_ms - claimed_at) / 1000:.0f}s ago, ttl {self._order_uuid_claim_ttl_ms / 1000:.0f}s)"
+                )
+            self._order_uuid_provisional[uuid] = now_ms
             return True
+
+    def confirm_order_uuid_rpc(self, uuid) -> None:
+        """
+        Promote a provisional claim to the permanent dedup set — call after the order COMMITTED.
+        A confirmed uuid never expires via the claim TTL (only via FIFO capacity eviction), so a
+        late duplicate of a committed order is still rejected. No-op-safe: confirming an unknown
+        uuid just records it (covers a confirm racing the TTL reap).
+        """
+        if not uuid:
+            return
+        with self._state_lock:
+            self._order_uuid_provisional.pop(uuid, None)
+            self._add_order_uuid_locked(uuid)
 
     def release_order_uuid_rpc(self, uuid) -> None:
         """
@@ -441,14 +472,19 @@ class CommonDataServer(RPCServerBase):
         if not uuid:
             return
         with self._state_lock:
+            self._order_uuid_provisional.pop(uuid, None)
             self._order_uuids_set.discard(uuid)
 
     def order_uuid_exists_rpc(self, uuid) -> bool:
         """Read-only membership check (early-reject fast path also served by the client-local cache)."""
         if not uuid:
             return False
+        now_ms = TimeUtil.now_in_millis()
         with self._state_lock:
-            return uuid in self._order_uuids_set
+            if uuid in self._order_uuids_set:
+                return True
+            claimed_at = self._order_uuid_provisional.get(uuid)
+            return claimed_at is not None and now_ms - claimed_at <= self._order_uuid_claim_ttl_ms
 
     def seed_order_uuids_rpc(self, uuids) -> int:
         """
@@ -494,6 +530,7 @@ class CommonDataServer(RPCServerBase):
             # Reset the order-UUID dedup set (else dedup state leaks across tests).
             self._order_uuids_deque.clear()
             self._order_uuids_set.clear()
+            self._order_uuid_provisional.clear()
             logger.debug("[COMMON_DATA] Test state cleared (shutdown, sync_in_progress, sync_epoch, order coordination reset)")
 
     # ==================== Combined State RPC Methods ====================

--- a/shared_objects/rpc/common_data_server.py
+++ b/shared_objects/rpc/common_data_server.py
@@ -128,6 +128,13 @@ class CommonDataServer(RPCServerBase):
         self._sync_waiting = False
         self._last_sync_start_ms = 0
         self._last_sync_complete_ms = 0
+        # Lease on the sync gate: the sync side (core) renews this while its sync runs
+        # (renew_sync_lease_rpc heartbeat). sync_waiting has no owning process on THIS server —
+        # if core is hard-killed between wait_for_orders and mark_sync_complete, nothing would
+        # ever clear it and every order network-wide would be rejected until the next sync. A
+        # stale lease (no renewal for SYNC_WAITING_LEASE_MS) auto-clears the gate instead.
+        self._sync_lease_renewed_ms = 0
+        self._sync_lease_ms = ValiConfig.SYNC_WAITING_LEASE_MS  # instance attr so tests can shrink it
         self._order_condition = threading.Condition(self._state_lock)
         # INVARIANT (load-bearing): the condition MUST wrap _state_lock, not a lock of its own.
         # The R2.5a order/sync TOCTOU fix depends on begin_order_rpc's `_sync_waiting` check and
@@ -285,6 +292,7 @@ class CommonDataServer(RPCServerBase):
         cap, emit a throttled alert — but do NOT evict live entries (would undercount).
         """
         with self._order_condition:
+            self._expire_stale_sync_gate_locked()
             count = self._reap_and_count_locked()
             if self._sync_waiting:
                 return None  # sync quiescing/running — refuse; caller rejects with should_retry
@@ -321,15 +329,51 @@ class CommonDataServer(RPCServerBase):
         with self._order_condition:
             return self._reap_and_count_locked()
 
+    def _expire_stale_sync_gate_locked(self) -> None:
+        """
+        Auto-clear a sync gate whose lease has lapsed. Caller holds _order_condition/_state_lock.
+
+        The gate's owner is a process on the OTHER side of an RPC boundary (core's PositionSyncer);
+        if it is hard-killed between wait_for_orders and mark_sync_complete, no code path on this
+        server would ever clear sync_waiting — and begin_order_rpc would reject every order,
+        network-wide, until the next successful sync. The in-flight registry got a TTL for exactly
+        this cross-process reason (R2.4); this is the same medicine for the sync flag.
+        """
+        if not self._sync_waiting:
+            return
+        now_ms = TimeUtil.now_in_millis()
+        renewed = self._sync_lease_renewed_ms or self._last_sync_start_ms
+        if renewed and (now_ms - renewed) > self._sync_lease_ms:
+            self._sync_waiting = False
+            self._sync_lease_renewed_ms = 0
+            logger.error(
+                f"[COMMON_DATA] sync_waiting lease expired ({(now_ms - renewed) / 1000:.0f}s since "
+                f"last renewal > {self._sync_lease_ms / 1000:.0f}s) — the sync owner (core) is "
+                f"presumed dead mid-sync. Auto-clearing the gate so orders resume."
+            )
+
+    def renew_sync_lease_rpc(self) -> bool:
+        """Heartbeat from the sync owner (core) while its sync runs. Returns whether the gate is
+        still held (False => it already expired or was completed; the owner should treat its sync
+        window as lost)."""
+        with self._order_condition:
+            if not self._sync_waiting:
+                return False
+            self._sync_lease_renewed_ms = TimeUtil.now_in_millis()
+            return True
+
     def is_sync_waiting_rpc(self) -> bool:
         """True if a sync is waiting for orders to drain (order early-reject reads this)."""
         with self._order_condition:
+            self._expire_stale_sync_gate_locked()
             return self._sync_waiting
 
     def set_sync_waiting_rpc(self, value: bool) -> None:
         """Set the sync_waiting flag directly (mark_sync_complete_rpc clears it)."""
         with self._order_condition:
             self._sync_waiting = value
+            # Stamp/clear the lease so a directly-set gate is still covered by expiry.
+            self._sync_lease_renewed_ms = TimeUtil.now_in_millis() if value else 0
 
     def wait_for_orders_rpc(self, timeout_seconds: float = None) -> bool:
         """
@@ -342,12 +386,18 @@ class CommonDataServer(RPCServerBase):
         with self._order_condition:
             self._sync_waiting = True
             self._last_sync_start_ms = TimeUtil.now_in_millis()
+            self._sync_lease_renewed_ms = self._last_sync_start_ms
             deadline_ms = None if timeout_seconds is None else self._last_sync_start_ms + int(timeout_seconds * 1000)
             while self._reap_and_count_locked() > 0:
+                # Renew while this drain loop is alive: the loop runs in the RPC call's server
+                # thread, so it proves the wait itself is progressing. Once we return True, the
+                # sync owner's own heartbeat (renew_sync_lease_rpc) must take over.
+                self._sync_lease_renewed_ms = TimeUtil.now_in_millis()
                 if deadline_ms is not None:
                     remaining_s = (deadline_ms - TimeUtil.now_in_millis()) / 1000.0
                     if remaining_s <= 0:
                         self._sync_waiting = False
+                        self._sync_lease_renewed_ms = 0
                         return False
                     self._order_condition.wait(timeout=min(self._WAIT_POLL_SECONDS, remaining_s))
                 else:
@@ -358,6 +408,7 @@ class CommonDataServer(RPCServerBase):
         """Clear sync_waiting (sync finished; orders may resume)."""
         with self._order_condition:
             self._sync_waiting = False
+            self._sync_lease_renewed_ms = 0
             self._last_sync_complete_ms = TimeUtil.now_in_millis()
 
     def get_order_sync_state_rpc(self) -> dict:
@@ -525,6 +576,7 @@ class CommonDataServer(RPCServerBase):
             self._inflight_orders.clear()
             self._next_order_token = 0
             self._sync_waiting = False
+            self._sync_lease_renewed_ms = 0
             self._last_sync_start_ms = 0
             self._last_sync_complete_ms = 0
             # Reset the order-UUID dedup set (else dedup state leaks across tests).

--- a/shared_objects/rpc/common_data_server.py
+++ b/shared_objects/rpc/common_data_server.py
@@ -124,6 +124,9 @@ class CommonDataServer(RPCServerBase):
         # retry of a never-committed order is not permanently rejected as a duplicate.
         self._order_uuid_provisional = {}   # uuid -> claimed_at_ms
         self._order_uuid_claim_ttl_ms = ValiConfig.ORDER_UUID_CLAIM_TTL_MS  # instance attr so tests can shrink it
+        # Above this many live provisional claims, check_and_add sweeps expired ones (amortized
+        # cleanup for claims whose uuid is never retried). Normal in-flight population is <100.
+        self._PROVISIONAL_SWEEP_THRESHOLD = 1_000
 
         self._sync_waiting = False
         self._last_sync_start_ms = 0
@@ -470,6 +473,20 @@ class CommonDataServer(RPCServerBase):
             return True
         now_ms = TimeUtil.now_in_millis()
         with self._state_lock:
+            # Amortized sweep: expired provisionals for uuids that are NEVER retried (claimant
+            # hard-killed, miner gave up) would otherwise accumulate forever — the per-uuid reap
+            # below only fires when the SAME uuid is re-claimed. Sweeping only past a size
+            # threshold keeps the common case O(1).
+            if len(self._order_uuid_provisional) > self._PROVISIONAL_SWEEP_THRESHOLD:
+                expired = [u for u, ts in self._order_uuid_provisional.items()
+                           if now_ms - ts > self._order_uuid_claim_ttl_ms]
+                for u in expired:
+                    del self._order_uuid_provisional[u]
+                if expired:
+                    logger.warning(
+                        f"[COMMON_DATA] Swept {len(expired)} expired provisional order-uuid claims "
+                        f"({len(self._order_uuid_provisional)} live claims remain)"
+                    )
             if uuid in self._order_uuids_set:
                 return False
             claimed_at = self._order_uuid_provisional.get(uuid)

--- a/shared_objects/rpc/port_manager.py
+++ b/shared_objects/rpc/port_manager.py
@@ -192,9 +192,14 @@ class PortManager:
         current_pid = os.getpid()
 
         try:
-            # Build a single lsof command for all ports: lsof -ti :50000 -ti :50001 ...
-            # This is much faster than calling lsof for each port
-            lsof_args = ['lsof']
+            # Build a single lsof command for all ports: lsof -sTCP:LISTEN -ti :50000 -ti :50001 ...
+            # This is much faster than calling lsof for each port.
+            # LISTEN-only is load-bearing: a bare `lsof -ti :PORT` also matches processes holding
+            # mere ESTABLISHED client connections to that port — which under the PM2 split means
+            # SIGKILLing another tier's MAIN process (vanta-state/vanta-orders hold long-lived
+            # client connections to each other's server ports) instead of just clearing a stale
+            # listener.
+            lsof_args = ['lsof', '-sTCP:LISTEN']
             for port in ports:
                 lsof_args.extend(['-ti', f':{port}'])
 

--- a/shared_objects/rpc/rpc_client_base.py
+++ b/shared_objects/rpc/rpc_client_base.py
@@ -170,6 +170,13 @@ class RPCClientBase:
     # staleness-tolerant). Callers needing fail-fast (probes) pass retry=False to _invoke_rpc.
     _RECONNECT_MAX_RETRIES = 5
     _RECONNECT_RETRY_DELAY_S = 1.0
+    # Circuit breaker: once a full self-heal cycle (or a lazy connect) has failed, further calls
+    # within this window fail FAST (single attempt, quick connect, no settle sleeps) instead of
+    # each paying the full multi-cycle penalty. Without it, a state-tier restart turned every
+    # call from every one of the 32 axon/waitress worker threads into ~4-8s of blocked thread —
+    # saturating both pools within seconds and queueing even health checks. The first call after
+    # the window (or any success) closes the breaker.
+    _BACKOFF_WINDOW_S = 5.0
 
     # Class-level registry of all active client instances (for test cleanup)
     _active_instances: list = []
@@ -307,6 +314,10 @@ class RPCClientBase:
         # across the axon's executor threads) a transient-error storm doesn't spawn many managers or
         # tear down a freshly-rebuilt connection. Reentrant: connect() may be entered via _server.
         self._conn_lock = threading.RLock()
+        # Circuit breaker state: monotonic-ish wall-clock deadline until which calls fail fast
+        # (see _BACKOFF_WINDOW_S). 0 = breaker closed. Read/written unlocked (float assignment is
+        # atomic; a racy read only costs one extra fast/slow attempt).
+        self._backoff_until = 0.0
 
         # Resilient proxy returned by the _server property in RPC mode. Bound to this client so
         # every method call routes through _invoke_rpc()'s reconnect-on-bounce logic.
@@ -370,7 +381,10 @@ class RPCClientBase:
         both connect to the same live server, the last write to self._proxy wins, and the orphaned
         manager is GC'd. Locking here would add contention to the common already-connected path.
         """
-        if self._proxy is None and not self._connected and self.connection_mode == RPCConnectionMode.RPC:
+        # Keyed on _proxy alone (not `and not self._connected`): a racing teardown must never
+        # leave this returning None while _connected looks True — connect() itself no-ops when
+        # already connected, so the extra call in a race is harmless.
+        if self._proxy is None and self.connection_mode == RPCConnectionMode.RPC:
             self.connect()
         return self._proxy
 
@@ -563,8 +577,22 @@ class RPCClientBase:
         if self._direct_server is not None:
             return getattr(self._direct_server, method_name)(*args, **kwargs)
 
+        # Circuit breaker: while open (a recent self-heal or connect already failed), this call
+        # gets ONE fast attempt — quick connect, no self-heal cycles, no settle sleeps — so an
+        # outage costs each caller ~0.3s instead of ~4-8s of blocked thread. Any success closes
+        # the breaker.
+        breaker_open = time.time() < self._backoff_until
+
         # ---- First attempt (lazy-connects on first use) ----
-        proxy = self._ensure_proxy()
+        try:
+            if breaker_open and self._proxy is None:
+                self.connect(max_retries=1, retry_delay=0.25)
+            proxy = self._ensure_proxy()
+        except Exception:
+            # Even the connect failed — open (or extend) the breaker so concurrent/subsequent
+            # calls fail fast instead of each paying the full connect-retry penalty.
+            self._backoff_until = time.time() + self._BACKOFF_WINDOW_S
+            raise
         generation = self._connection_generation
         try:
             result = getattr(proxy, method_name)(*args, **kwargs)
@@ -572,16 +600,28 @@ class RPCClientBase:
             # route through here now), and repr-ing large payloads (metagraph/position lists) on
             # the hot path would cost even when trace logging is disabled. Name + result type only.
             logger.debug(f"{self.service_name}Client.{method_name} -> {type(result).__name__}")
+            if self._backoff_until:
+                self._backoff_until = 0.0
             return result
         except Exception as e:
             if not ErrorUtils.is_transient_rpc_error(e):
                 # Business rejection / missing method / etc. — do NOT reconnect or retry.
                 raise
+            # Type says transient — but multiprocessing transports server-raised exceptions
+            # VERBATIM, so an OSError subclass raised by the server's own business logic (e.g.
+            # a position-lock TimeoutError under contention) is type-identical to a dead socket.
+            # Disambiguate by probing the SAME connection: if it still serves calls, the error
+            # came from the server's logic — re-executing the method would multiply real work
+            # (6x the full order pipeline per the review) for nothing. Probe cost is one cheap
+            # RPC, on error paths only.
+            if self._transport_probe_ok(proxy):
+                raise
             last_error = e
 
         # Fail-fast opt-out: drop the poisoned connection (de-duped) so the next call reconnects,
         # then re-raise now instead of running the multi-cycle self-heal.
-        if not retry:
+        if not retry or breaker_open:
+            self._backoff_until = time.time() + self._BACKOFF_WINDOW_S
             with self._conn_lock:
                 if self._connection_generation == generation:
                     self._reset_connection()
@@ -623,14 +663,20 @@ class RPCClientBase:
                 except Exception as e2:
                     if not ErrorUtils.is_transient_rpc_error(e2):
                         raise
+                    if self._transport_probe_ok(proxy):
+                        # Fresh connection works — this is the server's own OSError-family
+                        # business exception; stop re-executing (see first-attempt comment).
+                        raise
                     last_error = e2
 
             # Brief settle so a just-restarted server becomes ready before the next cycle.
             if attempt < self._RECONNECT_MAX_RETRIES:
                 time.sleep(self._RECONNECT_RETRY_DELAY_S)
 
-        # All recovery cycles exhausted — drop the (still-dead) connection so a later call
-        # reconnects cleanly, and surface the failure to the caller (placer retry / daemon loop).
+        # All recovery cycles exhausted — open the circuit breaker (subsequent calls fail fast
+        # for _BACKOFF_WINDOW_S), drop the (still-dead) connection so a later call reconnects
+        # cleanly, and surface the failure to the caller (placer retry / daemon loop).
+        self._backoff_until = time.time() + self._BACKOFF_WINDOW_S
         with self._conn_lock:
             if self._connection_generation == generation:
                 self._reset_connection()
@@ -639,6 +685,21 @@ class RPCClientBase:
             f"{self._RECONNECT_MAX_RETRIES} reconnect attempts: {last_error!r}"
         )
         raise last_error
+
+    def _transport_probe_ok(self, proxy) -> bool:
+        """
+        True if the connection that just raised is actually alive — meaning the exception was
+        raised by the SERVER'S code (transported verbatim by multiprocessing) rather than by the
+        transport itself. Every RPCServerBase exposes health_check_rpc, and BaseProxy uses a
+        per-thread connection, so this probes the exact connection the failed call used.
+        """
+        if proxy is None:
+            return False
+        try:
+            proxy.health_check_rpc()
+            return True
+        except Exception:
+            return False
 
     def is_connected(self) -> bool:
         """Check if client is connected (or has direct server)."""
@@ -710,9 +771,13 @@ class RPCClientBase:
             except Exception as e:
                 logger.debug(f"{self.service_name}Client error during manager cleanup: {e}")
 
+        # Write order is load-bearing: _connected FIRST, then _proxy. _ensure_proxy reads these
+        # unlocked; the reverse order exposed (_proxy=None, _connected=True), which skipped the
+        # reconnect and produced getattr(None, method) -> AttributeError — misclassified as a
+        # permanent business error on the order path.
+        self._connected = False
         self._manager = None
         self._proxy = None
-        self._connected = False
 
     def _reset_connection(self) -> None:
         """

--- a/shared_objects/rpc/server_orchestrator.py
+++ b/shared_objects/rpc/server_orchestrator.py
@@ -679,8 +679,24 @@ class ServerOrchestrator:
             if scoped_start:
                 logger.info("Scoped start: skipping global RPC-port kill (each server clears its "
                                 "own port) so we don't kill another tier's servers.")
-            else:
+            elif mode == ServerMode.TESTING:
+                # Test cleanup keeps the nuclear sweep — tests own the whole port range.
                 PortManager.force_kill_all_rpc_ports()
+            else:
+                # Production boot: clear ONLY the ports this start will own (covers orphaned
+                # children of a previous crashed run). The all-RPC-ports sweep is NOT safe here:
+                # vanta-rest (:50022) and vanta-ws (:50014) hold RPC_* ports but are sibling PM2
+                # apps the orchestrator never starts — the sweep SIGKILLed them on every core
+                # restart under --serve without --split-state, and killed a stale vanta-state's
+                # servers during a rollback. A listener owned by another app is not ours to kill.
+                own_ports = set()
+                for _name in servers_to_start:
+                    _cls = self.SERVERS[_name].server_class
+                    _port = getattr(_cls, 'service_port', None)
+                    if isinstance(_port, int):
+                        own_ports.add(_port)
+                logger.info(f"Unscoped start: clearing only this tier's {len(own_ports)} server ports")
+                PortManager.force_kill_ports(sorted(own_ports))
 
             # Start servers in parallel using ThreadPoolExecutor
             start_order = self._get_start_order(servers_to_start)

--- a/tests/shared_objects/test_rpc_client_reconnect.py
+++ b/tests/shared_objects/test_rpc_client_reconnect.py
@@ -211,6 +211,70 @@ def test_reset_connection_preserves_registration_and_cache_daemon(client):
     assert client not in RPCClientBase._active_instances
 
 
+def test_server_raised_oserror_with_healthy_transport_not_retried(client):
+    """A server-side OSError-family BUSINESS exception (e.g. position-lock TimeoutError) arrives
+    type-identical to a dead socket — but the transport probe (health_check_rpc on the same
+    connection) succeeds, so the client must re-raise WITHOUT reconnecting or re-executing."""
+    state = {"connects": 0, "target_calls": 0}
+
+    def behavior(name, args, kwargs):
+        if name == "health_check_rpc":
+            return {"status": "healthy"}  # transport is alive
+        state["target_calls"] += 1
+        raise TimeoutError("Failed to acquire lock after 10.0s")  # OSError subclass, server-raised
+
+    _seed_live_but_poisoned(client, behavior)
+    monkeypatch_connect(client, lambda **_k: state.__setitem__("connects", state["connects"] + 1))
+
+    with pytest.raises(TimeoutError):
+        client._invoke_rpc("execute_order_rpc")
+
+    assert state["target_calls"] == 1   # NOT re-executed 5 more times
+    assert state["connects"] == 0       # healthy connection never torn down
+    assert client._connected is True
+
+
+def test_circuit_breaker_fails_fast_after_exhaustion_then_closes_on_success(client):
+    """After self-heal exhaustion the breaker opens: the next call gets ONE fast attempt (no
+    multi-cycle self-heal). A later success closes the breaker."""
+    state = {"connects": 0, "calls": 0, "ready": False}
+
+    def behavior(name, args, kwargs):
+        state["calls"] += 1
+        if not state["ready"]:
+            raise BrokenPipeError(32, "Broken pipe")
+        return "OK"
+
+    _seed_live_but_poisoned(client, behavior)
+
+    def fake_connect(max_retries=None, retry_delay=None):
+        state["connects"] += 1
+        client._proxy = _ScriptedProxy(behavior)
+        client._connected = True
+        client._connection_generation += 1
+        return True
+
+    monkeypatch_connect(client, fake_connect)
+
+    # Exhaust the self-heal — opens the breaker.
+    with pytest.raises(BrokenPipeError):
+        client._invoke_rpc("echo_rpc")
+    assert client._backoff_until > 0
+    connects_after_exhaustion = state["connects"]
+
+    # Breaker open: the next call must fail fast — one reconnect at most, no settle cycles.
+    with pytest.raises(BrokenPipeError):
+        client._invoke_rpc("echo_rpc")
+    assert state["connects"] - connects_after_exhaustion <= 1
+
+    # Server recovers; a successful call closes the breaker.
+    state["ready"] = True
+    client._proxy = _ScriptedProxy(behavior)
+    client._connected = True
+    assert client._invoke_rpc("echo_rpc") == "OK"
+    assert client._backoff_until == 0.0
+
+
 def monkeypatch_connect(client, fn):
     """Replace the instance's connect with a plain function (no `self`), matching how
     _invoke_rpc calls self.connect(max_retries=..., retry_delay=...)."""

--- a/tests/vali_tests/test_order_sync_client.py
+++ b/tests/vali_tests/test_order_sync_client.py
@@ -254,6 +254,29 @@ class TestOrderSyncClient(unittest.TestCase):
         t.join(timeout=1.0)
         self.assertTrue(sync_done[0], "sync proceeds once the admitted order ends")
 
+    def test_sync_gate_lease_expires_when_owner_dies(self):
+        """Core hard-killed mid-sync: no mark_sync_complete, no heartbeat — the gate must
+        auto-clear after the lease instead of rejecting orders until the next sync (~24h)."""
+        self.assertTrue(self.server.wait_for_orders_rpc(timeout_seconds=0.1))
+        self.assertTrue(self.server.is_sync_waiting_rpc())
+        # Owner dies: renewals stop. Backdate the last renewal past the lease.
+        self.server._sync_lease_renewed_ms -= (self.server._sync_lease_ms + 1)
+        self.assertFalse(self.server.is_sync_waiting_rpc(), "expired gate auto-clears")
+        self.assertIsNotNone(self.server.begin_order_rpc("post-expiry-order"),
+                             "orders are admitted again after the stale gate expires")
+
+    def test_sync_gate_lease_renewal_keeps_gate_held(self):
+        """A live owner's heartbeat keeps the gate held past the lease window."""
+        self.assertTrue(self.server.wait_for_orders_rpc(timeout_seconds=0.1))
+        self.server._sync_lease_renewed_ms -= (self.server._sync_lease_ms + 1)
+        # Renewal arrives before anyone observes the gate — but a renewal on an
+        # already-expired-but-unobserved gate is still honored (sync_waiting is True).
+        self.assertTrue(self.server.renew_sync_lease_rpc())
+        self.assertTrue(self.server.is_sync_waiting_rpc(), "renewed gate stays held")
+        self.assertIsNone(self.server.begin_order_rpc("order-during-sync"), "orders still gated")
+        self.server.mark_sync_complete_rpc()
+        self.assertFalse(self.server.is_sync_waiting_rpc())
+
     def test_sync_side_does_not_fail_open(self):
         """The sync side must NOT swallow errors — it cannot safely rewrite positions blind."""
         class _RaisingWait:

--- a/tests/vali_tests/test_order_uuid_dedup.py
+++ b/tests/vali_tests/test_order_uuid_dedup.py
@@ -87,14 +87,40 @@ class TestOrderUuidDedup(unittest.TestCase):
     # ==================== Capacity eviction ====================
 
     def test_capacity_eviction_fifo(self):
+        # Capacity applies to CONFIRMED (committed) uuids; claims are provisional until confirmed.
         self.server._order_uuid_capacity = 3
         for u in ["u1", "u2", "u3"]:
             self.dedup.check_and_add(u)
+            self.dedup.confirm(u)
         self.assertEqual(self.server.order_uuid_count_rpc(), 3)
-        self.dedup.check_and_add("u4")  # evicts u1 (oldest)
+        self.dedup.check_and_add("u4")
+        self.dedup.confirm("u4")  # evicts u1 (oldest)
         self.assertEqual(self.server.order_uuid_count_rpc(), 3)
         self.assertFalse(self.server.order_uuid_exists_rpc("u1"), "oldest evicted")
         self.assertTrue(self.server.order_uuid_exists_rpc("u4"))
+
+    # ==================== Two-phase claims (provisional -> confirm/release/TTL) ====================
+
+    def test_provisional_claim_rejects_duplicates_until_ttl(self):
+        """A live provisional claim rejects duplicates; an expired one (claimant hard-killed
+        mid-apply, release never ran) lets the miner's retry re-claim."""
+        self.assertTrue(self.dedup.check_and_add("crash-uuid"))
+        other = self._new_client()
+        self.assertFalse(other.check_and_add("crash-uuid"), "live claim rejects the duplicate")
+        # Simulate claim expiry (hard-killed claimant never confirmed or released).
+        self.server._order_uuid_provisional["crash-uuid"] -= (self.server._order_uuid_claim_ttl_ms + 1)
+        self.assertTrue(other.check_and_add("crash-uuid"),
+                        "expired provisional claim is reclaimable — the order never committed")
+
+    def test_confirmed_claim_never_expires_via_ttl(self):
+        """confirm() promotes the claim to the permanent set: even with an expired TTL, a
+        duplicate of a COMMITTED order is still rejected."""
+        self.assertTrue(self.dedup.check_and_add("committed-uuid"))
+        self.dedup.confirm("committed-uuid")
+        self.server._order_uuid_claim_ttl_ms = 0
+        other = self._new_client()
+        self.assertFalse(other.check_and_add("committed-uuid"),
+                         "confirmed uuid is permanent (FIFO-evicted only)")
 
     # ==================== The two scenarios this feature exists for ====================
 

--- a/tests/vali_tests/test_position_lock.py
+++ b/tests/vali_tests/test_position_lock.py
@@ -291,6 +291,41 @@ class TestPositionLockBehavior(TestBase):
                 # Both locks held
                 pass
 
+    def test_stale_release_after_lease_reclaim_is_noop(self):
+        """A lease-reclaimed holder's late release must NOT free the reclaimer's lock.
+
+        Sequence: A acquires; A's hold exceeds the lease; B's acquire reclaims and takes the
+        lock; A's (stale-token) release arrives late — it must be ignored, so a third acquire
+        still blocks while B holds.
+        """
+        from shared_objects.locks.position_lock_server import PositionLockServer
+        server = PositionLockServer(running_unit_tests=True, start_server=False, start_daemon=False)
+        miner = "test_miner_stale_release"
+        trade_pair = "BTCUSD"
+        lock_key = (miner, trade_pair)
+
+        token_a = server.acquire_rpc(miner, trade_pair, timeout=2.0)
+        self.assertTrue(token_a)
+        # Backdate A's hold past the lease so B's acquire reclaims it.
+        with server.locks_dict_lock:
+            tok, held_at = server.lock_owner[lock_key]
+            server.lock_owner[lock_key] = (tok, held_at - (server._lock_lease_ms + 1))
+
+        token_b = server.acquire_rpc(miner, trade_pair, timeout=2.0)
+        self.assertTrue(token_b, "B reclaims the stale hold and acquires")
+        self.assertNotEqual(token_a, token_b)
+
+        # A's late release with its stale token: ignored, B still holds.
+        self.assertFalse(server.release_rpc(miner, trade_pair, token_a))
+        self.assertFalse(server.acquire_rpc(miner, trade_pair, timeout=0.2),
+                         "lock must still be held by B after A's stale release")
+
+        # B's own release works.
+        self.assertTrue(server.release_rpc(miner, trade_pair, token_b))
+        token_c = server.acquire_rpc(miner, trade_pair, timeout=1.0)
+        self.assertTrue(token_c)
+        server.release_rpc(miner, trade_pair, token_c)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/vali_objects/data_sync/order_sync_client.py
+++ b/vali_objects/data_sync/order_sync_client.py
@@ -19,10 +19,12 @@ degrades to False and begin/end degrade to no-ops — orders keep flowing. The S
 fail open: if it cannot confirm orders are quiesced it must not proceed with a checkpoint-wide
 rewrite, so wait_for_orders errors propagate to the caller.
 """
+import threading
+
 import bittensor as bt
 
 from shared_objects.rpc.common_data_client import CommonDataClient
-from vali_objects.vali_config import RPCConnectionMode
+from vali_objects.vali_config import RPCConnectionMode, ValiConfig
 
 
 class OrderSyncClient:
@@ -115,18 +117,46 @@ class OrderSyncClient:
             return False  # never suppress the order's own exception
 
     class _SyncContext:
-        """Waits for orders to drain on enter (raising on timeout), clears sync_waiting on exit."""
+        """
+        Waits for orders to drain on enter (raising on timeout), clears sync_waiting on exit.
+
+        While held, a daemon heartbeat thread renews the gate's server-side lease every
+        SYNC_LEASE_RENEW_INTERVAL_S. The gate lives on CommonDataServer in another process; if
+        THIS process (core) is hard-killed mid-sync, the heartbeat dies with it and the server
+        auto-clears the gate after SYNC_WAITING_LEASE_MS — instead of rejecting every order
+        network-wide until the next successful sync. Renewal errors are swallowed (a blip must
+        not kill the sync); a dead server means orders aren't being gated anyway.
+        """
         def __init__(self, client: CommonDataClient, timeout_seconds: float = None):
             self.client = client
             self.timeout_seconds = timeout_seconds
             self.acquired = False
+            self._stop_heartbeat = threading.Event()
+            self._heartbeat_thread = None
+
+        def _heartbeat(self):
+            while not self._stop_heartbeat.wait(ValiConfig.SYNC_LEASE_RENEW_INTERVAL_S):
+                try:
+                    if not self.client.renew_sync_lease():
+                        bt.logging.error(
+                            "OrderSyncClient: sync gate no longer held (lease expired or cleared) "
+                            "— the in-progress sync has lost its exclusion window"
+                        )
+                        return
+                except Exception as e:
+                    bt.logging.warning(f"OrderSyncClient: sync-lease renewal failed (continuing): {e}")
 
         def __enter__(self):
             self.acquired = self.client.wait_for_orders(self.timeout_seconds)
             if not self.acquired:
                 raise TimeoutError("Timeout waiting for orders to complete")
+            self._heartbeat_thread = threading.Thread(
+                target=self._heartbeat, name="sync-lease-heartbeat", daemon=True
+            )
+            self._heartbeat_thread.start()
             return self
 
         def __exit__(self, exc_type, exc_val, exc_tb):
+            self._stop_heartbeat.set()
             self.client.mark_sync_complete()
             return False

--- a/vali_objects/order_uuid_dedup_client.py
+++ b/vali_objects/order_uuid_dedup_client.py
@@ -117,6 +117,17 @@ class OrderUuidDedupClient:
         self._remember_local(uuid)
         return claimed
 
+    def confirm(self, uuid) -> None:
+        """Promote a provisional claim to the permanent dedup set — call after the order COMMITTED.
+        Best-effort: a failed confirm must never raise out of the order handler; the provisional
+        claim keeps rejecting duplicates until its TTL, by which point the placer has its ack."""
+        if not uuid:
+            return
+        try:
+            self._client.confirm_order_uuid(uuid)
+        except Exception as e:
+            bt.logging.warning(f"OrderUuidDedupClient.confirm best-effort (dedup unreachable): {e}")
+
     def release(self, uuid) -> None:
         """Undo a claim after an apply failure (server-authoritative), and drop it from the cache.
         Best-effort: a failed release RPC must never raise out of the order handler (see

--- a/vali_objects/utils/limit_order/limit_order_manager.py
+++ b/vali_objects/utils/limit_order/limit_order_manager.py
@@ -358,7 +358,18 @@ class LimitOrderManager(CacheController):
                 if existing_order.src not in [OrderSource.LIMIT_UNFILLED, OrderSource.BRACKET_UNFILLED, OrderSource.STOP_LIMIT_UNFILLED]:
                     raise SignalException(f"Cannot edit order {order_uuid}: order is no longer unfilled (race condition)")
             else:
-                # NEW ORDER PATH: Check max unfilled orders limit
+                # NEW ORDER PATH: idempotent replay guard — a retried process_limit_order (RPC
+                # self-heal or placer resend after a lost ack) with an already-registered uuid
+                # returns the standing order instead of appending a duplicate.
+                existing_order = self._find_existing_order_under_lock(miner_hotkey, order_uuid)
+                if existing_order:
+                    logger.warning(
+                        f"Limit order [{order_uuid}] already registered for {miner_hotkey} — "
+                        f"returning existing (idempotent replay)"
+                    )
+                    return {"status": "success", "order_uuid": order_uuid, "replayed": True}
+
+                # Check max unfilled orders limit
                 total_unfilled = self._count_unfilled_orders_for_hotkey(miner_hotkey)
                 if total_unfilled >= ValiConfig.MAX_UNFILLED_LIMIT_ORDERS:
                     raise SignalException(
@@ -368,6 +379,18 @@ class LimitOrderManager(CacheController):
 
             # Get position for validation
             open_position = self._get_open_position(miner_hotkey, order)
+
+            # Replay guard, filled case: a limit order that filled immediately on its first apply
+            # lives in the position (not the unfilled book), so the check above misses it. Answer
+            # the replay idempotently instead of re-validating and re-filling a committed order.
+            if not is_edit and open_position is not None and any(
+                o.order_uuid == order_uuid for o in open_position.orders
+            ):
+                logger.warning(
+                    f"Limit order [{order_uuid}] already filled into position for {miner_hotkey} — "
+                    f"idempotent replay, not re-filling"
+                )
+                return {"status": "success", "order_uuid": order_uuid, "replayed": True}
 
             # Validate order using shared validation logic (business rules)
             if order.execution_type == ExecutionType.BRACKET:
@@ -1285,6 +1308,14 @@ class LimitOrderManager(CacheController):
                     self._last_fill_time[trade_pair][miner_hotkey] = 0
 
                 for bracket_data in brackets_to_create:
+                    # Idempotent replay guard: bracket uuids are deterministic
+                    # ("{parent_uuid}-bracket-{i}"), so a retried create_sltp_order (RPC self-heal
+                    # or placer resend of a committed parent) must not append duplicate brackets.
+                    if self._find_existing_order_under_lock(miner_hotkey, bracket_data['uuid']):
+                        logger.warning(
+                            f"Bracket order [{bracket_data['uuid']}] already exists — skipping (idempotent replay)"
+                        )
+                        continue
                     # Build trailing_stop dict for the Order if trailing fields present
                     trailing_stop_dict = None
                     if bracket_data.get('trailing_percent') is not None:

--- a/vali_objects/utils/market_order/market_order_manager.py
+++ b/vali_objects/utils/market_order/market_order_manager.py
@@ -63,10 +63,6 @@ class MarketOrderManager():
     ) -> tuple[Order, Position] | None:
         _start = TimeUtil.now_in_millis()
         now_ms = now_ms or _start
-        if enforce_cooldown:
-            err = self.enforce_order_cooldown(trade_pair.trade_pair_id, now_ms, hotkey)
-            if err:
-                raise SignalException(err)
 
         if not self._live_price_client.is_market_open(trade_pair):
             raise SignalException(f"The market for {trade_pair.trade_pair_id} is currently closed.")
@@ -81,6 +77,28 @@ class MarketOrderManager():
             miner_account = self._miner_account_client.get_or_create(hotkey)
             position = self._position_client.get_open_position_for_trade_pair(hotkey, trade_pair.trade_pair_id)
             position_type = position.position_type if position else order_type
+
+            # Idempotent replay guard: if this order_uuid is already committed to durable position
+            # state, return the committed result instead of applying again. This is what makes the
+            # RPC layer's at-least-once retry (and a placer resend after a lost ack) safe — the
+            # retry can land on a freshly restarted server whose in-memory caches (cooldown, dedup)
+            # are empty, so only the on-disk position can witness the first apply. Runs under the
+            # position lock, so it is serialized with all writers of this (hotkey, pair).
+            replayed = self._find_committed_order(hotkey, trade_pair.trade_pair_id, order_uuid, position)
+            if replayed is not None:
+                logger.warning(
+                    f"[ORDER_EXECUTION] {hotkey} {order_uuid} replay of an already-committed order "
+                    f"— returning the committed result (idempotent no-op)"
+                )
+                return replayed
+
+            # Cooldown is enforced under the lock (as its docstring requires) and AFTER the replay
+            # guard, so a legitimate replay is answered idempotently rather than bounced as
+            # "placed too soon" against its own first apply.
+            if enforce_cooldown:
+                err = self.enforce_order_cooldown(trade_pair.trade_pair_id, now_ms, hotkey)
+                if err:
+                    raise SignalException(err)
 
             if fill_price is None or not price_sources:
                 price_sources = self._live_price_client.get_sorted_price_sources_for_trade_pair(trade_pair, now_ms)
@@ -137,6 +155,42 @@ class MarketOrderManager():
             )
             logger.info(f"[ORDER_EXECUTION] {hotkey} {order_uuid} completed in {TimeUtil.now_in_millis() - _start}ms")
             return order, position
+
+    def _find_committed_order(
+        self,
+        hotkey: str,
+        trade_pair_id: str,
+        order_uuid: str,
+        open_position: Position | None,
+    ) -> tuple[Order, Position] | None:
+        """
+        Return the committed (order, position) for order_uuid if a prior apply already persisted
+        it, else None. Caller must hold the position lock. The open position (already fetched by
+        the caller) answers the common case without extra I/O; the closed-position scan only runs
+        when the uuid might have closed its position (e.g. the first apply flattened it).
+        """
+        if not order_uuid:
+            return None
+        if open_position is not None:
+            for o in open_position.orders:
+                if o.order_uuid == order_uuid:
+                    return o, open_position
+        # Not in the open position: the first apply may have closed the position (FLAT or an
+        # effective close), leaving the uuid only in a closed position for this trade pair.
+        try:
+            all_positions = self._position_client.get_positions_for_one_hotkey(hotkey) or []
+        except Exception as e:
+            # Best-effort widening of the guard: if the lookup fails, fall through to the normal
+            # apply path (the open-position check above already covered the likeliest replay).
+            logger.warning(f"[ORDER_EXECUTION] {hotkey} {order_uuid} replay-guard closed-position lookup failed: {e}")
+            return None
+        for p in all_positions:
+            if p.trade_pair.trade_pair_id != trade_pair_id:
+                continue
+            for o in p.orders:
+                if o.order_uuid == order_uuid:
+                    return o, p
+        return None
 
     def _apply_order(
         self,

--- a/vali_objects/utils/order_processor.py
+++ b/vali_objects/utils/order_processor.py
@@ -195,12 +195,22 @@ class OrderProcessor:
             return OrderProcessingResult(ExecutionType.MARKET)
 
         created_order, updated_position = result
-        if updated_position and updated_position.is_closed_position:
-            self.process_limit_cancel(hotkey, trade_pair, "ALL", now_ms, ExecutionType.BRACKET)
+        # POST-COMMIT side effects: the position write above is durable. A failure past this point
+        # must NOT propagate — the handler's except path treats any exception as "apply failed",
+        # releases the uuid claim, and invites the placer to resend, which would double-apply a
+        # committed order. Brackets/cancels are best-effort against a bouncing LimitOrderServer.
+        try:
+            if updated_position and updated_position.is_closed_position:
+                self.process_limit_cancel(hotkey, trade_pair, "ALL", now_ms, ExecutionType.BRACKET)
 
-        if created_order and (updated_position and not updated_position.is_closed_position) and signal.bracket_orders:
-            created_order.bracket_orders = signal.bracket_orders
-            self.limit_order_client.create_sltp_order(hotkey, created_order)
+            if created_order and (updated_position and not updated_position.is_closed_position) and signal.bracket_orders:
+                created_order.bracket_orders = signal.bracket_orders
+                self.limit_order_client.create_sltp_order(hotkey, created_order)
+        except Exception as e:
+            logger.error(
+                f"[ORDER_PROCESSOR] {hotkey} {order_uuid} order COMMITTED but post-commit "
+                f"bracket/cancel side effect failed (order stands, brackets may be missing): {e}"
+            )
 
         return OrderProcessingResult(
             execution_type=ExecutionType.MARKET,
@@ -223,7 +233,14 @@ class OrderProcessor:
             close_all=close_all,
             now_ms=now_ms,
         )
-        self.process_limit_cancel(hotkey, None, "ALL", now_ms, ExecutionType.BRACKET)
+        # Post-commit: positions are closed above; a failed bracket sweep must not turn the
+        # committed close into an "apply failed" resend (see process_market_order).
+        try:
+            self.process_limit_cancel(hotkey, None, "ALL", now_ms, ExecutionType.BRACKET)
+        except Exception as e:
+            logger.error(
+                f"[ORDER_PROCESSOR] {hotkey} FLAT_ALL COMMITTED but post-commit bracket cancel failed: {e}"
+            )
         return OrderProcessingResult(execution_type=ExecutionType.FLAT_ALL, should_track_uuid=True)
 
 

--- a/vali_objects/uuid_tracker.py
+++ b/vali_objects/uuid_tracker.py
@@ -60,6 +60,12 @@ class UUIDTracker:
         OrderUuidDedupClient.release."""
         self.remove(uuid)
 
+    def confirm(self, uuid) -> None:
+        """No-op API mirror of OrderUuidDedupClient.confirm: in-process claims are already
+        permanent (check_and_add records directly), and process death loses the whole tracker
+        anyway (rebuilt from on-disk positions at boot)."""
+        pass
+
     def exists(self, uuid):
         with self.lock:  # Ensure exclusive access within this block
             return uuid in self.uuid_set

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -298,6 +298,12 @@ class ValiConfig:
     # 100k. Dedup only needs to cover the retry/replay window (seconds–minutes), not forever;
     # oldest uuids are evicted past capacity.
     ORDER_UUID_DEDUP_CAPACITY = 100_000
+    # A claimed-but-unconfirmed order uuid (check_and_add taken, confirm/release never called —
+    # the claimant was hard-killed mid-apply) expires after this long, so a miner's retry of an
+    # order that never committed is not permanently rejected as a duplicate. Confirmed uuids
+    # (post-commit) never expire this way — they live in the FIFO dedup set. Must exceed the
+    # longest real apply (lock wait + RPC self-heal cycles + price fetches).
+    ORDER_UUID_CLAIM_TTL_MS = 300_000  # 5 minutes
     # Position-lock lease (never-release protection): a server-side (hotkey, trade_pair) lock held
     # longer than this is presumed abandoned (holder crashed between acquire and release) and
     # force-reclaimed on the next acquire. Set FAR above any real hold (order processing is a few

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -290,9 +290,12 @@ class ValiConfig:
     # Cross-process order/sync coordination (spec R2.4): an in-flight order registration on
     # CommonDataServer older than this is treated as abandoned (the producer — e.g. vanta-orders —
     # crashed mid-order) and reaped, so it can't block position sync forever. Must comfortably
-    # exceed the worst-case real order-processing time (lock wait + price fetch + write, ~seconds)
-    # to avoid reaping a genuinely-live order; sync is infrequent (daily) so a generous value is fine.
-    ORDER_INFLIGHT_TTL_MS = 60_000  # 60 seconds
+    # exceed the worst-case real order-processing time — which is NOT "~seconds": a hung (not dead)
+    # state server blocks the apply silently (BaseManager calls have no transport timeout), and
+    # lock waits (10s/attempt) plus RPC self-heal cycles stack on top. Reaping a live order lets
+    # the checkpoint-wide sync rewrite race that order's eventual position write. Sync is
+    # infrequent (daily), so waiting minutes for a straggler is far cheaper than that race.
+    ORDER_INFLIGHT_TTL_MS = 300_000  # 5 minutes
     # Server-side order-UUID dedup (spec R2.6): FIFO capacity of the authoritative dedup set on
     # CommonDataServer that replaces the process-local UUIDTracker. Matches UUIDTracker's historic
     # 100k. Dedup only needs to cover the retry/replay window (seconds–minutes), not forever;
@@ -306,11 +309,14 @@ class ValiConfig:
     ORDER_UUID_CLAIM_TTL_MS = 300_000  # 5 minutes
     # Position-lock lease (never-release protection): a server-side (hotkey, trade_pair) lock held
     # longer than this is presumed abandoned (holder crashed between acquire and release) and
-    # force-reclaimed on the next acquire. Set FAR above any real hold (order processing is a few
-    # seconds: lock wait + price fetch + write) so a live-but-slow holder is never reclaimed; the
-    # hazard it guards is a crashed vanta-orders process leaking a lock forever. Analog of
-    # ORDER_INFLIGHT_TTL_MS for the position-lock server.
-    POSITION_LOCK_LEASE_MS = 60_000  # 60 seconds
+    # force-reclaimed on the next acquire. Must sit FAR above the worst LEGITIMATE hold — which is
+    # minutes, not seconds: mdd_checker._refresh_position_prices holds this exact lock while making
+    # one historical Polygon REST call per recent order (5-min window, ~5s order cadence => dozens
+    # of calls at 1-3s+ each under normal latency, worse when rate-limited). Reclaiming a live
+    # holder puts two writers on one position. Releases are owner-token-checked (see
+    # PositionLockServer), so a reclaimed holder's late release can no longer free the reclaimer's
+    # lock. Analog of ORDER_INFLIGHT_TTL_MS for the position-lock server.
+    POSITION_LOCK_LEASE_MS = 600_000  # 10 minutes
     ORDER_MIN_LEVERAGE = 0.00001
     ORDER_MAX_LEVERAGE = 500
 

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -307,6 +307,13 @@ class ValiConfig:
     # (post-commit) never expire this way — they live in the FIFO dedup set. Must exceed the
     # longest real apply (lock wait + RPC self-heal cycles + price fetches).
     ORDER_UUID_CLAIM_TTL_MS = 300_000  # 5 minutes
+    # Lease on the cross-process sync gate (sync_waiting on CommonDataServer): the sync side
+    # (core) renews it via a heartbeat while its sync runs; if core is hard-killed mid-sync the
+    # renewals stop and the gate auto-clears after this long, instead of rejecting every order
+    # network-wide until the next successful sync (potentially ~24h). Must exceed the heartbeat
+    # interval (60s) by enough to ride out core GC pauses / brief stalls.
+    SYNC_WAITING_LEASE_MS = 300_000  # 5 minutes
+    SYNC_LEASE_RENEW_INTERVAL_S = 60  # core heartbeat cadence while a sync holds the gate
     # Position-lock lease (never-release protection): a server-side (hotkey, trade_pair) lock held
     # longer than this is presumed abandoned (holder crashed between acquire and release) and
     # force-reclaimed on the next acquire. Must sit FAR above the worst LEGITIMATE hold — which is

--- a/vanta_api/run_rest_server.py
+++ b/vanta_api/run_rest_server.py
@@ -39,8 +39,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
                         help="Subnet netuid; is_mainnet is derived as (netuid == 8). Default: 8.")
     parser.add_argument("--api-keys-file", type=str, default=None,
                         help="Path to the API keys JSON file. Default: ValiBkpUtils.get_api_keys_file_path().")
-    parser.add_argument("--host", type=str, default="0.0.0.0",
-                        help="Host to bind the Flask HTTP server. Default: 0.0.0.0 (external reachability).")
+    parser.add_argument("--host", type=str, default="127.0.0.1",
+                        help="Host to bind the Flask HTTP server. Default: 127.0.0.1 — parity with "
+                             "the in-core spawn's --api-host default, so the split never widens the "
+                             "bind surface an operator didn't ask for. Pass 0.0.0.0 for external reachability.")
     parser.add_argument("--port", type=int, default=None,
                         help=f"Port for the Flask HTTP server. Default: ValiConfig.REST_API_PORT ({ValiConfig.REST_API_PORT}).")
     parser.add_argument("--refresh-interval", type=int, default=15,

--- a/vanta_api/run_state_server.py
+++ b/vanta_api/run_state_server.py
@@ -111,6 +111,19 @@ def main() -> int:
     signal.signal(signal.SIGTERM, _sigterm_to_keyboard_interrupt)
 
     try:
+        # Run on-disk state migrations BEFORE any server loads that state. vanta-state starts
+        # FIRST (run.sh ordering) and its servers (position_manager, limit_order, miner_account)
+        # load exactly the files migrations rewrite — if core ran them instead (as the monolith
+        # does), it would migrate the files AFTER this tier already loaded pre-migration data,
+        # and this tier's next save would clobber the migrated file while migrations_completed.txt
+        # marks it done forever. Core skips migrations under --split-state for this reason.
+        from runnable.run_migrations import main as run_migrations
+        bt.logging.info("[vanta-state] Checking for pending migrations (state tier owns them under --split-state)...")
+        if not run_migrations():
+            bt.logging.error("[vanta-state] Migration failed. Starting state servers without executing migrations")
+        else:
+            bt.logging.info("[vanta-state] Migrations completed successfully.")
+
         # Start the include-set (scoped start: skips the global RPC-port kill so we never take down
         # core's subtensor_ops or other core-held ports).
         orchestrator.start_state_servers(context)

--- a/vanta_api/run_ws_server.py
+++ b/vanta_api/run_ws_server.py
@@ -55,8 +55,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
                              "mainnet-specific behavior, so this is informational only.")
     parser.add_argument("--api-keys-file", type=str, default=None,
                         help="Path to the API keys JSON file. Default: ValiBkpUtils.get_api_keys_file_path().")
-    parser.add_argument("--host", type=str, default="0.0.0.0",
-                        help="Host to bind the WebSocket server. Default: 0.0.0.0 (external reachability).")
+    parser.add_argument("--host", type=str, default="127.0.0.1",
+                        help="Host to bind the WebSocket server. Default: 127.0.0.1 — parity with "
+                             "the in-core spawn's --api-host default, so the split never widens the "
+                             "bind surface an operator didn't ask for. Pass 0.0.0.0 for external reachability.")
     parser.add_argument("--port", type=int, default=None,
                         help=f"Port for the WebSocket server. Default: ValiConfig.VANTA_WEBSOCKET_PORT ({ValiConfig.VANTA_WEBSOCKET_PORT}).")
     parser.add_argument("--refresh-interval", type=int, default=15,


### PR DESCRIPTION
## Summary

Hardening pass over the order-HA / process-split work, fixing the 16 defects confirmed by an adversarial review of `test/order-ha2` (rebased onto main `881bd1b5`). Full review report: https://claude.ai/code/artifact/070300bf-fa6b-4eb9-b694-2ac3acea5da4

One commit per work package:

### WP1 — Order-path idempotency (3 critical findings)
At-least-once delivery (RPC self-heal re-invocation, placer resends after a lost ack) was landing on non-idempotent order writes → **double-applied orders** (doubled exposure → wrongful 5%/8% drawdown eliminations).
- `MarketOrderManager.execute_order`: replay guard under the position lock returns the committed `(order, position)` when the uuid is already in durable position state; cooldown moved inside the lock, after the guard.
- `OrderProcessor`: bracket create/cancel after the position write are **post-commit** — failures no longer propagate as "apply failed" (which released the uuid claim and invited a resend of a committed order).
- Two-phase uuid claims on `CommonDataServer`: `check_and_add` → provisional (TTL 5 min), `confirm` → permanent post-commit, `release` → drop. A hard-killed claimant no longer strands a uuid forever; duplicates of committed orders are still rejected.
- `LimitOrderManager`: replayed limit/bracket uuids answered idempotently instead of appended as duplicates.

### WP2 — Lock owner tokens + realistic lease/TTL (1 critical)
The 60s lock lease force-released live-but-slow holders (mdd_checker's per-order Polygon fetches hold one lock for minutes), and `threading.Lock` has no holder identity — a reclaimed holder's late release freed the *reclaimer's* lock (2–3 concurrent writers on one position, **default monolith path**). `acquire_rpc` now returns an owner token; `release_rpc` is token-checked; lease 60s → 10 min; in-flight order TTL 60s → 5 min.

### WP3 — Sync-gate lease + heartbeat (1 high, found by 3 reviewers)
Core hard-killed mid-sync latched `sync_waiting=True` on the surviving vanta-state → every order network-wide rejected until the next sync (~24h). The gate now carries a 5-min lease renewed by a 60s heartbeat from core's `_SyncContext`; a dead owner auto-clears the gate.

### WP4 — Deploy safety (3 high, 1 medium)
- Port sweep: `lsof` matching is LISTEN-only, and the unscoped production boot clears **only the ports it will own** — it was SIGKILLing vanta-rest/vanta-ws on every core restart under `--serve` (PM2 'errored' → order intake down until manual restart).
- run.sh deletes split apps whose flags were dropped, before starting anything — rollback no longer triggers the mutual-SIGKILL port war between a stale vanta-state and the monolith core.
- vanta-orders waits (≤600s) for the metagraph to populate instead of reading core's bound-but-empty metagraph as "not registered" and `exit()`ing into a crash-loop.
- `--api-host/--api-rest-port/--api-ws-port` forwarded to vanta-rest/vanta-ws; split apps default to `127.0.0.1` (parity with in-core `--api-host`) — no silent bind move / exposure widening on relaunch.

### WP5 — Migration ordering under `--split-state` (1 high)
Migrations now run in vanta-state *before* its servers load the files they rewrite; core skips them when split. Previously core migrated the files underneath the live state tier, whose next save silently undid the migration forever.

### WP6 — Client hardening (3 medium, 1 low)
- Transport-vs-business disambiguation: on a "transient" OSError-family error, probe the same connection with `health_check_rpc`; a live transport means the server's own business exception (e.g. position-lock `TimeoutError`) — re-raise instead of re-executing the order pipeline 6x (~64s pinned thread each).
- Circuit breaker (5s window): after a failed self-heal/connect, calls fail fast (~0.3s) instead of ~4–8s of blocked thread each — a vanta-state restart no longer saturates the 32-thread axon/waitress pools.
- Hyperliquid fills hitting a transient dispatch failure are queued and replayed (≈1h tolerance) instead of dropped forever.
- Entity-dashboard broadcast in the ack path is best-effort (was replacing crafted success synapses with axon errors during core restarts).
- `_teardown_transport` write-order race fixed (`getattr(None, method)` → permanent order rejection).

## Test plan

- All new/changed behavior covered by regression tests: two-phase uuid claims (TTL expiry, confirm permanence), stale-token lock release after lease reclaim, sync-gate lease expiry + renewal.
- Full touched-area suite run per-module in isolated pytest processes on this branch vs the unfixed `test/order-ha2` baseline: zero regressions (results in PR conversation).
- Pre-existing failures on the base branch (`test_hyperliquid` drift, inherited from main) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
