### PR TITLE
Write positions to a per-hotkey file

### DIFF
--- a/miner_objects/position_inspector.py
+++ b/miner_objects/position_inspector.py
@@ -5,6 +5,7 @@ import time
 import asyncio
 import json
 import shutil
+import threading
 import os
 
 from miner_config import MinerConfig
@@ -175,7 +176,19 @@ class PositionInspector:
         """
         try:
             file_path = MinerConfig.get_position_file_location()
-            temp_path = file_path + ".tmp"
+            # get_position_file_location() is process-global. That is correct for one
+            # wallet per process, but a host running several miners in a single process
+            # has every PositionInspector writing the same path: the file ends up holding
+            # whichever wallet finished last and the rest are silently discarded. Keying
+            # the destination by hotkey keeps each wallet's positions separate.
+            hotkey = getattr(getattr(self.wallet, "hotkey", None), "ss58_address", None)
+            if hotkey:
+                root, ext = os.path.splitext(file_path)
+                file_path = f"{root}-{hotkey}{ext}"
+            # A shared temp name races the same way, and worse: the first shutil.move
+            # renames it away, so every other writer fails with ENOENT and reports
+            # "Failed to save positions to disk" while nothing is actually wrong.
+            temp_path = f"{file_path}.tmp.{os.getpid()}.{threading.get_ident()}"
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(temp_path, 'w') as f:
                 json.dump(positions if positions else [], f, indent=2)


### PR DESCRIPTION
### What

`PositionInspector.write_positions_to_disk()` resolves its destination through `MinerConfig.get_position_file_location()`, which returns a single process-global path. This keys the destination by the wallet's hotkey and gives each writer a unique temp name.

### Why

With one wallet per process the current behaviour is correct. When several miners share a process it fails in two ways:

1. **Positions are lost silently.** Every `PositionInspector` in the process writes the same path, so the file ends up holding whichever wallet finished last. The other wallets' positions are discarded and nothing is logged.

2. **The temp path races, and reports the wrong thing.** All writers use `file_path + ".tmp"`. The first `shutil.move` renames it out from under the others, so each of them raises `ENOENT` and logs `Failed to save positions to disk` — even though that writer did nothing wrong. The message points at disk or permissions when the actual cause is a collision between writers.

We hit both running a set of miners in one process to cut memory (roughly 4.7 GB across separate processes down to ~280 MB, since `ServerOrchestrator` is already an explicit singleton and a miner binds no axon). The first symptom was a wave of `Failed to save positions to disk` errors, which is what sent us looking; the lost positions underneath were the quieter half.

### Note on the filename

The destination becomes `mining/positions-<hotkey>.json` rather than `mining/positions.json`. Nothing in the repo reads that path — it appears to be an operator-facing dump — but it is a visible change for anyone with their own tooling pointed at the old name. Happy to gate the suffix behind a config flag, or apply it only when more than one wallet is active, if you would rather the default path stayed put.

Single-wallet behaviour is otherwise unchanged.
