### PR TITLE
Emit net_value on the v2 dashboard position frame

### DIFF
--- a/tests/vali_tests/test_position_dashboard_frame.py
+++ b/tests/vali_tests/test_position_dashboard_frame.py
@@ -1,0 +1,113 @@
+"""
+The v2 dashboard frame for a position (`Position.to_dashboard`).
+
+WHY THIS EXISTS. The frame carried `nl` (net_leverage) but never `net_value`,
+and the two are NOT interchangeable downstream: `net_leverage` is
+`net_value / self.account_size` where `account_size` is THIS POSITION's
+snapshot (see `Position.update_position_state`), not the subaccount's nominal
+account size. A dashboard client that receives only `nl` and multiplies by the
+nominal size therefore gets a figure wrong by the ratio between the two —
+constant per account, and measured at up to ~16% (worst case $30,385 on a
+$221K book) across live mainnet subaccounts on 2026-09-01.
+
+That matters beyond display: `get_max_order_size()` compares the per-pair cap
+against `abs(position.net_value)`, so a client sizing from `nl` cannot
+reproduce the very cap its orders are clamped by.
+
+Plain `unittest.TestCase` on purpose — this is pure serialization and needs no
+orchestrator or server fixtures.
+"""
+import unittest
+
+from vali_objects.enums.order_type_enum import OrderType
+from vali_objects.vali_config import TradePair
+from vali_objects.vali_dataclasses.position import Position
+
+
+def _position(**overrides) -> Position:
+    position = Position(
+        miner_hotkey="test_miner",
+        position_uuid="test_position",
+        open_ms=1_700_000_000_000,
+        trade_pair=TradePair.BTCUSD,
+        account_size=100_000,
+        position_type=OrderType.LONG,
+    )
+    for key, value in overrides.items():
+        setattr(position, key, value)
+    return position
+
+
+class TestPositionDashboardFrame(unittest.TestCase):
+    def test_emits_net_value_alongside_net_leverage(self):
+        position = _position(
+            net_leverage=0.25,
+            net_quantity=2.0,
+            net_value=123456.78,
+        )
+
+        frame = position.to_dashboard(0, filled_orders={}, unfilled_orders={})
+
+        self.assertIn("nv", frame)
+        self.assertEqual(frame["nv"], 123456.78)
+        # Both facts must travel together — shipping `nl` alone is the defect.
+        self.assertEqual(frame["nl"], 0.25)
+
+    def test_net_value_is_not_derivable_from_net_leverage_and_nominal_size(self):
+        """
+        The regression this field exists to prevent.
+
+        Here the position's own account_size snapshot ($115,473) differs from
+        the subaccount's nominal $100,000 — an account up ~15%. Reconstructing
+        the value as `nominal_account_size * nl` understates it by that same
+        ratio, which is exactly the error observed in production.
+        """
+        net_value = 86_604.75
+        position_account_size = 115_473.0
+        position = _position(
+            account_size=position_account_size,
+            net_quantity=1.0,
+            net_value=net_value,
+            net_leverage=net_value / position_account_size,
+        )
+
+        frame = position.to_dashboard(0, filled_orders={}, unfilled_orders={})
+
+        reconstructed = 100_000 * frame["nl"]
+        self.assertNotAlmostEqual(reconstructed, net_value, delta=1.0)
+        # The emitted value is exact regardless of the snapshot difference.
+        self.assertEqual(frame["nv"], net_value)
+
+    def test_omits_net_value_when_zero(self):
+        """
+        Same truthiness gate as `nl`: a flat/closed position carries
+        net_value 0.0 and must not grow every frame with a dead key.
+        """
+        position = _position(net_leverage=0.0, net_quantity=0.0, net_value=0.0)
+
+        frame = position.to_dashboard(0, filled_orders={}, unfilled_orders={})
+
+        self.assertNotIn("nv", frame)
+        self.assertNotIn("nl", frame)
+
+    def test_short_position_keeps_the_sign(self):
+        """
+        `net_value` is signed for a SHORT. Consumers compare `abs(net_value)`
+        (as `get_max_order_size` does); the sign is preserved rather than
+        normalised so direction stays recoverable from the frame alone.
+        """
+        position = _position(
+            position_type=OrderType.SHORT,
+            net_quantity=-2.0,
+            net_value=-50_000.0,
+            net_leverage=-0.5,
+        )
+
+        frame = position.to_dashboard(0, filled_orders={}, unfilled_orders={})
+
+        self.assertEqual(frame["nv"], -50_000.0)
+        self.assertEqual(abs(frame["nv"]), 50_000.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_objects/vali_dataclasses/position.py
+++ b/vali_objects/vali_dataclasses/position.py
@@ -270,6 +270,19 @@ class Position(BaseModel):
         if self.net_leverage:
             results["nl"] = self.net_leverage
 
+        # Net value in USD. Emitted alongside net_leverage because the two are
+        # NOT interchangeable downstream: net_leverage is net_value divided by
+        # THIS POSITION's account_size snapshot (see update_position_state),
+        # not the subaccount's nominal account_size. A client that only
+        # receives `nl` and multiplies by the nominal size gets a figure that
+        # is wrong by the ratio between the two, constant per account and up
+        # to ~16% on live accounts as of 2026-09-01 — and it is this value,
+        # not the leverage, that get_max_order_size() compares against the
+        # per-pair cap. Same truthiness gate as `nl` so a closed position
+        # (net_value 0.0) does not grow the frame.
+        if self.net_value:
+            results["nv"] = self.net_value
+
         if self.is_closed_position:
             results["c"] = self.close_ms
             results["rc"] = self.return_at_close


### PR DESCRIPTION
## Summary

`Position.to_dashboard` (the v2 frame, shared by REST **and** the websocket via `position_client.get_dashboard`) emits `nl` but never `net_value`. The two are not interchangeable: `net_leverage = net_value / self.account_size`, where `account_size` is **that position's** snapshot — not the subaccount's nominal size.

So a client receiving only `nl` has to reconstruct value as `nominal_account_size * nl`, which is wrong whenever the account has moved off its nominal size.

This adds `nv` to the frame.

## Why it matters beyond display

`get_max_order_size` clamps orders against `abs(position.net_value)` for the per-pair cap. A client sizing from `nl` therefore **cannot reproduce the cap its own orders are subject to**, and shows more headroom than the validator will grant.

Real case that surfaced this (2026-09-01): a TAO/USDC order for 3.7909 TAO ($844.57) filled at 0.09028 TAO ($20.11) — a 97.6% silent downsizing — while the trading UI reported six figures of available headroom.

## Measured impact

Against 18 live mainnet subaccounts, 32 open positions:

- **24 of 32** positions off by >1%
- error is **constant per account** — e.g. 0.864 / 0.866 / 0.866 / 0.866 across one account's four positions. That constancy is the signature that rules out mark drift and points at the denominator.
- worst case **$30,385 understated on a $221K book** (13.7%)
- implied denominators recovered from the ratios match balance-at-open, not nominal size (e.g. $115,473 vs a nominal $100,000 on an account up ~15%)

## Implementation notes

- Key `nv`, matching the frame's short-key convention.
- Same truthiness gate as `nl`, so flat/closed positions (net_value 0.0) don't grow the frame.
- Sign preserved for SHORT positions; consumers take `abs()` as `get_max_order_size` does.
- **Consumers should not try to sum `fo` instead.** `position_manager` only includes fills newer than `positions_time_ms`, so `fo` is incremental — summing it works on a cold snapshot and silently under-counts on a live stream.

## Test plan

New `tests/vali_tests/test_position_dashboard_frame.py` (plain `unittest.TestCase` — pure serialization, no orchestrator): 4 tests covering emission alongside `nl`, the non-derivability regression, the zero-gate, and sign preservation. **4 passed.** Mutation-checked: removing the two added lines fails 3 of the 4.

Adjacent suites (`test_capital_used_by_class.py`, `test_entity_dashboard_integration.py`) are **12 failed / 19 passed on clean `main` and 12 failed / 23 passed with this change** — same failures, all pre-existing, none introduced here. Note `tests/vali_tests/test_positions.py` does not collect on `main` (class-level `Position(...)` missing `position_type`), which is why the new tests live in their own file.

## Follow-up (not in this PR)

The consuming client needs a matching change to read `nv`; until then it keeps using its current fallback. Separately, this does **not** explain the full headroom discrepancy in the originating incident — a larger, still-unidentified defect remains on the client side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)