### PR TITLE
Security: entity endpoint hardening (ownership, admin gate, replay protection, fee-waiver flag)

### DIFF
--- a/tests/vali_tests/test_entity_endpoint_security.py
+++ b/tests/vali_tests/test_entity_endpoint_security.py
@@ -92,6 +92,32 @@ class TestEliminateSubaccountOwnership(unittest.TestCase):
         finally:
             del KEY_TIERS["ops-reader"]
 
+    def test_key_missing_from_alias_map_rejected(self):
+        # A valid tier-200 key absent from api_key_to_alias (stale/out-of-sync
+        # mapping) must be rejected, never treated as an owner.
+        KEY_TIERS["unmapped-key"] = 200
+        try:
+            resp = self._post("unmapped-key", ENTITY_A)
+            self.assertEqual(resp.status_code, 403)
+            self.server._entity_client.eliminate_subaccount.assert_not_called()
+        finally:
+            del KEY_TIERS["unmapped-key"]
+
+    def test_null_entity_hotkey_rejected(self):
+        # JSON null passes the field-presence check; it must never match a
+        # missing alias (None == None) and read as ownership.
+        KEY_TIERS["unmapped-key"] = 200
+        try:
+            resp = self.client.post(
+                "/entity/subaccount/eliminate",
+                headers={"Authorization": "Bearer unmapped-key"},
+                json={"entity_hotkey": None, "subaccount_id": 0},
+            )
+            self.assertEqual(resp.status_code, 400)
+            self.server._entity_client.eliminate_subaccount.assert_not_called()
+        finally:
+            del KEY_TIERS["unmapped-key"]
+
 
 class TestRebuildAccountTierGate(unittest.TestCase):
     """F2: account rebuild is admin-only (tier 500), including preview mode."""
@@ -196,9 +222,58 @@ class TestCreateSubaccountReplayProtection(unittest.TestCase):
         self.server._entity_client.create_subaccount.assert_not_called()
 
     def test_stale_timestamp_rejected(self):
-        body = self._signed_body(timestamp=int(time.time() * 1000) - 10 * 60 * 1000)
+        # One millisecond past the NonceManager window (read from the real
+        # instance, so this tracks the implementation's TTL).
+        stale_ms = self.server.nonce_manager.ttl_ms + 1
+        body = self._signed_body(timestamp=int(time.time() * 1000) - stale_ms)
         resp = self._post(body)
         self.assertEqual(resp.status_code, 401)
+        self.server._entity_client.create_subaccount.assert_not_called()
+
+    def test_same_nonce_different_entity_allowed(self):
+        # Nonces are scoped per coldkey::hotkey — a nonce used by one entity
+        # must not block a different entity's request.
+        shared_nonce = uuid.uuid4().hex
+        first = self._post(self._signed_body(nonce=shared_nonce))
+        self.assertEqual(first.status_code, 200)
+
+        other_cold = Keypair.create_from_uri("//Charlie")
+        other_hot = Keypair.create_from_uri("//Dave").ss58_address
+        ts = int(time.time() * 1000)
+        sig_dict = {
+            "account_size": 25000.0,
+            "asset_class": "crypto",
+            "entity_coldkey": other_cold.ss58_address,
+            "entity_hotkey": other_hot,
+            "nonce": shared_nonce,
+            "timestamp": ts,
+        }
+        body = {
+            "entity_coldkey": other_cold.ss58_address,
+            "entity_hotkey": other_hot,
+            "account_size": 25000.0,
+            "asset_class": "crypto",
+            "signature": other_cold.sign(json.dumps(sig_dict, sort_keys=True).encode()).hex(),
+            "nonce": shared_nonce,
+            "timestamp": ts,
+            "version": "3.1.0",
+        }
+        second = self._post(body)
+        self.assertEqual(second.status_code, 200, second.get_json())
+
+    def test_old_cli_version_rejected_with_upgrade_message(self):
+        body = self._signed_body()
+        body["version"] = "2.2.1"
+        resp = self._post(body)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("upgrade", resp.get_json()["error"].lower())
+        self.server._entity_client.create_subaccount.assert_not_called()
+
+    def test_unowned_hotkey_rejected(self):
+        # Subtensor coldkey->hotkey ownership failure must 403 before any RPC.
+        self.server._verify_coldkey_owns_hotkey = lambda ck, hk: False
+        resp = self._post(self._signed_body())
+        self.assertEqual(resp.status_code, 403)
         self.server._entity_client.create_subaccount.assert_not_called()
 
     def test_collateral_exempt_rejected(self):

--- a/tests/vali_tests/test_entity_endpoint_security.py
+++ b/tests/vali_tests/test_entity_endpoint_security.py
@@ -1,0 +1,216 @@
+# developer: Taoshi Inc
+# Copyright (c) 2026 Taoshi Inc
+"""
+Security regression tests for the entity REST endpoints (responsible-disclosure findings):
+
+  F1  POST /entity/subaccount/eliminate — an entity API key may only eliminate its OWN
+      subaccounts (tier-500 admin keys retain cross-entity capability).
+  F2  POST /admin/rebuild-account/<hotkey> — rebuilding an arbitrary miner's persisted
+      account state requires tier 500 (admin), not the self-service entity tier 200.
+  F3  POST /entity/create-subaccount — the signed payload carries a one-time nonce +
+      timestamp; a captured request cannot be replayed (each replay used to re-trigger
+      the Theta registration-fee slashing flow).
+  F4  collateral_exempt is rejected outright at the network boundary — any entity could
+      previously self-sign the fee-waiver flag.
+
+Uses the lightweight endpoint-test pattern from test_hl_trader_endpoint.py: a bare
+ValidatorRestServer via object.__new__ (no heavy constructor), a minimal Flask app, and
+mocked RPC clients — the real handler methods run unmodified.
+"""
+import json
+import time
+import unittest
+import uuid
+from unittest.mock import MagicMock
+
+from flask import Flask
+from bittensor_wallet import Keypair
+
+from vanta_api.nonce_manager import NonceManager
+
+
+ENTITY_A = "5EntityAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+ENTITY_B = "5EntityBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+KEY_A = "api-key-entity-a"
+KEY_B = "api-key-entity-b"
+KEY_ADMIN = "api-key-admin"
+KEY_TIERS = {KEY_A: 200, KEY_B: 200, KEY_ADMIN: 500}
+
+
+def _bare_server():
+    """ValidatorRestServer without its heavy constructor, with auth mocked to a fixed key set."""
+    from vanta_api.validator_rest_server import ValidatorRestServer
+
+    server = object.__new__(ValidatorRestServer)
+    server.api_key_to_alias = {KEY_A: ENTITY_A, KEY_B: ENTITY_B, KEY_ADMIN: "ops-admin"}
+    server.is_valid_api_key = lambda k: k in KEY_TIERS
+    server.can_access_tier = lambda k, tier: KEY_TIERS.get(k, 0) >= tier
+    server._entity_client = MagicMock()
+    server.nonce_manager = NonceManager()
+    return server
+
+
+class TestEliminateSubaccountOwnership(unittest.TestCase):
+    """F1: cross-entity elimination must be refused."""
+
+    def setUp(self):
+        self.server = _bare_server()
+        self.server._entity_client.eliminate_subaccount.return_value = (True, "eliminated")
+        app = Flask(__name__)
+        app.route("/entity/subaccount/eliminate", methods=["POST"])(self.server.eliminate_subaccount)
+        self.client = app.test_client()
+
+    def _post(self, api_key, entity_hotkey):
+        return self.client.post(
+            "/entity/subaccount/eliminate",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"entity_hotkey": entity_hotkey, "subaccount_id": 0},
+        )
+
+    def test_cross_entity_eliminate_rejected(self):
+        resp = self._post(KEY_B, ENTITY_A)
+        self.assertEqual(resp.status_code, 403)
+        self.server._entity_client.eliminate_subaccount.assert_not_called()
+
+    def test_own_entity_eliminate_allowed(self):
+        resp = self._post(KEY_A, ENTITY_A)
+        self.assertEqual(resp.status_code, 200)
+        self.server._entity_client.eliminate_subaccount.assert_called_once()
+
+    def test_admin_cross_entity_eliminate_allowed(self):
+        resp = self._post(KEY_ADMIN, ENTITY_A)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_non_entity_tier200_key_rejected(self):
+        # A manually-provisioned tier-200 key whose alias is not an entity hotkey
+        # must not be able to eliminate anyone.
+        KEY_TIERS["ops-reader"] = 200
+        self.server.api_key_to_alias["ops-reader"] = "some-user-id"
+        try:
+            resp = self._post("ops-reader", ENTITY_A)
+            self.assertEqual(resp.status_code, 403)
+        finally:
+            del KEY_TIERS["ops-reader"]
+
+
+class TestRebuildAccountTierGate(unittest.TestCase):
+    """F2: account rebuild is admin-only (tier 500), including preview mode."""
+
+    def setUp(self):
+        self.server = _bare_server()
+        self.server._miner_account_client = MagicMock()
+        app = Flask(__name__)
+        app.route("/admin/rebuild-account/<hotkey>", methods=["POST"])(self.server.rebuild_miner_account)
+        self.client = app.test_client()
+
+    def _post(self, api_key, body=None):
+        return self.client.post(
+            "/admin/rebuild-account/5SomeMinerHotkey",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json=body or {},
+        )
+
+    def test_tier200_rejected(self):
+        resp = self._post(KEY_A)
+        self.assertEqual(resp.status_code, 403)
+        self.server._miner_account_client.get_account.assert_not_called()
+
+    def test_tier200_preview_rejected_too(self):
+        # Preview discloses arbitrary miners' account internals — same gate.
+        resp = self._post(KEY_B, {"preview": True})
+        self.assertEqual(resp.status_code, 403)
+
+    def test_admin_passes_gate(self):
+        # 404 (no such account from the mocked client) proves the tier gate admitted the
+        # request and the handler proceeded to account lookup.
+        self.server._miner_account_client.get_account.return_value = None
+        resp = self._post(KEY_ADMIN)
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestCreateSubaccountReplayProtection(unittest.TestCase):
+    """F3 + F4: signed nonce/timestamp single-use; collateral_exempt refused outright."""
+
+    def setUp(self):
+        self.server = _bare_server()
+        self.server._entity_client.create_subaccount.return_value = (
+            True, {"synthetic_hotkey": "e_0", "subaccount_id": 0}, "created")
+        self.server._verify_coldkey_owns_hotkey = lambda ck, hk: True
+        app = Flask(__name__)
+        app.route("/entity/create-subaccount", methods=["POST"])(self.server.create_subaccount)
+        self.client = app.test_client()
+        self.coldkey = Keypair.create_from_uri("//Alice")
+        self.hotkey_addr = Keypair.create_from_uri("//Bob").ss58_address
+
+    def _signed_body(self, nonce=None, timestamp=None, extra=None, tamper_nonce=None):
+        nonce = nonce or uuid.uuid4().hex
+        timestamp = timestamp if timestamp is not None else int(time.time() * 1000)
+        sig_dict = {
+            "account_size": 25000.0,
+            "asset_class": "crypto",
+            "entity_coldkey": self.coldkey.ss58_address,
+            "entity_hotkey": self.hotkey_addr,
+            "nonce": str(nonce),
+            "timestamp": timestamp,
+        }
+        signature = self.coldkey.sign(json.dumps(sig_dict, sort_keys=True).encode()).hex()
+        body = {
+            "entity_coldkey": self.coldkey.ss58_address,
+            "entity_hotkey": self.hotkey_addr,
+            "account_size": 25000.0,
+            "asset_class": "crypto",
+            "signature": signature,
+            "nonce": str(tamper_nonce if tamper_nonce is not None else nonce),
+            "timestamp": timestamp,
+            "version": "3.1.0",
+        }
+        if extra:
+            body.update(extra)
+        return body
+
+    def _post(self, body):
+        return self.client.post("/entity/create-subaccount", json=body)
+
+    def test_missing_nonce_rejected(self):
+        body = self._signed_body()
+        del body["nonce"]
+        resp = self._post(body)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("nonce", resp.get_json()["error"])
+
+    def test_valid_request_succeeds_then_replay_rejected(self):
+        body = self._signed_body()
+        first = self._post(body)
+        self.assertEqual(first.status_code, 200, first.get_json())
+        self.server._entity_client.create_subaccount.assert_called_once()
+
+        replay = self._post(body)  # byte-identical captured request
+        self.assertEqual(replay.status_code, 401, "replayed nonce must be rejected")
+        self.server._entity_client.create_subaccount.assert_called_once()  # still once
+
+    def test_tampered_nonce_fails_signature(self):
+        # The nonce is signature-covered: an attacker cannot swap in a fresh nonce.
+        body = self._signed_body(tamper_nonce=uuid.uuid4().hex)
+        resp = self._post(body)
+        self.assertEqual(resp.status_code, 401)
+        self.server._entity_client.create_subaccount.assert_not_called()
+
+    def test_stale_timestamp_rejected(self):
+        body = self._signed_body(timestamp=int(time.time() * 1000) - 10 * 60 * 1000)
+        resp = self._post(body)
+        self.assertEqual(resp.status_code, 401)
+        self.server._entity_client.create_subaccount.assert_not_called()
+
+    def test_collateral_exempt_rejected(self):
+        resp = self._post(self._signed_body(extra={"collateral_exempt": True}))
+        self.assertEqual(resp.status_code, 403)
+        self.server._entity_client.create_subaccount.assert_not_called()
+
+    def test_legacy_admin_flag_rejected(self):
+        resp = self._post(self._signed_body(extra={"admin": True}))
+        self.assertEqual(resp.status_code, 403)
+        self.server._entity_client.create_subaccount.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -78,8 +78,13 @@ class ValiConfig:
     # versioning
     VERSION = meta_version
 
-    # minimum required vanta-cli version
-    VANTA_CLI_MINIMUM_VERSION = "2.2.1"
+    # minimum required vanta-cli version.
+    # 3.1.0: create-subaccount requires a signed nonce+timestamp (replay protection) and no
+    # longer accepts collateral_exempt — older CLIs sign the legacy field set and would fail
+    # with a confusing missing-fields/signature error; the version gate gives them a clear
+    # upgrade message instead. COORDINATE: release vanta-cli >= 3.1.0 (signing the new field
+    # set) before this reaches mainnet.
+    VANTA_CLI_MINIMUM_VERSION = "3.1.0"
 
     DAYS_IN_YEAR_CRYPTO = 365  # annualization factor
     DAYS_IN_YEAR_FOREX = 252

--- a/vanta_api/entity_miner_rest_server.py
+++ b/vanta_api/entity_miner_rest_server.py
@@ -26,6 +26,7 @@ import queue
 import re
 import threading
 import time
+import uuid
 from collections import deque
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone, timedelta
@@ -1038,17 +1039,18 @@ class EntityMinerRestServer(MinerRestServer):
         Request body (JSON) — standard:
         {
             "asset_class": "crypto" | "forex" | "equities",  // Required
-            "account_size": float,                           // Required, must be > 0
-            "collateral_exempt": bool                        // Optional, default false
+            "account_size": float                            // Required, must be > 0
         }
 
         Request body (JSON) — HL-linked:
         {
             "hl_address": "0x...",     // Required, 0x + 40 hex chars
             "account_size": float,     // Required, must be > 0
-            "payout_address": "0x...", // Optional, EVM address for USDC payouts
-            "collateral_exempt": bool  // Optional, default false
+            "payout_address": "0x..."  // Optional, EVM address for USDC payouts
         }
+
+        collateral_exempt is NOT accepted (403 if supplied): exempt accounts are created
+        only by Taoshi tooling on the validator host, never over the network.
         """
         import requests as http_requests
         start_time = time.time()
@@ -1087,10 +1089,12 @@ class EntityMinerRestServer(MinerRestServer):
                 if drawdown_criteria not in ("trailing", "static"):
                     return jsonify({'status': 'error', 'message': 'drawdown_criteria must be "trailing" or "static"'}), 400
 
-            raw = request_data.get("collateral_exempt", request_data.get("admin", False))
-            if not isinstance(raw, bool):
-                return jsonify({'status': 'error', 'message': 'collateral_exempt must be a boolean'}), 400
-            collateral_exempt = raw
+            # collateral_exempt is not accepted from gateway callers (defense in depth — the
+            # validator rejects it too): it waives the collateral registration fee, and there
+            # is no admin identity at this boundary. Covers the legacy 'admin' key name.
+            if request_data.get("collateral_exempt") or request_data.get("admin"):
+                return jsonify({'status': 'error',
+                                'message': 'collateral_exempt is not accepted on this endpoint'}), 403
 
             # Optional idempotency key forwarded to the validator. Validated
             # here so a malformed value fails fast; forwarded in the payload
@@ -1150,16 +1154,20 @@ class EntityMinerRestServer(MinerRestServer):
         if not self._coldkey or not self._hotkey or not self._validator_url:
             return jsonify({'status': 'error', 'message': 'Wallet not configured'}), 500
 
-        # 4. Sign message
+        # 4. Sign message. nonce + timestamp are signature-covered replay protection: the
+        # validator rejects a reused nonce (per coldkey::hotkey, 5-minute window), so a
+        # captured request cannot be replayed to re-trigger the registration-fee slashing.
         try:
+            nonce = uuid.uuid4().hex
+            timestamp_ms = int(time.time() * 1000)
             message_dict = {
                 "account_size": account_size,
                 "asset_class": asset_class,
                 "entity_coldkey": self._coldkey.ss58_address,
                 "entity_hotkey": self._hotkey.ss58_address,
+                "nonce": nonce,
+                "timestamp": timestamp_ms,
             }
-            if collateral_exempt:
-                message_dict["collateral_exempt"] = collateral_exempt
             if is_hl:
                 message_dict["hl_address"] = hl_address
                 if payout_address is not None:
@@ -1179,10 +1187,12 @@ class EntityMinerRestServer(MinerRestServer):
                 "asset_class": asset_class,
                 "drawdown_criteria": drawdown_criteria,
                 "signature": signature,
-                "version": "2.2.1"
+                "nonce": nonce,
+                "timestamp": timestamp_ms,
+                # Capability version for the validator's minimum-version gate: this gateway
+                # signs the nonce+timestamp field set introduced with the 3.1.0 minimum.
+                "version": "3.1.0"
             }
-            if collateral_exempt:
-                payload["collateral_exempt"] = collateral_exempt
             # client_ref rides unsigned alongside drawdown_criteria. message_dict
             # above is intentionally left untouched so the coldkey signature is
             # byte-identical to the legacy field set (forward/back compatible).

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -336,7 +336,8 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         self.app.route("/development/order", methods=["POST"])(self.process_development_order)
 
         # Account management endpoints
-        self.app.route("/miner-account/rebuild/<hotkey>", methods=["POST"])(self.rebuild_miner_account)
+        # Admin-prefixed so the tier-500 audit logger (base_rest_server) records every call.
+        self.app.route("/admin/rebuild-account/<hotkey>", methods=["POST"])(self.rebuild_miner_account)
         self.app.route("/wipe/<hotkey>", methods=["POST"])(self.wipe_hotkey)
         self.app.route("/admin/<hotkey>/positions/<position_uuid>", methods=["DELETE"])(self.delete_position)
         self.app.route("/admin/<hotkey>/positions/<position_uuid>", methods=["PATCH"])(self.patch_position)
@@ -1668,20 +1669,23 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         Supports preview mode (default) which computes the rebuilt state without persisting,
         and an optional open_ms_after filter to only include positions opened after a timestamp.
 
-        Requires tier 200 access.
+        Requires tier 500 (admin) access: this rewrites an arbitrary miner's persisted
+        balance/equity/buying power, and tier 200 is the self-service entity tier that any
+        registered entity can obtain — it must never gate cross-account mutation. Preview mode
+        is gated too (it discloses arbitrary miners' account internals).
 
         Example:
-        curl -X POST http://localhost:48888/miner-account/rebuild/<hotkey> \\
-          -H "Authorization: Bearer YOUR_API_KEY" \\
+        curl -X POST http://localhost:48888/admin/rebuild-account/<hotkey> \\
+          -H "Authorization: Bearer YOUR_ADMIN_API_KEY" \\
           -H "Content-Type: application/json" \\
           -d '{"open_ms_after": 1700000000000, "preview": true}'
         """
-        # Auth check - tier 200 required
+        # Auth check - tier 500 (admin) required
         api_key = self._get_api_key_safe()
         if not self.is_valid_api_key(api_key):
             return jsonify({'error': 'Unauthorized access'}), 401
-        if not self.can_access_tier(api_key, 200):
-            return jsonify({'error': 'Rebuild endpoint requires tier 200 access'}), 403
+        if not self.can_access_tier(api_key, 500):
+            return jsonify({'error': 'Rebuild endpoint requires tier 500 (admin) access'}), 403
 
         try:
             # Parse request body
@@ -2320,6 +2324,8 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             "entity_coldkey": "5FxY...",
             "account_size": 25000,
             "asset_class": "crypto",
+            "nonce": "one-time-hex",
+            "timestamp": 1700000000000,
             "signature": "0x..."
           }'
 
@@ -2333,6 +2339,8 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             "asset_class": "hl_all",
             "hl_address": "0x1234...abcd",
             "payout_address": "0xAbCd...1234",
+            "nonce": "one-time-hex",
+            "timestamp": 1700000000000,
             "signature": "0x..."
           }'
         """
@@ -2365,8 +2373,12 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
 
             is_hl = 'hl_address' in data
 
-            # Validate required fields
-            required_fields = ['entity_coldkey', 'entity_hotkey', 'account_size', 'asset_class', 'signature']
+            # Validate required fields. nonce + timestamp are REQUIRED and signature-covered
+            # (see sig_dict below): without them a captured request body could be replayed
+            # forever, and every accepted replay re-triggers the Theta registration-fee
+            # slashing flow. Mirrors the /collateral/withdraw pattern.
+            required_fields = ['entity_coldkey', 'entity_hotkey', 'account_size', 'asset_class',
+                               'signature', 'nonce', 'timestamp']
             if is_hl:
                 required_fields.append('hl_address')
             missing_fields = [field for field in required_fields if field not in data]
@@ -2377,8 +2389,19 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             entity_hotkey = data['entity_hotkey']
             account_size = data['account_size']
             asset_class = data['asset_class']
-            collateral_exempt = data.get('collateral_exempt')
             drawdown_criteria = data.get('drawdown_criteria', 'trailing')
+
+            # collateral_exempt is NOT accepted over the network. It waives the collateral
+            # registration fee, and the only "auth" on this endpoint is the caller's own
+            # coldkey signature — i.e. any entity could self-sign the flag and register fee
+            # -free accounts at scale. Exempt accounts are created only by Taoshi tooling
+            # calling entity_client/entity_manager directly on the validator host. Reject
+            # loudly (rather than silently ignore) so a signed-with-flag request fails with
+            # a clear error instead of a confusing signature mismatch. Covers the legacy
+            # 'admin' key name from before the #886 rename.
+            if data.get('collateral_exempt') or data.get('admin'):
+                return jsonify({'error': 'collateral_exempt is not accepted on this endpoint'}), 403
+            collateral_exempt = False
             # Optional idempotency key. Deliberately NOT part of the signed
             # payload (sig_dict below is frozen) so that a new gateway signing
             # the legacy field set still verifies against an older validator,
@@ -2388,9 +2411,6 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if client_ref is not None:
                 if not isinstance(client_ref, str) or not re.match(r'^[A-Za-z0-9_.:-]{1,64}\Z', client_ref):
                     return jsonify({'error': 'client_ref must be 1-64 chars of [A-Za-z0-9_.:-]'}), 400
-
-            if collateral_exempt is not None and not isinstance(collateral_exempt, bool):
-                return jsonify({'error': 'collateral_exempt must be a boolean'}), 400
 
             # Validate account_size is a positive number
             try:
@@ -2429,9 +2449,11 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 "asset_class": asset_class,
                 "entity_coldkey": entity_coldkey,
                 "entity_hotkey": entity_hotkey,
+                # Signature-covered so an attacker can neither strip nor alter them; the
+                # nonce check below is what makes a captured request single-use.
+                "nonce": str(data['nonce']),
+                "timestamp": data['timestamp'],
             }
-            if collateral_exempt:
-                sig_dict["collateral_exempt"] = collateral_exempt
             if is_hl:
                 sig_dict["hl_address"] = hl_address
                 if payout_address is not None:
@@ -2443,14 +2465,27 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if not is_valid:
                 return jsonify({'error': 'Invalid signature. Subaccount creation unauthorized'}), 401
 
-            collateral_exempt = bool(collateral_exempt)
-
             # Verify coldkey-hotkey ownership using subtensor
             t0 = time.time()
             owns_hotkey = self._verify_coldkey_owns_hotkey(entity_coldkey, entity_hotkey)
             timings['verify_coldkey_ownership'] = int((time.time() - t0) * 1000)
             if not owns_hotkey:
                 return jsonify({'error': 'Coldkey does not own the specified hotkey'}), 403
+
+            # Replay protection: one-time nonce within a bounded timestamp window (same
+            # pattern and manager as /collateral/withdraw). Each accepted create triggers
+            # the Theta registration-fee slashing flow, so replays are a treasury drain.
+            try:
+                nonce_timestamp = int(data['timestamp'])
+            except (TypeError, ValueError):
+                return jsonify({'error': 'timestamp must be an integer (ms since epoch)'}), 400
+            is_valid, error_msg = self.nonce_manager.is_valid_request(
+                address=f"{entity_coldkey}::{entity_hotkey}",
+                nonce=str(data['nonce']),
+                timestamp=nonce_timestamp,
+            )
+            if not is_valid:
+                return jsonify({'error': f'{error_msg}'}), 401
 
             # Create subaccount via RPC
             t0 = time.time()
@@ -2606,6 +2641,22 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 subaccount_id = int(subaccount_id)
             except (ValueError, TypeError):
                 return jsonify({'error': 'subaccount_id must be an integer'}), 400
+
+            # Ownership check: an entity API key may only eliminate its OWN subaccounts.
+            # Entity keys are issued by /entity/request-api-key with the api_keys.json entry
+            # keyed by the entity hotkey, so api_key_to_alias maps key -> entity_hotkey (the
+            # same identity pattern websocket_server uses for dashboard scoping). Without this,
+            # ANY tier-200 key (every registered entity has one) could eliminate a rival's
+            # subaccount — and the elimination frees the victim's hl_address binding for
+            # re-registration by the attacker. Tier-500 admin keys retain cross-entity
+            # capability, consistent with /admin/eliminate/<hotkey>.
+            caller_entity = self.api_key_to_alias.get(api_key)
+            if entity_hotkey != caller_entity and not self.can_access_tier(api_key, 500):
+                logger.warning(
+                    f"Rejected cross-entity eliminate: key alias [{caller_entity}] targeted "
+                    f"entity [{entity_hotkey}] subaccount [{subaccount_id}]"
+                )
+                return jsonify({'error': 'API key is not authorized for this entity'}), 403
 
             # Eliminate subaccount via RPC
             success, message = self._entity_client.eliminate_subaccount(

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -2650,8 +2650,13 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             # subaccount — and the elimination frees the victim's hl_address binding for
             # re-registration by the attacker. Tier-500 admin keys retain cross-entity
             # capability, consistent with /admin/eliminate/<hotkey>.
+            # entity_hotkey must be a real hotkey string: a JSON null passes the
+            # field-presence check above, and None == None against a missing alias
+            # must never read as ownership.
+            if not isinstance(entity_hotkey, str) or not entity_hotkey.strip():
+                return jsonify({'error': 'entity_hotkey must be a non-empty string'}), 400
             caller_entity = self.api_key_to_alias.get(api_key)
-            if entity_hotkey != caller_entity and not self.can_access_tier(api_key, 500):
+            if (caller_entity is None or entity_hotkey != caller_entity) and not self.can_access_tier(api_key, 500):
                 logger.warning(
                     f"Rejected cross-entity eliminate: key alias [{caller_entity}] targeted "
                     f"entity [{entity_hotkey}] subaccount [{subaccount_id}]"


### PR DESCRIPTION
## Summary

Fixes the four **High** findings from the responsible-disclosure report, each independently verified against the current tree (line numbers had drifted; all four confirmed exploitable) before fixing. One coherent security patch:

| # | Finding | Fix |
|---|---|---|
| F1 | Any entity API key could eliminate a **rival entity's** subaccount (`/entity/subaccount/eliminate` checked only tier 200 — the self-service entity tier) and the elimination frees the victim's `hl_address` for attacker re-binding (reward routing) | Ownership check via `api_key_to_alias` (the identity pattern `websocket_server` already uses): 403 unless the caller **is** the target entity; tier-500 admin bypass consistent with `/admin/eliminate/<hotkey>` |
| F2 | Any tier-200 key could **rewrite any miner's persisted account state** via `/miner-account/rebuild/<hotkey>` (equity down → wrongful drawdown elimination; equity up → fake track record) | Tier 500 (admin) required — including preview mode (it disclosed account internals); route moved to `/admin/rebuild-account/<hotkey>` so the tier-500 audit logger records every call |
| F3 | `create-subaccount`'s coldkey signature covered only static fields → a **captured request replays forever**, and each replay re-triggers the Theta registration-fee slashing flow | `nonce` + `timestamp` required and **signature-covered**, enforced one-time via the same `NonceManager` pattern as `/collateral/withdraw` (5-min window, keyed `coldkey::hotkey`); gateway signs the new field set |
| F4 | Caller-supplied `collateral_exempt` (self-signed!) skipped the collateral registration fee — free accounts at scale | Rejected with 403 at **both** network boundaries (validator REST + entity gateway), covering the legacy `admin` key name; internal `entity_client`/`entity_manager` callers (Taoshi tooling, tests) unchanged |

## Compatibility

- **F3 is a deliberate hard break for old clients**: `VANTA_CLI_MINIMUM_VERSION` bumped to **3.1.0** so pre-nonce CLIs get a clear upgrade message instead of a confusing signature failure. **A vanta-cli release signing `{…, nonce, timestamp}` must ship before this reaches mainnet.** No legacy no-nonce fallback was added — the version field is unsigned/attacker-controlled, so any fallback would preserve the vulnerability.
- `client_ref` idempotency (PR #888) is unchanged: it remains the honest-client retry layer; the signed nonce is the adversarial replay barrier.
- NonceManager is in-memory per process; a REST restart clears it. Acceptable within the 5-minute timestamp window.

## Test plan

- 13 new endpoint-level regression tests (`test_entity_endpoint_security.py`): real handler methods, real sr25519 signatures, real NonceManager; cross-entity eliminate rejected / own+admin allowed; tier-200 rebuild (incl. preview) rejected; replay of a byte-identical captured request rejected; tampered nonce fails signature; stale timestamp rejected; `collateral_exempt` and legacy `admin` rejected.
- Surrounding suites vs the development base: `test_entity_management` 39P, `test_entity_miner_gateway` 49P, `test_nonce_manager` 14P, `test_api_key_refresh` 4P, `test_hl_trader_limits_endpoint` 19P — all clean. `test_hl_trader_endpoint` (18F) and `test_entity_collateral` (1F) fail **identically on the unfixed development base** (pre-existing drift).

## Follow-ups noted during verification (not in this PR)

The reporter's lower-severity list overlaps with what verification surfaced: `GET /entity/<hotkey>` and `GET /entities` expose any entity's data to any tier-200 key (also the enumeration vector for F1); `/entity/request-api-key` shares F3's missing-nonce shape; and HL subaccount creation never proves control of the claimed `hl_address`. Recommend a follow-up branch for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
