### PR TITLE
feat(pro-accounts): admin-set pro account size ($200K-$1M), required when entering the pro track

### DIFF
--- a/docs/entity_miner.md
+++ b/docs/entity_miner.md
@@ -250,21 +250,26 @@ Hyperliquid-sourced pairs, so Hyperliquid subaccounts have no pro tier.
 
 #### Pro account size
 
-The pro account size is set by the network, not by the UI or the admin granting the promotion. It is
-**$1,000,000** today (`ValiConfig.PRO_ACCOUNT_SIZE`) and can change in a future release. Every
-subaccount dashboard (`GET /entity/subaccount/<synthetic_hotkey>`, `GET /v2/entity/subaccount/<synthetic_hotkey>`,
-and the websocket dashboard stream) publishes it as `subaccount_info.default_pro_account_size`, for
-standard and pro subaccounts alike, so the size a promotion will grant can be shown before the
-subaccount is on the pro track. It says nothing about eligibility: Hyperliquid subaccounts carry it
-too but have no pro tier.
+There is no network default pro account size. The admin sets it when offering the pro track, through
+`POST /admin/miner-bucket/<synthetic_hotkey>` with a `pro_account_size`, and that endpoint is the
+only way to set one. The network accepts any finite amount from **$200,000** to **$1,000,000**
+inclusive (`ValiConfig.MIN_PRO_ACCOUNT_SIZE` to `ValiConfig.MAX_PRO_ACCOUNT_SIZE`); the preset amounts
+offered in the Command Center are a UI choice, not a network rule.
 
-When a subaccount enters the pro track it is granted that size, recorded as
-`subaccount_info.pro_account_size` (null until then; standard subaccounts that were never promoted
-keep null). The recorded size is kept for the rest of the pro journey, including the miner's own
-`POST /api/promote-pro-transition` out of `PRO_CHALLENGE_TRANSITION`, so a later change to the
-network size does not resize an account that was already promoted. The admin endpoint and the
-promote-pro-transition request still accept an explicit `pro_account_size` override (at most
-`ValiConfig.MAX_PRO_ACCOUNT_SIZE`, $1,000,000); the Vanta UI never sends one.
+- **Entering the pro track** (e.g. `SUBACCOUNT_FUNDED` → `PRO_CHALLENGE_TRANSITION`, or
+  `SUBACCOUNT_CHALLENGE` → `PRO_CHALLENGE_DIRECT`) requires a size. This includes a re-offer after a
+  demotion: the size from the earlier pro journey is never reused.
+- **Moving within the pro track** keeps the recorded size. When promoting to `PRO_FUNDED` the admin
+  may send a new size (still within the range), which replaces it.
+- **Start Pro Now** (`POST /api/promote-pro-transition`, and the validator's
+  `POST /entity/subaccount/pro-transition` behind it) always keeps the recorded size. A miner cannot
+  choose or change its size: a request that includes `pro_account_size` at all is rejected with a 400
+  before anything is signed or a nonce is used.
+- **Standard buckets** never record a pro size.
+
+The granted size is published as `subaccount_info.pro_account_size` in the v2 subaccount dashboard
+(`GET /v2/entity/subaccount/<synthetic_hotkey>` and the websocket dashboard stream): null until the
+subaccount is first offered the pro track, and kept on the record after a demotion.
 
 Every pro bucket is subject to two drawdown rules, both checked continuously:
 - **Daily loss limit:** equity cannot drop **5%** below the day's opening equity at any point during the day.

--- a/docs/entity_miner.md
+++ b/docs/entity_miner.md
@@ -248,6 +248,24 @@ Hyperliquid-sourced pairs, so Hyperliquid subaccounts have no pro tier.
 | `PRO_CHALLENGE_DIRECT`        | pro            | no            | —                       |
 | `PRO_FUNDED`                  | pro            | yes           | pro account size        |
 
+#### Pro account size
+
+The pro account size is set by the network, not by the UI or the admin granting the promotion. It is
+**$1,000,000** today (`ValiConfig.PRO_ACCOUNT_SIZE`) and can change in a future release. Every
+subaccount dashboard (`GET /entity/subaccount/<synthetic_hotkey>`, `GET /v2/entity/subaccount/<synthetic_hotkey>`,
+and the websocket dashboard stream) publishes it as `subaccount_info.default_pro_account_size`, for
+standard and pro subaccounts alike, so the size a promotion will grant can be shown before the
+subaccount is on the pro track. It says nothing about eligibility: Hyperliquid subaccounts carry it
+too but have no pro tier.
+
+When a subaccount enters the pro track it is granted that size, recorded as
+`subaccount_info.pro_account_size` (null until then; standard subaccounts that were never promoted
+keep null). The recorded size is kept for the rest of the pro journey, including the miner's own
+`POST /api/promote-pro-transition` out of `PRO_CHALLENGE_TRANSITION`, so a later change to the
+network size does not resize an account that was already promoted. The admin endpoint and the
+promote-pro-transition request still accept an explicit `pro_account_size` override (at most
+`ValiConfig.MAX_PRO_ACCOUNT_SIZE`, $1,000,000); the Vanta UI never sends one.
+
 Every pro bucket is subject to two drawdown rules, both checked continuously:
 - **Daily loss limit:** equity cannot drop **5%** below the day's opening equity at any point during the day.
 - **EOD trailing loss limit:** equity cannot drop **8%** below the end-of-day equity high-water mark.

--- a/docs/validator_rest_server.md
+++ b/docs/validator_rest_server.md
@@ -523,17 +523,28 @@ Requires **tier 500** access. Like every `/admin/*` route, calls are recorded in
 
 **Body:**
 - `bucket` (string, required): a `MinerBucket` value, e.g. `PRO_CHALLENGE_TRANSITION`.
-- `pro_account_size` (number, optional override): USD size of the granted pro account, at most
-  `ValiConfig.MAX_PRO_ACCOUNT_SIZE` ($1,000,000). The pro account size is set by the network, so
-  this is normally omitted (the Vanta UI never sends it): entering the pro track without it grants
-  the size already recorded on the subaccount, or the network's `ValiConfig.PRO_ACCOUNT_SIZE`
-  (currently $1,000,000, published on every subaccount dashboard as
-  `subaccount_info.default_pro_account_size`) when none is recorded. Ignored for standard buckets.
+- `pro_account_size` (number): USD size of the pro account. There is no network default, and this
+  endpoint is the only way to set one. When sent it must be a finite number from $200,000 to
+  $1,000,000 inclusive (`ValiConfig.MIN_PRO_ACCOUNT_SIZE` to `ValiConfig.MAX_PRO_ACCOUNT_SIZE`),
+  whatever the bucket; `NaN`, `Infinity`, strings and booleans are rejected. The network enforces only
+  this range, not the Command Center presets.
+  - **Required when entering the pro track** from a standard account (e.g. `SUBACCOUNT_FUNDED` →
+    `PRO_CHALLENGE_TRANSITION`). A re-offer after a demotion needs a size again: a size recorded on an
+    earlier pro journey is never reused.
+  - **Optional on a move within the pro track** (e.g. promoting to `PRO_FUNDED`): a new size replaces
+    the recorded one; omitted, the recorded size is kept.
+  - **Ignored for standard buckets**, which never record a pro size.
 
 Entering the pro track snapshots the subaccount's existing size, which becomes its
-`standard_account_size` and the basis for payouts during the pro challenge, and records the granted
-size as `pro_account_size`. A subaccount that already has a `pro_account_size` keeps it on later pro
-moves unless a new one is sent. A rejected move changes nothing.
+`standard_account_size` and the basis for payouts during the pro challenge, and records the size as
+`pro_account_size`. A rejected move changes nothing: an invalid or missing size is a 400 before the
+subaccount or its bucket is touched, and a move that fails *after* the sizing is applied rolls the
+sizing back, so a subaccount is never left marked pro in a bucket that did not change — which would
+both leave it trading the pro size off the pro track and let the next size-less offer reuse that size
+instead of demanding one.
+
+The miner's own promotion out of `PRO_CHALLENGE_TRANSITION` (`POST /entity/subaccount/pro-transition`)
+keeps the recorded size and rejects any request that includes `pro_account_size`.
 
 When the target bucket changes the account size, the subaccount's open positions are force closed,
 its pending limit orders are cancelled, and its ledgers restart against the new size.
@@ -544,7 +555,7 @@ its pending limit orders are cancelled, and its ledgers restart against the new 
 curl -X POST "http://localhost:48888/admin/miner-bucket/5GhDr3xy...abc_1" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"bucket": "PRO_CHALLENGE_TRANSITION"}'
+  -d '{"bucket": "PRO_CHALLENGE_TRANSITION", "pro_account_size": 500000}'
 ```
 
 **Response:**
@@ -559,8 +570,10 @@ curl -X POST "http://localhost:48888/admin/miner-bucket/5GhDr3xy...abc_1" \
 
 **Error Responses:**
 ```json
-// 400 - unknown bucket, pro_account_size above the maximum, or miner already in that bucket
-{ "error": "Account size $2000000 exceeds maximum allowed $1000000" }
+// 400 - unknown bucket, pro_account_size missing when entering the pro track, pro_account_size not a
+//       finite number from $200,000 to $1,000,000, or miner already in that bucket
+{ "error": "pro_account_size is required to enter the pro track" }
+{ "error": "pro_account_size $2000000 is outside the allowed range $200,000 to $1,000,000" }
 
 // 403 - API key below tier 500
 { "error": "Set miner bucket endpoint requires tier 500 access" }
@@ -1268,6 +1281,65 @@ Change a standard subaccount's `leverage_tier` (1 to 3) after creation, see [ent
 - The entity miner gateway (`POST /api/update-subaccount-leverage-tier`) builds and signs this request. End users typically call the gateway rather than this endpoint directly.
 - The new tier is broadcast to all validators like a subaccount registration.
 
+### Promote Pro Transition Subaccount
+
+`POST /entity/subaccount/pro-transition`
+
+Start Pro Now: move a subaccount from `PRO_CHALLENGE_TRANSITION` to `PRO_CHALLENGE_FROM_STANDARD` on
+the miner's own request, instead of waiting for the end of the transition week, see
+[entity_miner.md](entity_miner.md#traders-who-have-already-passed-the-standard-challenge). Every open
+position is force closed, every pending limit order is cancelled, and the ledgers restart on the pro
+account, so this cannot be undone.
+
+The pro account is sized at the `pro_account_size` the admin set when offering the transition. A
+miner cannot choose or change it: a request that includes `pro_account_size` at all, even `null`, is
+rejected with a 400 before the signature is checked or the nonce is used, so the same nonce can still
+be sent without the field. Only `POST /admin/miner-bucket/<hotkey>` sets a pro account size.
+
+**Authentication:** Coldkey signature (no API key required). Each signature is single use.
+
+**Request Body:**
+```json
+{
+  "entity_hotkey": "5GhDr3xy...abc",
+  "entity_coldkey": "5FxY...",
+  "synthetic_hotkey": "5GhDr3xy...abc_0",
+  "nonce": "3f9c1e5a...",
+  "timestamp": 1749234567890,
+  "signature": "0x...",
+  "version": "2.2.1"
+}
+```
+
+**Parameters:**
+- `entity_hotkey` (string, required): The entity's hotkey SS58 address
+- `entity_coldkey` (string, required): The entity's coldkey SS58 address
+- `synthetic_hotkey` (string, required): The subaccount to promote. Must belong to `entity_hotkey`.
+- `nonce` (string, required): Random string, new for every request. A nonce is accepted once per entity; a repeat is rejected with 401.
+- `timestamp` (int, required): Request time in milliseconds. Requests older than 5 minutes, or more than 1 minute in the future, are rejected with 401.
+- `signature` (string, required): Coldkey signature over the sorted-JSON of `{entity_coldkey, entity_hotkey, nonce, synthetic_hotkey, timestamp}`.
+- `version` (string, optional): vanta-cli version string for compatibility checking.
+
+**Response:**
+```json
+{
+  "status": "success",
+  "message": "5GhDr3xy...abc_0 moved to PRO_CHALLENGE_FROM_STANDARD",
+  "synthetic_hotkey": "5GhDr3xy...abc_0",
+  "bucket": "PRO_CHALLENGE_FROM_STANDARD",
+  "pro_account_size": 500000.0,
+  "account_size": 500000.0
+}
+```
+
+**Errors:**
+- `400`: the request includes `pro_account_size`, a field is missing or invalid, or the promotion was rejected (subaccount not in `PRO_CHALLENGE_TRANSITION`, or no recorded pro account size)
+- `401`: invalid signature, reused nonce, or expired timestamp
+- `403`: coldkey does not own the hotkey, or the subaccount belongs to another entity
+
+**Important Notes:**
+- The entity miner gateway (`POST /api/promote-pro-transition`) builds and signs this request and never sends a size. End users typically call the gateway rather than this endpoint directly.
+
 ### Set Entity Endpoint
 
 `POST /entity/set-endpoint`
@@ -1431,7 +1503,6 @@ Retrieve comprehensive dashboard data for a specific subaccount by aggregating i
       "synthetic_hotkey": "5GhDr3xy...abc_0",
       "entity_hotkey": "5GhDr3xy...abc",
       "subaccount_id": 0,
-      "default_pro_account_size": 1000000,
       "status": "active",
       "drawdown_criteria": "trailing",
       "created_at_ms": 1702345678901,
@@ -1704,7 +1775,6 @@ curl -H "Authorization: Bearer YOUR_TIER_200_API_KEY" \
 - `synthetic_hotkey`: The subaccount's synthetic hotkey ({entity_hotkey}_{subaccount_id})
 - `entity_hotkey`: The parent entity's hotkey
 - `subaccount_id`: Monotonically increasing subaccount ID
-- `default_pro_account_size`: USD size the network grants when this subaccount is promoted onto the pro track (`ValiConfig.PRO_ACCOUNT_SIZE`, currently $1,000,000). Present for every subaccount, standard or pro, so a UI can show it before promotion. It is not an eligibility signal (Hyperliquid subaccounts have no pro tier) and it is not the granted size: a subaccount that was already promoted keeps the `pro_account_size` it was granted even if this value later changes.
 - `status`: Current status ("active", "eliminated", or "unknown")
 - `created_at_ms`: Timestamp when subaccount was created
 - `eliminated_at_ms`: Timestamp when eliminated (null if active)
@@ -1876,7 +1946,6 @@ curl -H "Authorization: Bearer YOUR_TIER_200_API_KEY" \
       "account_size": 100000.0,
       "standard_account_size": null,
       "pro_account_size": null,
-      "default_pro_account_size": 1000000,
       "account_type": "standard",
       "drawdown_criteria": "static",
       "status": "active",
@@ -2046,8 +2115,7 @@ This is the only guaranteed section of the response. All other sections may be m
 - `asset_class`: Asset class (crypto, forex, etc.)
 - `account_size`: Current account size (in USD)
 - `standard_account_size`: Account size on the standard track, snapshotted when the subaccount entered the pro track (null until then)
-- `pro_account_size`: Account size granted for the pro account (null until the subaccount is promoted onto the pro track)
-- `default_pro_account_size`: USD size the network grants when this subaccount is promoted onto the pro track (`ValiConfig.PRO_ACCOUNT_SIZE`, currently $1,000,000). Present for every subaccount, standard or pro, so a UI can show it before promotion. It is not an eligibility signal (Hyperliquid subaccounts have no pro tier) and it is not the granted size: a subaccount that was already promoted keeps the `pro_account_size` it was granted even if this value later changes.
+- `pro_account_size`: Pro account size the admin set when offering the subaccount the pro track, $200,000 to $1,000,000 (null until the subaccount is first offered the pro track; kept after a demotion)
 - `account_type`: `"standard"` or `"pro"`
 - `status`: Current status ("active", "eliminated", or "unknown")
 - `created_at_ms`: Timestamp when subaccount was created
@@ -2463,7 +2531,6 @@ Resolve a Hyperliquid wallet address to its synthetic hotkey and return the full
       "entity_hotkey": "5GhDr3xy...abc",
       "subaccount_id": 0,
       "asset_class": "crypto",
-      "default_pro_account_size": 1000000,
       "hl_address": "0xabcd1234...",
       "payout_address": "0xAbCd...",
       "status": "active",

--- a/docs/validator_rest_server.md
+++ b/docs/validator_rest_server.md
@@ -523,10 +523,17 @@ Requires **tier 500** access. Like every `/admin/*` route, calls are recorded in
 
 **Body:**
 - `bucket` (string, required): a `MinerBucket` value, e.g. `PRO_CHALLENGE_TRANSITION`.
-- `pro_account_size` (number, required when entering the pro track): USD size of the granted pro
-  account. Snapshotted alongside the subaccount's existing size, which becomes its
-  `standard_account_size` and the basis for payouts during the pro challenge. Omit on later pro
-  moves to keep the size already recorded.
+- `pro_account_size` (number, optional override): USD size of the granted pro account, at most
+  `ValiConfig.MAX_PRO_ACCOUNT_SIZE` ($1,000,000). The pro account size is set by the network, so
+  this is normally omitted (the Vanta UI never sends it): entering the pro track without it grants
+  the size already recorded on the subaccount, or the network's `ValiConfig.PRO_ACCOUNT_SIZE`
+  (currently $1,000,000, published on every subaccount dashboard as
+  `subaccount_info.default_pro_account_size`) when none is recorded. Ignored for standard buckets.
+
+Entering the pro track snapshots the subaccount's existing size, which becomes its
+`standard_account_size` and the basis for payouts during the pro challenge, and records the granted
+size as `pro_account_size`. A subaccount that already has a `pro_account_size` keeps it on later pro
+moves unless a new one is sent. A rejected move changes nothing.
 
 When the target bucket changes the account size, the subaccount's open positions are force closed,
 its pending limit orders are cancelled, and its ledgers restart against the new size.
@@ -537,7 +544,7 @@ its pending limit orders are cancelled, and its ledgers restart against the new 
 curl -X POST "http://localhost:48888/admin/miner-bucket/5GhDr3xy...abc_1" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"bucket": "PRO_CHALLENGE_TRANSITION", "pro_account_size": 500000}'
+  -d '{"bucket": "PRO_CHALLENGE_TRANSITION"}'
 ```
 
 **Response:**
@@ -552,8 +559,8 @@ curl -X POST "http://localhost:48888/admin/miner-bucket/5GhDr3xy...abc_1" \
 
 **Error Responses:**
 ```json
-// 400 - unknown bucket, missing pro_account_size, or miner already in that bucket
-{ "error": "pro_account_size is required to enter the pro track" }
+// 400 - unknown bucket, pro_account_size above the maximum, or miner already in that bucket
+{ "error": "Account size $2000000 exceeds maximum allowed $1000000" }
 
 // 403 - API key below tier 500
 { "error": "Set miner bucket endpoint requires tier 500 access" }
@@ -1424,6 +1431,7 @@ Retrieve comprehensive dashboard data for a specific subaccount by aggregating i
       "synthetic_hotkey": "5GhDr3xy...abc_0",
       "entity_hotkey": "5GhDr3xy...abc",
       "subaccount_id": 0,
+      "default_pro_account_size": 1000000,
       "status": "active",
       "drawdown_criteria": "trailing",
       "created_at_ms": 1702345678901,
@@ -1696,6 +1704,7 @@ curl -H "Authorization: Bearer YOUR_TIER_200_API_KEY" \
 - `synthetic_hotkey`: The subaccount's synthetic hotkey ({entity_hotkey}_{subaccount_id})
 - `entity_hotkey`: The parent entity's hotkey
 - `subaccount_id`: Monotonically increasing subaccount ID
+- `default_pro_account_size`: USD size the network grants when this subaccount is promoted onto the pro track (`ValiConfig.PRO_ACCOUNT_SIZE`, currently $1,000,000). Present for every subaccount, standard or pro, so a UI can show it before promotion. It is not an eligibility signal (Hyperliquid subaccounts have no pro tier) and it is not the granted size: a subaccount that was already promoted keeps the `pro_account_size` it was granted even if this value later changes.
 - `status`: Current status ("active", "eliminated", or "unknown")
 - `created_at_ms`: Timestamp when subaccount was created
 - `eliminated_at_ms`: Timestamp when eliminated (null if active)
@@ -1865,6 +1874,10 @@ curl -H "Authorization: Bearer YOUR_TIER_200_API_KEY" \
       "subaccount_uuid": "abc...789",
       "asset_class": "crypto",
       "account_size": 100000.0,
+      "standard_account_size": null,
+      "pro_account_size": null,
+      "default_pro_account_size": 1000000,
+      "account_type": "standard",
       "drawdown_criteria": "static",
       "status": "active",
       "created_at_ms": 1770657674533,
@@ -2032,6 +2045,10 @@ This is the only guaranteed section of the response. All other sections may be m
 - `subaccount_uuid`: Unique identifier for this subaccount
 - `asset_class`: Asset class (crypto, forex, etc.)
 - `account_size`: Current account size (in USD)
+- `standard_account_size`: Account size on the standard track, snapshotted when the subaccount entered the pro track (null until then)
+- `pro_account_size`: Account size granted for the pro account (null until the subaccount is promoted onto the pro track)
+- `default_pro_account_size`: USD size the network grants when this subaccount is promoted onto the pro track (`ValiConfig.PRO_ACCOUNT_SIZE`, currently $1,000,000). Present for every subaccount, standard or pro, so a UI can show it before promotion. It is not an eligibility signal (Hyperliquid subaccounts have no pro tier) and it is not the granted size: a subaccount that was already promoted keeps the `pro_account_size` it was granted even if this value later changes.
+- `account_type`: `"standard"` or `"pro"`
 - `status`: Current status ("active", "eliminated", or "unknown")
 - `created_at_ms`: Timestamp when subaccount was created
 - `eliminated_at_ms`: Timestamp when eliminated (null if active)
@@ -2446,6 +2463,7 @@ Resolve a Hyperliquid wallet address to its synthetic hotkey and return the full
       "entity_hotkey": "5GhDr3xy...abc",
       "subaccount_id": 0,
       "asset_class": "crypto",
+      "default_pro_account_size": 1000000,
       "hl_address": "0xabcd1234...",
       "payout_address": "0xAbCd...",
       "status": "active",

--- a/entity_management/entity_client.py
+++ b/entity_management/entity_client.py
@@ -186,6 +186,14 @@ class EntityClient(RPCClientBase):
         """Point a subaccount at the account size its target bucket trades."""
         return self._server.apply_bucket_account_size_rpc(synthetic_hotkey, target_bucket, pro_account_size)
 
+    def snapshot_bucket_account_size(self, synthetic_hotkey: str) -> Optional[dict]:
+        """The sizing fields apply_bucket_account_size writes, read before it runs."""
+        return self._server.snapshot_bucket_account_size_rpc(synthetic_hotkey)
+
+    def restore_bucket_account_size(self, synthetic_hotkey: str, snapshot: dict) -> Tuple[bool, str]:
+        """Undo an apply_bucket_account_size whose bucket move then failed."""
+        return self._server.restore_bucket_account_size_rpc(synthetic_hotkey, snapshot)
+
     def get_payout_scale(self, synthetic_hotkey: str) -> float:
         """Multiplier applied to this subaccount's PnL when folded into the entity payout."""
         return self._server.get_payout_scale_rpc(synthetic_hotkey)

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -778,6 +778,14 @@ class EntityManager(ValidatorBroadcastBase):
         recorded; every other pro bucket switches the live account size to the pro size.
         Returning to a standard bucket restores the standard size.
 
+        The granted pro size is, in order: the explicit pro_account_size, the size already recorded
+        on the subaccount, then the network's ValiConfig.PRO_ACCOUNT_SIZE. Standard buckets never
+        write pro_account_size, so a standard account that was never promoted keeps None.
+
+        Nothing is stored until every step has succeeded, so a rejected or failed move leaves the
+        subaccount exactly as it was: a standard account never picks up a pro size or the pro
+        account type from a pro move that did not happen.
+
         Returns:
             (success, message)
         """
@@ -787,25 +795,28 @@ class EntityManager(ValidatorBroadcastBase):
 
         entity_hotkey, subaccount_id = parse_synthetic_hotkey(synthetic_hotkey)
 
+        # Work out the new sizes without touching the stored subaccount
+        standard_account_size = subaccount.standard_account_size
         if target_bucket.is_pro_track:
             if pro_account_size is None:
                 pro_account_size = subaccount.pro_account_size
             if pro_account_size is None:
-                return False, "pro_account_size is required to enter the pro track"
+                pro_account_size = ValiConfig.PRO_ACCOUNT_SIZE
             if pro_account_size > ValiConfig.MAX_PRO_ACCOUNT_SIZE:
                 return False, (
                     f"Account size ${pro_account_size} exceeds maximum allowed "
                     f"${ValiConfig.MAX_PRO_ACCOUNT_SIZE}"
                 )
-            if subaccount.standard_account_size is None:
-                subaccount.standard_account_size = subaccount.account_size
-            subaccount.pro_account_size = pro_account_size
-            subaccount.account_type = AccountType.PRO.value
+            if standard_account_size is None:
+                standard_account_size = subaccount.account_size
+            account_type = AccountType.PRO.value
             # TRANSITION winds down the standard account, so it keeps the standard size
-            target_size = pro_account_size if target_bucket.is_pro else subaccount.standard_account_size
+            target_size = pro_account_size if target_bucket.is_pro else standard_account_size
         else:
-            subaccount.account_type = AccountType.STANDARD.value
-            target_size = subaccount.standard_account_size or subaccount.account_size
+            # A standard bucket never records a pro size; keep whatever is already there
+            pro_account_size = subaccount.pro_account_size
+            account_type = AccountType.STANDARD.value
+            target_size = standard_account_size or subaccount.account_size
 
         if target_size != subaccount.account_size:
             cpt = (ValiConfig.ENTITY_COST_PER_THETA_LOW
@@ -819,10 +830,13 @@ class EntityManager(ValidatorBroadcastBase):
             )
             if not record:
                 return False, f"Failed to set account size for {synthetic_hotkey}"
-            subaccount.account_size = target_size
 
         entity_lock = self._get_entity_lock(entity_hotkey)
         with entity_lock:
+            subaccount.standard_account_size = standard_account_size
+            subaccount.pro_account_size = pro_account_size
+            subaccount.account_type = account_type
+            subaccount.account_size = target_size
             entity_data = self.entities.get(entity_hotkey)
             if entity_data:
                 entity_data.subaccounts[subaccount_id] = subaccount
@@ -1203,6 +1217,9 @@ class EntityManager(ValidatorBroadcastBase):
                 "account_size": subaccount.account_size,
                 "standard_account_size": subaccount.standard_account_size,
                 "pro_account_size": subaccount.pro_account_size,
+                # The size a pro promotion grants, published for every subaccount so a UI can show it
+                # before promotion. pro_account_size above stays the granted size (None until promoted).
+                "default_pro_account_size": ValiConfig.PRO_ACCOUNT_SIZE,
                 "account_type": subaccount.account_type,
                 "status": subaccount.status,
                 "created_at_ms": subaccount.created_at_ms,
@@ -1638,6 +1655,8 @@ class EntityManager(ValidatorBroadcastBase):
             'subaccount_uuid': subaccount.subaccount_uuid,
             'asset_class': subaccount.asset_class,
             'account_size': subaccount.account_size,
+            # Same field, same place as the v2 subaccount_info: the size a pro promotion grants
+            'default_pro_account_size': ValiConfig.PRO_ACCOUNT_SIZE,
             'status': subaccount.status,
             'created_at_ms': subaccount.created_at_ms,
             'eliminated_at_ms': subaccount.eliminated_at_ms,

--- a/entity_management/entity_manager.py
+++ b/entity_management/entity_manager.py
@@ -17,6 +17,7 @@ Pattern follows ChallengePeriodManager:
 - Local dicts (NOT IPC) for performance
 - Disk persistence via JSON
 """
+import math
 import re
 import uuid
 import time
@@ -25,7 +26,7 @@ from typing import Dict, Optional, Tuple, List
 from pydantic import BaseModel, Field
 
 import template.protocol
-from entity_management.entity_utils import is_synthetic_hotkey, parse_synthetic_hotkey
+from entity_management.entity_utils import is_synthetic_hotkey, parse_synthetic_hotkey, pro_account_size_error
 from vali_objects.miner_account import MinerAccountClient
 from vali_objects.miner_account.account_snapshot import read_all_snapshots, DEFAULT_TOLERANCE_MS
 from vali_objects.utils.entity_collateral.entity_collateral_client import EntityCollateralClient
@@ -778,9 +779,17 @@ class EntityManager(ValidatorBroadcastBase):
         recorded; every other pro bucket switches the live account size to the pro size.
         Returning to a standard bucket restores the standard size.
 
-        The granted pro size is, in order: the explicit pro_account_size, the size already recorded
-        on the subaccount, then the network's ValiConfig.PRO_ACCOUNT_SIZE. Standard buckets never
-        write pro_account_size, so a standard account that was never promoted keeps None.
+        There is no network default pro size. The admin sets it when offering the pro track
+        (POST /admin/miner-bucket/<hotkey>), and this is the last check before it is stored:
+          * An explicit pro_account_size, for any target, must be an int or float (not a bool),
+            finite, and within [ValiConfig.MIN_PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE].
+          * Entering the pro track from a subaccount whose account_type is not "pro" requires an
+            explicit size. A size recorded on an earlier pro journey, which a demotion keeps, is never
+            reused: a re-offer needs a size again.
+          * A move within the pro track uses the explicit size when one is sent (the admin re-setting
+            it, e.g. on PRO_FUNDED), else the size recorded when the subaccount entered the track
+            (Start Pro Now and the organic promotions send none). With neither, the move is rejected.
+          * A standard bucket never records a pro size; an explicit one is ignored.
 
         Nothing is stored until every step has succeeded, so a rejected or failed move leaves the
         subaccount exactly as it was: a standard account never picks up a pro size or the pro
@@ -793,20 +802,36 @@ class EntityManager(ValidatorBroadcastBase):
         if subaccount is None:
             return False, f"{synthetic_hotkey} is not a known subaccount"
 
+        if pro_account_size is not None:
+            size_error = pro_account_size_error(pro_account_size)
+            if size_error:
+                return False, size_error
+
         entity_hotkey, subaccount_id = parse_synthetic_hotkey(synthetic_hotkey)
 
         # Work out the new sizes without touching the stored subaccount
         standard_account_size = subaccount.standard_account_size
+        # Where the pro size came from ("explicit" or "recorded"), for the log; None for standard buckets
+        pro_size_source = None
         if target_bucket.is_pro_track:
-            if pro_account_size is None:
+            if pro_account_size is not None:
+                pro_size_source = "explicit"
+            elif subaccount.account_type == AccountType.PRO.value and subaccount.pro_account_size is not None:
                 pro_account_size = subaccount.pro_account_size
-            if pro_account_size is None:
-                pro_account_size = ValiConfig.PRO_ACCOUNT_SIZE
-            if pro_account_size > ValiConfig.MAX_PRO_ACCOUNT_SIZE:
-                return False, (
-                    f"Account size ${pro_account_size} exceeds maximum allowed "
-                    f"${ValiConfig.MAX_PRO_ACCOUNT_SIZE}"
-                )
+                pro_size_source = "recorded"
+                # A recorded size passed the range check when it was set, and is not re-checked against
+                # today's range so a later range change cannot strand a pro account mid-journey. It must
+                # still be a usable number: never trade a corrupt one.
+                if (isinstance(pro_account_size, bool)
+                        or not isinstance(pro_account_size, (int, float))
+                        or (isinstance(pro_account_size, float) and not math.isfinite(pro_account_size))
+                        or pro_account_size <= 0):
+                    return False, (
+                        f"Recorded pro_account_size {pro_account_size!r} for {synthetic_hotkey} is not a "
+                        f"finite positive number; send an explicit pro_account_size"
+                    )
+            else:
+                return False, "pro_account_size is required to enter the pro track"
             if standard_account_size is None:
                 standard_account_size = subaccount.account_size
             account_type = AccountType.PRO.value
@@ -842,11 +867,93 @@ class EntityManager(ValidatorBroadcastBase):
                 entity_data.subaccounts[subaccount_id] = subaccount
         self._write_entities_from_memory_to_disk()
 
+        pro_size_note = f" (pro size source: {pro_size_source})" if pro_size_source else ""
         logger.info(
             f"[ENTITY_MANAGER] {synthetic_hotkey} -> {target_bucket.value}: account_size=${subaccount.account_size}, "
-            f"standard=${subaccount.standard_account_size}, pro=${subaccount.pro_account_size}"
+            f"standard=${subaccount.standard_account_size}, pro=${subaccount.pro_account_size}{pro_size_note}"
         )
         return True, f"{synthetic_hotkey} account size set to ${subaccount.account_size}"
+
+    def snapshot_bucket_account_size(self, synthetic_hotkey: str) -> Optional[dict]:
+        """
+        The four sizing fields apply_bucket_account_size writes, read before it runs.
+
+        Take one before an apply and hand it to restore_bucket_account_size if the bucket move that
+        follows then fails. A plain dict, so it crosses the EntityClient RPC hop unchanged.
+        """
+        subaccount = self.get_subaccount_info_for_synthetic(synthetic_hotkey)
+        if subaccount is None:
+            return None
+        return {
+            "account_size": subaccount.account_size,
+            "standard_account_size": subaccount.standard_account_size,
+            "pro_account_size": subaccount.pro_account_size,
+            "account_type": subaccount.account_type,
+        }
+
+    def restore_bucket_account_size(self, synthetic_hotkey: str, snapshot: dict) -> Tuple[bool, str]:
+        """
+        Undo an apply_bucket_account_size whose bucket move then failed.
+
+        apply_bucket_account_size commits: it resizes the live account and writes the record to disk
+        before its caller moves the bucket. A failed move would otherwise leave a standard subaccount
+        marked "pro" with a pro size on record, and the size-less branch of the next offer is gated on
+        exactly that marking — so a re-offer with the size field blank would silently reuse the stale
+        size instead of demanding one. Worse, an entry that trades the pro size (PRO_CHALLENGE_DIRECT,
+        PRO_CHALLENGE_FROM_STANDARD) would leave the account live at that size in a bucket that never
+        moved.
+
+        `snapshot` is what snapshot_bucket_account_size returned before the apply. The live account size
+        is put back first and the record is left untouched if that fails: a record restored behind a
+        still-resized account is a silent divergence no later move heals (a move back to the recorded
+        size finds nothing to do), whereas a subaccount left marked pro is loudly wrong and re-syncs on
+        the next demotion.
+        """
+        subaccount = self.get_subaccount_info_for_synthetic(synthetic_hotkey)
+        if subaccount is None:
+            return False, f"{synthetic_hotkey} is not a known subaccount"
+        if not snapshot or "account_size" not in snapshot:
+            return False, f"No account size snapshot to restore for {synthetic_hotkey}"
+
+        entity_hotkey, subaccount_id = parse_synthetic_hotkey(synthetic_hotkey)
+        previous_account_size = snapshot["account_size"]
+
+        if previous_account_size != subaccount.account_size:
+            cpt = (ValiConfig.ENTITY_COST_PER_THETA_LOW
+                   if previous_account_size <= ValiConfig.ENTITY_COST_PER_THETA_LOW_THRESHOLD
+                   else ValiConfig.ENTITY_COST_PER_THETA)
+            record = self._miner_account_client.set_miner_account_size(
+                synthetic_hotkey,
+                collateral_balance_theta=previous_account_size / cpt,
+                timestamp_ms=TimeUtil.now_in_millis(),
+                account_size=previous_account_size,
+            )
+            if not record:
+                logger.error(
+                    f"[ENTITY_MANAGER] {synthetic_hotkey} rollback FAILED: the live account is still "
+                    f"${subaccount.account_size}, not ${previous_account_size}. Leaving the record as it "
+                    f"is rather than diverging from the account; the subaccount stays marked "
+                    f"{subaccount.account_type} outside the bucket that never moved"
+                )
+                return False, f"Failed to restore account size for {synthetic_hotkey}"
+
+        entity_lock = self._get_entity_lock(entity_hotkey)
+        with entity_lock:
+            subaccount.account_size = previous_account_size
+            subaccount.standard_account_size = snapshot.get("standard_account_size")
+            subaccount.pro_account_size = snapshot.get("pro_account_size")
+            subaccount.account_type = snapshot.get("account_type", AccountType.STANDARD.value)
+            entity_data = self.entities.get(entity_hotkey)
+            if entity_data:
+                entity_data.subaccounts[subaccount_id] = subaccount
+        self._write_entities_from_memory_to_disk()
+
+        logger.info(
+            f"[ENTITY_MANAGER] {synthetic_hotkey} sizing rolled back after a failed bucket move: "
+            f"account_size=${subaccount.account_size}, standard=${subaccount.standard_account_size}, "
+            f"pro=${subaccount.pro_account_size}, account_type={subaccount.account_type}"
+        )
+        return True, f"{synthetic_hotkey} account size restored to ${subaccount.account_size}"
 
     def get_payout_scale(self, synthetic_hotkey: str) -> float:
         """
@@ -1217,9 +1324,6 @@ class EntityManager(ValidatorBroadcastBase):
                 "account_size": subaccount.account_size,
                 "standard_account_size": subaccount.standard_account_size,
                 "pro_account_size": subaccount.pro_account_size,
-                # The size a pro promotion grants, published for every subaccount so a UI can show it
-                # before promotion. pro_account_size above stays the granted size (None until promoted).
-                "default_pro_account_size": ValiConfig.PRO_ACCOUNT_SIZE,
                 "account_type": subaccount.account_type,
                 "status": subaccount.status,
                 "created_at_ms": subaccount.created_at_ms,
@@ -1655,8 +1759,6 @@ class EntityManager(ValidatorBroadcastBase):
             'subaccount_uuid': subaccount.subaccount_uuid,
             'asset_class': subaccount.asset_class,
             'account_size': subaccount.account_size,
-            # Same field, same place as the v2 subaccount_info: the size a pro promotion grants
-            'default_pro_account_size': ValiConfig.PRO_ACCOUNT_SIZE,
             'status': subaccount.status,
             'created_at_ms': subaccount.created_at_ms,
             'eliminated_at_ms': subaccount.eliminated_at_ms,

--- a/entity_management/entity_server.py
+++ b/entity_management/entity_server.py
@@ -254,6 +254,14 @@ class EntityServer(RPCServerBase):
         """Point a subaccount at the account size its target bucket trades."""
         return self._manager.apply_bucket_account_size(synthetic_hotkey, target_bucket, pro_account_size)
 
+    def snapshot_bucket_account_size_rpc(self, synthetic_hotkey: str) -> Optional[dict]:
+        """The sizing fields apply_bucket_account_size writes, read before it runs."""
+        return self._manager.snapshot_bucket_account_size(synthetic_hotkey)
+
+    def restore_bucket_account_size_rpc(self, synthetic_hotkey: str, snapshot: dict) -> Tuple[bool, str]:
+        """Undo an apply_bucket_account_size whose bucket move then failed."""
+        return self._manager.restore_bucket_account_size(synthetic_hotkey, snapshot)
+
     def get_payout_scale_rpc(self, synthetic_hotkey: str) -> float:
         """Multiplier applied to this subaccount's PnL when folded into the entity payout."""
         return self._manager.get_payout_scale(synthetic_hotkey)

--- a/entity_management/entity_utils.py
+++ b/entity_management/entity_utils.py
@@ -5,8 +5,10 @@ Entity utility functions for synthetic hotkey parsing and validation.
 
 These are static utility functions that can be called without RPC overhead.
 """
+import math
 from typing import Tuple, Optional
 from shared_objects.log import logger
+from vali_objects.vali_config import ValiConfig
 
 
 def is_synthetic_hotkey(hotkey: str) -> bool:
@@ -87,6 +89,31 @@ def parse_synthetic_hotkey(synthetic_hotkey: str) -> Tuple[Optional[str], Option
         return entity_hotkey, subaccount_id
     except ValueError:
         return None, None
+
+
+def pro_account_size_error(pro_account_size) -> Optional[str]:
+    """
+    Why pro_account_size cannot be used as a pro account size, or None when it can.
+
+    A pro account size is an int or float (never a bool) that is finite and within
+    [ValiConfig.MIN_PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE] inclusive. The network enforces
+    only this range; the size presets offered by the Command Center are a UI concern.
+
+    Sizes arrive as parsed JSON, and Python's JSON parser (so Flask's request.get_json) accepts the
+    literals NaN, Infinity and -Infinity. NaN fails every ordered comparison, so a plain range check
+    lets it through: finiteness is checked first. Integers are always finite (and may be too large to
+    convert to float), so only floats go through math.isfinite.
+    """
+    if isinstance(pro_account_size, bool) or not isinstance(pro_account_size, (int, float)):
+        return f"pro_account_size must be a number, got {type(pro_account_size).__name__}"
+    if isinstance(pro_account_size, float) and not math.isfinite(pro_account_size):
+        return f"pro_account_size must be a finite number, got {pro_account_size}"
+    if not ValiConfig.MIN_PRO_ACCOUNT_SIZE <= pro_account_size <= ValiConfig.MAX_PRO_ACCOUNT_SIZE:
+        return (
+            f"pro_account_size ${pro_account_size} is outside the allowed range "
+            f"${ValiConfig.MIN_PRO_ACCOUNT_SIZE:,} to ${ValiConfig.MAX_PRO_ACCOUNT_SIZE:,}"
+        )
+    return None
 
 
 def create_subaccount_dashboard(

--- a/tests/vali_tests/test_pro_account_size.py
+++ b/tests/vali_tests/test_pro_account_size.py
@@ -1,14 +1,20 @@
 """
-The network-owned pro account size.
+The admin-set pro account size.
+
+There is no network default: the admin sets the size when offering the pro track, and the network enforces
+only the inclusive range [ValiConfig.MIN_PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE] plus finite and
+numeric.
 
 Covers:
-  * ValiConfig.PRO_ACCOUNT_SIZE: the size a pro promotion grants, bounded by MAX_PRO_ACCOUNT_SIZE at import.
-  * EntityManager.apply_bucket_account_size: entering the pro track with no size grants the network size,
-    an explicit size is still honoured (and capped), a recorded size is kept, a failed or rejected move
-    changes nothing, and a standard account never picks up a pro size (so payout_scale stays 1.0).
-  * subaccount_info.default_pro_account_size: present with the same name in the same place in the v1
-    (GET /entity/subaccount/<hotkey>) and v2 (GET /v2/entity/subaccount/<hotkey>, websocket) dashboards,
-    for standard and pro subaccounts, next to an untouched subaccount_info.pro_account_size.
+  * ValiConfig: MIN_PRO_ACCOUNT_SIZE / MAX_PRO_ACCOUNT_SIZE are $200K / $1M, checked at import with a raise, and
+    the old network default PRO_ACCOUNT_SIZE is gone.
+  * pro_account_size_error: the shared check behind every entry point (range bounds, NaN / Infinity, bool, str).
+  * EntityManager.apply_bucket_account_size: a size is required to enter the pro track, including a re-offer
+    after a demotion; a move within the track uses an explicit size or the recorded one; PRO_FUNDED can re-set
+    the size within range; a standard target never records a size; a rejected or failed move changes nothing;
+    the log line names the size source.
+  * Dashboards: subaccount_info no longer carries default_pro_account_size in the v1, v2, websocket or
+    hl-traders payloads.
 
 EntityManager is built with object.__new__ and only the attributes these methods touch, so no RPC servers
 are started.
@@ -23,7 +29,7 @@ from flask import Flask
 
 import vali_objects.vali_config as vali_config_module
 from entity_management.entity_manager import EntityData, EntityManager, SubaccountInfo
-from entity_management.entity_utils import create_subaccount_dashboard
+from entity_management.entity_utils import create_subaccount_dashboard, pro_account_size_error
 from vali_objects.enums.account_type_enum import AccountType
 from vali_objects.enums.miner_bucket_enum import MinerBucket
 from vali_objects.vali_config import ValiConfig
@@ -31,8 +37,35 @@ from vali_objects.vali_config import ValiConfig
 NOW_MS = 1_748_000_000_000
 ENTITY_HOTKEY = "entity_alpha"
 STANDARD_SIZE = 100_000.0
-GRANTED_SIZE = 500_000.0  # deliberately different from ValiConfig.PRO_ACCOUNT_SIZE
-FIELD = "default_pro_account_size"
+GRANTED_SIZE = 500_000.0
+REMOVED_FIELD = "default_pro_account_size"
+REQUIRED = "pro_account_size is required to enter the pro track"
+
+PRO_BUCKETS = (MinerBucket.PRO_CHALLENGE_TRANSITION, MinerBucket.PRO_CHALLENGE_FROM_STANDARD,
+               MinerBucket.PRO_CHALLENGE_DIRECT, MinerBucket.PRO_FUNDED)
+STANDARD_BUCKETS = (MinerBucket.SUBACCOUNT_CHALLENGE, MinerBucket.SUBACCOUNT_FUNDED, MinerBucket.SUBACCOUNT_ALPHA)
+
+# Just outside the range, NaN / Infinity (which json.loads, so Flask's get_json, accepts), and wrong types.
+# Each is (size, fragment of the rejection message).
+OUT_OF_RANGE = "outside the allowed range"
+NOT_FINITE = "must be a finite number"
+NOT_A_NUMBER = "must be a number"
+INVALID_SIZES = (
+    (199_999, OUT_OF_RANGE),
+    (199_999.99, OUT_OF_RANGE),
+    (1_000_001, OUT_OF_RANGE),
+    (1_000_000.01, OUT_OF_RANGE),
+    (0, OUT_OF_RANGE),
+    (-500_000, OUT_OF_RANGE),
+    (10 ** 400, OUT_OF_RANGE),
+    (float("nan"), NOT_FINITE),
+    (float("inf"), NOT_FINITE),
+    (float("-inf"), NOT_FINITE),
+    (True, NOT_A_NUMBER),
+    (False, NOT_A_NUMBER),
+    ("500000", NOT_A_NUMBER),
+    ([500_000], NOT_A_NUMBER),
+)
 
 
 def _bare_manager():
@@ -79,13 +112,23 @@ def _add_standard(manager, subaccount_id=0, account_size=STANDARD_SIZE):
 
 
 def _add_pro(manager, subaccount_id=1, pro_size=GRANTED_SIZE):
-    """A subaccount already promoted onto a pro account of pro_size."""
+    """A subaccount already on the pro track, trading a pro account of pro_size."""
     hotkey = _add_standard(manager, subaccount_id)
     info = manager.get_subaccount_info_for_synthetic(hotkey)
     info.standard_account_size = STANDARD_SIZE
     info.pro_account_size = pro_size
     info.account_size = pro_size
     info.account_type = AccountType.PRO.value
+    return hotkey
+
+
+def _add_demoted(manager, subaccount_id=2, pro_size=GRANTED_SIZE):
+    """A subaccount demoted back to the standard track: standard again, but still carrying the pro size
+    recorded on its earlier pro journey (a standard bucket never clears it)."""
+    hotkey = _add_pro(manager, subaccount_id, pro_size)
+    info = manager.get_subaccount_info_for_synthetic(hotkey)
+    info.account_size = STANDARD_SIZE
+    info.account_type = AccountType.STANDARD.value
     return hotkey
 
 
@@ -109,38 +152,77 @@ def _no_section_clients():
 
 class TestProAccountSizeConfig(unittest.TestCase):
 
-    def test_network_grants_one_million_today(self):
-        self.assertEqual(ValiConfig.PRO_ACCOUNT_SIZE, 1_000_000)
+    def test_range_is_200k_to_1m(self):
+        self.assertEqual(ValiConfig.MIN_PRO_ACCOUNT_SIZE, 200_000)
+        self.assertEqual(ValiConfig.MAX_PRO_ACCOUNT_SIZE, 1_000_000)
 
-    def test_grant_is_positive_and_within_the_cap(self):
-        self.assertGreater(ValiConfig.PRO_ACCOUNT_SIZE, 0)
-        self.assertLessEqual(ValiConfig.PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE)
+    def test_there_is_no_network_default_size(self):
+        self.assertFalse(hasattr(ValiConfig, "PRO_ACCOUNT_SIZE"))
 
-    def test_import_fails_for_a_grant_outside_the_cap(self):
-        """Editing PRO_ACCOUNT_SIZE above MAX_PRO_ACCOUNT_SIZE (or to a non-positive value) breaks import."""
+    def test_import_raises_for_an_invalid_range(self):
+        """MIN above MAX, or a non-positive MIN, breaks import with a ValueError (a raise, not an assert that
+        python -O would strip)."""
         path = vali_config_module.__file__
         with open(path) as f:
             source = f.read()
-        assignment = re.compile(r"^(    PRO_ACCOUNT_SIZE = ).*$", re.M)
+        assignment = re.compile(r"^(    MIN_PRO_ACCOUNT_SIZE = ).*$", re.M)
         self.assertEqual(len(assignment.findall(source)), 1)
 
-        for bad in ("MAX_PRO_ACCOUNT_SIZE + 1", "0", "-1"):
-            with self.subTest(PRO_ACCOUNT_SIZE=bad):
+        for bad in ("MAX_PRO_ACCOUNT_SIZE + 1", "0", "-200_000"):
+            with self.subTest(MIN_PRO_ACCOUNT_SIZE=bad):
                 tampered = assignment.sub(lambda m: m.group(1) + bad, source)
-                with self.assertRaisesRegex(ValueError, "PRO_ACCOUNT_SIZE"):
+                with self.assertRaisesRegex(ValueError, "MIN_PRO_ACCOUNT_SIZE"):
                     exec(compile(tampered, path, "exec"), {"__name__": "vali_config_probe", "__file__": path})
+
+        # MIN == MAX is a valid (single-size) range
+        equal = assignment.sub(lambda m: m.group(1) + "MAX_PRO_ACCOUNT_SIZE", source)
+        exec(compile(equal, path, "exec"), {"__name__": "vali_config_probe", "__file__": path})
 
         # The untouched source imports cleanly, so the failures above come from the guard
         namespace = {"__name__": "vali_config_probe", "__file__": path}
         exec(compile(source, path, "exec"), namespace)
-        self.assertEqual(namespace["ValiConfig"].PRO_ACCOUNT_SIZE, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(namespace["ValiConfig"].MIN_PRO_ACCOUNT_SIZE, ValiConfig.MIN_PRO_ACCOUNT_SIZE)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# pro_account_size_error
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestProAccountSizeError(unittest.TestCase):
+
+    def test_accepts_the_inclusive_range(self):
+        for size in (200_000, 200_000.0, 250_000, 500_000.5, 999_999.99, 1_000_000, 1_000_000.0):
+            with self.subTest(size=size):
+                self.assertIsNone(pro_account_size_error(size))
+
+    def test_rejects_out_of_range_non_finite_and_non_numeric(self):
+        for size, reason in INVALID_SIZES + ((None, NOT_A_NUMBER), ({"size": 500_000}, NOT_A_NUMBER)):
+            with self.subTest(size=size):
+                error = pro_account_size_error(size)
+                self.assertIsNotNone(error)
+                self.assertIn(reason, error)
+                self.assertIn("pro_account_size", error)
+
+    def test_the_json_literals_flask_accepts_are_rejected(self):
+        """json.loads (and so Flask's request.get_json) turns these literals into non-finite floats, and NaN
+        passes a plain "< MIN" / "> MAX" range check."""
+        for literal in ("NaN", "Infinity", "-Infinity", "1e999"):
+            with self.subTest(literal=literal):
+                value = json.loads(literal)
+                self.assertIsInstance(value, float)
+                self.assertIn(NOT_FINITE, pro_account_size_error(value))
+
+    def test_range_is_read_from_config_at_call_time(self):
+        with patch.object(ValiConfig, "MIN_PRO_ACCOUNT_SIZE", 300_000):
+            self.assertIn(OUT_OF_RANGE, pro_account_size_error(250_000))
+            self.assertIsNone(pro_account_size_error(300_000))
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # EntityManager.apply_bucket_account_size
 # ═══════════════════════════════════════════════════════════════════════════════
 
-class TestApplyBucketAccountSizeDefault(unittest.TestCase):
+class TestApplyBucketAccountSize(unittest.TestCase):
 
     def setUp(self):
         self.manager = _bare_manager()
@@ -150,81 +232,122 @@ class TestApplyBucketAccountSizeDefault(unittest.TestCase):
     def _info(self, hotkey):
         return self.manager.get_subaccount_info_for_synthetic(hotkey)
 
-    def test_transition_without_a_size_records_the_network_size(self):
-        success, message = self.manager.apply_bucket_account_size(
-            self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION
-        )
+    def _snapshot(self, hotkey):
+        return self._info(hotkey).model_dump()
 
-        self.assertTrue(success, message)
-        info = self._info(self.standard)
-        self.assertEqual(info.pro_account_size, ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
-        self.assertEqual(info.account_type, AccountType.PRO.value)
-        # TRANSITION keeps trading the standard account
-        self.assertEqual(info.account_size, STANDARD_SIZE)
+    def _assert_rejected_unchanged(self, hotkey, bucket, pro_account_size, reason):
+        before = self._snapshot(hotkey)
+        self.set_size.reset_mock()
+        with patch.object(self.manager, "_write_entities_from_memory_to_disk") as write:
+            success, message = self.manager.apply_bucket_account_size(hotkey, bucket, pro_account_size)
+        self.assertFalse(success, message)
+        self.assertIn(reason, message)
+        self.assertEqual(self._snapshot(hotkey), before)
         self.set_size.assert_not_called()
+        write.assert_not_called()
 
-    def test_direct_pro_challenge_without_a_size_trades_the_network_size(self):
-        success, message = self.manager.apply_bucket_account_size(self.standard, MinerBucket.PRO_CHALLENGE_DIRECT)
+    # ==================== entering the pro track ====================
 
-        self.assertTrue(success, message)
-        info = self._info(self.standard)
-        self.assertEqual(info.pro_account_size, ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(info.account_size, ValiConfig.PRO_ACCOUNT_SIZE)
-        self.set_size.assert_called_once()
-        self.assertEqual(self.set_size.call_args.kwargs["account_size"], ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(
-            self.set_size.call_args.kwargs["collateral_balance_theta"],
-            ValiConfig.PRO_ACCOUNT_SIZE / ValiConfig.ENTITY_COST_PER_THETA,
-        )
+    def test_entering_the_track_requires_a_size(self):
+        for bucket in PRO_BUCKETS:
+            with self.subTest(bucket=bucket):
+                self._assert_rejected_unchanged(self.standard, bucket, None, REQUIRED)
+        self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
 
-    def test_default_is_read_when_the_promotion_happens(self):
-        """The network can change the size; a promotion grants whatever it is at that moment."""
-        changed = ValiConfig.PRO_ACCOUNT_SIZE - 1
-        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", changed):
-            self.assertTrue(self.manager.apply_bucket_account_size(
-                self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION)[0])
-        self.assertEqual(self._info(self.standard).pro_account_size, changed)
-
-    def test_explicit_size_is_honoured(self):
+    def test_transition_with_a_size_records_it_and_keeps_the_standard_account(self):
         success, message = self.manager.apply_bucket_account_size(
             self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION, GRANTED_SIZE
         )
 
         self.assertTrue(success, message)
-        self.assertEqual(self._info(self.standard).pro_account_size, GRANTED_SIZE)
-
-    def test_explicit_size_above_the_cap_is_rejected_and_changes_nothing(self):
-        success, message = self.manager.apply_bucket_account_size(
-            self.standard, MinerBucket.PRO_CHALLENGE_DIRECT, ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1
-        )
-
-        self.assertFalse(success)
-        self.assertIn("exceeds maximum", message)
         info = self._info(self.standard)
-        self.assertIsNone(info.pro_account_size)
-        self.assertIsNone(info.standard_account_size)
-        self.assertEqual(info.account_type, AccountType.STANDARD.value)
+        self.assertEqual(info.pro_account_size, GRANTED_SIZE)
+        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+        self.assertEqual(info.account_type, AccountType.PRO.value)
         self.assertEqual(info.account_size, STANDARD_SIZE)
         self.set_size.assert_not_called()
 
-    def test_recorded_size_is_kept_over_the_network_size(self):
-        """Once granted, a size survives later pro moves even if the network size has changed since."""
+    def test_range_bounds_are_inclusive(self):
+        for size, accepted in ((199_999, False), (200_000, True), (1_000_000, True), (1_000_001, False)):
+            with self.subTest(pro_account_size=size):
+                manager = self.manager = _bare_manager()
+                self.set_size = manager._miner_account_client.set_miner_account_size
+                hotkey = _add_standard(manager)
+                if not accepted:
+                    self._assert_rejected_unchanged(hotkey, MinerBucket.PRO_CHALLENGE_DIRECT, size, OUT_OF_RANGE)
+                    continue
+                success, message = manager.apply_bucket_account_size(hotkey, MinerBucket.PRO_CHALLENGE_DIRECT, size)
+                self.assertTrue(success, message)
+                info = self._info(hotkey)
+                self.assertEqual(info.pro_account_size, size)
+                self.assertEqual(info.account_size, size)
+                self.assertEqual(self.set_size.call_args.kwargs["account_size"], size)
+                self.assertEqual(self.set_size.call_args.kwargs["collateral_balance_theta"],
+                                 size / ValiConfig.ENTITY_COST_PER_THETA)
+
+    def test_invalid_explicit_sizes_are_rejected_for_every_target_and_change_nothing(self):
         pro = _add_pro(self.manager)
+        for hotkey in (self.standard, pro):
+            for bucket in PRO_BUCKETS + STANDARD_BUCKETS:
+                for size, reason in INVALID_SIZES:
+                    with self.subTest(hotkey=hotkey, bucket=bucket, pro_account_size=size):
+                        self._assert_rejected_unchanged(hotkey, bucket, size, reason)
+        self.assertIsNone(self._info(self.standard).pro_account_size)
+        self.assertEqual(self._info(pro).pro_account_size, GRANTED_SIZE)
 
-        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", GRANTED_SIZE + 1):
-            success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.PRO_FUNDED)
+    def test_reoffer_after_demotion_requires_a_size_again(self):
+        """The size recorded on an earlier pro journey is never silently reused when re-entering the track."""
+        demoted = _add_demoted(self.manager)
+        for bucket in PRO_BUCKETS:
+            with self.subTest(bucket=bucket):
+                self._assert_rejected_unchanged(demoted, bucket, None, REQUIRED)
+        self.assertEqual(self._info(demoted).pro_account_size, GRANTED_SIZE)
 
+        success, message = self.manager.apply_bucket_account_size(
+            demoted, MinerBucket.PRO_CHALLENGE_TRANSITION, 300_000
+        )
         self.assertTrue(success, message)
-        info = self._info(pro)
-        self.assertEqual(info.pro_account_size, GRANTED_SIZE)
-        self.assertEqual(info.account_size, GRANTED_SIZE)
-        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+        info = self._info(demoted)
+        self.assertEqual(info.pro_account_size, 300_000)
+        self.assertEqual(info.account_type, AccountType.PRO.value)
+        self.assertEqual(info.account_size, STANDARD_SIZE)
 
-    def test_transition_then_promotion_grants_the_size_recorded_at_transition(self):
-        """The admin move records the network size; the miner's own promotion (no size) trades it."""
+    def test_full_journey_offer_demote_reoffer(self):
+        """Offer at 500K, start pro, demote, re-offer: the re-offer needs a size and trades the new one."""
+        hotkey = self.standard
+        apply = self.manager.apply_bucket_account_size
+        self.assertTrue(apply(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, GRANTED_SIZE)[0])
+        self.assertTrue(apply(hotkey, MinerBucket.PRO_CHALLENGE_FROM_STANDARD)[0])
+        self.assertEqual(self._info(hotkey).account_size, GRANTED_SIZE)
+        self.assertTrue(apply(hotkey, MinerBucket.SUBACCOUNT_FUNDED)[0])
+        self.assertEqual(self._info(hotkey).account_size, STANDARD_SIZE)
+
+        self._assert_rejected_unchanged(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, None, REQUIRED)
+
+        self.assertTrue(apply(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, 250_000)[0])
+        self.assertTrue(apply(hotkey, MinerBucket.PRO_CHALLENGE_FROM_STANDARD)[0])
+        info = self._info(hotkey)
+        self.assertEqual(info.pro_account_size, 250_000)
+        self.assertEqual(info.account_size, 250_000)
+        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+        self.assertAlmostEqual(self.manager.get_payout_scale(hotkey), STANDARD_SIZE / 250_000)
+
+    # ==================== within the pro track ====================
+
+    def test_move_within_the_track_uses_the_recorded_size(self):
+        pro = _add_pro(self.manager)
+        for bucket in (MinerBucket.PRO_FUNDED, MinerBucket.PRO_CHALLENGE_FROM_STANDARD):
+            with self.subTest(bucket=bucket):
+                success, message = self.manager.apply_bucket_account_size(pro, bucket)
+                self.assertTrue(success, message)
+                info = self._info(pro)
+                self.assertEqual(info.pro_account_size, GRANTED_SIZE)
+                self.assertEqual(info.account_size, GRANTED_SIZE)
+                self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+
+    def test_start_pro_now_trades_the_size_set_at_transition(self):
         self.assertTrue(self.manager.apply_bucket_account_size(
-            self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION)[0])
+            self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION, GRANTED_SIZE)[0])
 
         success, message = self.manager.apply_bucket_account_size(
             self.standard, MinerBucket.PRO_CHALLENGE_FROM_STANDARD
@@ -232,40 +355,63 @@ class TestApplyBucketAccountSizeDefault(unittest.TestCase):
 
         self.assertTrue(success, message)
         info = self._info(self.standard)
-        self.assertEqual(info.account_size, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(info.account_size, GRANTED_SIZE)
+        self.assertEqual(self.set_size.call_args.kwargs["account_size"], GRANTED_SIZE)
+        self.assertAlmostEqual(self.manager.get_payout_scale(self.standard), STANDARD_SIZE / GRANTED_SIZE)
+
+    def test_move_within_the_track_with_no_recorded_size_is_rejected(self):
+        pro = _add_pro(self.manager)
+        self._info(pro).pro_account_size = None
+        for bucket in PRO_BUCKETS:
+            with self.subTest(bucket=bucket):
+                self._assert_rejected_unchanged(pro, bucket, None, REQUIRED)
+
+    def test_pro_funded_can_re_set_the_size_within_range(self):
+        pro = _add_pro(self.manager)
+
+        self._assert_rejected_unchanged(pro, MinerBucket.PRO_FUNDED, 1_000_001, OUT_OF_RANGE)
+        self._assert_rejected_unchanged(pro, MinerBucket.PRO_FUNDED, 199_999, OUT_OF_RANGE)
+
+        success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.PRO_FUNDED, 750_000)
+        self.assertTrue(success, message)
+        info = self._info(pro)
+        self.assertEqual(info.pro_account_size, 750_000)
+        self.assertEqual(info.account_size, 750_000)
         self.assertEqual(info.standard_account_size, STANDARD_SIZE)
-        self.assertAlmostEqual(self.manager.get_payout_scale(self.standard),
-                               STANDARD_SIZE / ValiConfig.PRO_ACCOUNT_SIZE)
 
-    def test_failed_account_resize_leaves_a_standard_account_untouched(self):
-        """A pro move whose account resize fails leaves the subaccount standard, with no pro size."""
-        self.set_size.return_value = None
+    def test_recorded_size_is_not_rechecked_against_the_range(self):
+        """A size that was valid when granted keeps working if the range later moves past it."""
+        pro = _add_pro(self.manager)
+        with patch.object(ValiConfig, "MAX_PRO_ACCOUNT_SIZE", 400_000), \
+                patch.object(ValiConfig, "MIN_PRO_ACCOUNT_SIZE", 300_000):
+            success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.PRO_FUNDED)
+        self.assertTrue(success, message)
+        self.assertEqual(self._info(pro).account_size, GRANTED_SIZE)
 
-        for size in (None, GRANTED_SIZE):
-            with self.subTest(pro_account_size=size):
-                success, message = self.manager.apply_bucket_account_size(
-                    self.standard, MinerBucket.PRO_CHALLENGE_DIRECT, size
-                )
+    def test_corrupt_recorded_size_is_rejected_and_changes_nothing(self):
+        for recorded in (float("nan"), float("inf"), 0.0, -1.0):
+            with self.subTest(recorded=recorded):
+                manager = self.manager = _bare_manager()
+                self.set_size = manager._miner_account_client.set_miner_account_size
+                pro = _add_pro(manager)
+                self._info(pro).pro_account_size = recorded
+                self._assert_rejected_unchanged(pro, MinerBucket.PRO_FUNDED, None, "Recorded pro_account_size")
 
-                self.assertFalse(success)
-                self.assertIn("Failed to set account size", message)
-                info = self._info(self.standard)
-                self.assertIsNone(info.pro_account_size)
-                self.assertIsNone(info.standard_account_size)
-                self.assertEqual(info.account_type, AccountType.STANDARD.value)
-                self.assertEqual(info.account_size, STANDARD_SIZE)
-                self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
+    def test_explicit_size_replaces_a_corrupt_recorded_one(self):
+        pro = _add_pro(self.manager)
+        self._info(pro).pro_account_size = float("nan")
 
-    def test_failed_account_resize_is_not_written_to_disk(self):
-        self.set_size.return_value = None
-        with patch.object(self.manager, "_write_entities_from_memory_to_disk") as write:
-            self.manager.apply_bucket_account_size(self.standard, MinerBucket.PRO_CHALLENGE_DIRECT)
-        write.assert_not_called()
+        success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.PRO_FUNDED, 600_000)
+
+        self.assertTrue(success, message)
+        self.assertEqual(self._info(pro).pro_account_size, 600_000)
+        self.assertEqual(self._info(pro).account_size, 600_000)
+
+    # ==================== standard buckets ====================
 
     def test_standard_buckets_never_record_a_pro_size(self):
-        for bucket in (MinerBucket.SUBACCOUNT_CHALLENGE, MinerBucket.SUBACCOUNT_FUNDED, MinerBucket.SUBACCOUNT_ALPHA):
+        for bucket in STANDARD_BUCKETS:
             with self.subTest(bucket=bucket):
-                # Even a stray explicit size is ignored for a standard bucket
                 success, message = self.manager.apply_bucket_account_size(self.standard, bucket, GRANTED_SIZE)
                 self.assertTrue(success, message)
                 info = self._info(self.standard)
@@ -276,18 +422,10 @@ class TestApplyBucketAccountSizeDefault(unittest.TestCase):
                 self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
         self.set_size.assert_not_called()
 
-    def test_standard_account_payout_scale_is_unaffected_by_the_network_size(self):
-        """Publishing a network size must not give a never-promoted account a payout scale."""
-        for size in (ValiConfig.PRO_ACCOUNT_SIZE, ValiConfig.PRO_ACCOUNT_SIZE - 1):
-            with self.subTest(PRO_ACCOUNT_SIZE=size), patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", size):
-                self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
-                self.assertEqual(self.manager.get_subaccount_dashboard(self.standard)[FIELD], size)
-                self.assertIsNone(self._info(self.standard).pro_account_size)
-
-    def test_demotion_restores_the_standard_size_and_keeps_the_granted_one(self):
+    def test_demotion_restores_the_standard_size_and_ignores_a_sent_size(self):
         pro = _add_pro(self.manager)
 
-        success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.SUBACCOUNT_FUNDED)
+        success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.SUBACCOUNT_FUNDED, 750_000)
 
         self.assertTrue(success, message)
         info = self._info(pro)
@@ -295,17 +433,78 @@ class TestApplyBucketAccountSizeDefault(unittest.TestCase):
         self.assertEqual(info.account_type, AccountType.STANDARD.value)
         self.assertEqual(info.pro_account_size, GRANTED_SIZE)
 
+    # ==================== failed resize ====================
+
+    def test_failed_account_resize_leaves_the_subaccount_untouched(self):
+        self.set_size.return_value = None
+        pro = _add_pro(self.manager)
+        for hotkey, bucket, size in (
+            (self.standard, MinerBucket.PRO_CHALLENGE_DIRECT, GRANTED_SIZE),
+            (pro, MinerBucket.PRO_FUNDED, 750_000),
+            (pro, MinerBucket.SUBACCOUNT_FUNDED, None),
+        ):
+            with self.subTest(hotkey=hotkey, bucket=bucket):
+                before = self._snapshot(hotkey)
+                with patch.object(self.manager, "_write_entities_from_memory_to_disk") as write:
+                    success, message = self.manager.apply_bucket_account_size(hotkey, bucket, size)
+                self.assertFalse(success)
+                self.assertIn("Failed to set account size", message)
+                self.assertEqual(self._snapshot(hotkey), before)
+                write.assert_not_called()
+        self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
+
+
+class TestApplyBucketAccountSizeLog(unittest.TestCase):
+    """The size-change log line says whether a pro size was explicit or recorded."""
+
+    def setUp(self):
+        self.manager = _bare_manager()
+        self.standard = _add_standard(self.manager)
+
+    def _logged(self, hotkey, bucket, pro_account_size=None):
+        with patch("entity_management.entity_manager.logger") as logger:
+            success, message = self.manager.apply_bucket_account_size(hotkey, bucket, pro_account_size)
+        self.assertTrue(success, message)
+        lines = [call.args[0] for call in logger.info.call_args_list if "[ENTITY_MANAGER]" in call.args[0]]
+        self.assertEqual(len(lines), 1, lines)
+        return lines[0]
+
+    def test_explicit_size(self):
+        line = self._logged(self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION, GRANTED_SIZE)
+        self.assertIn("pro size source: explicit", line)
+        self.assertIn(f"pro=${GRANTED_SIZE}", line)
+
+    def test_recorded_size(self):
+        pro = _add_pro(self.manager)
+        line = self._logged(pro, MinerBucket.PRO_FUNDED)
+        self.assertIn("pro size source: recorded", line)
+        self.assertIn(f"pro=${GRANTED_SIZE}", line)
+
+    def test_explicit_re_set_within_the_track(self):
+        pro = _add_pro(self.manager)
+        line = self._logged(pro, MinerBucket.PRO_FUNDED, 750_000)
+        self.assertIn("pro size source: explicit", line)
+
+    def test_standard_bucket_names_no_source(self):
+        pro = _add_pro(self.manager)
+        for hotkey, bucket, size in ((pro, MinerBucket.SUBACCOUNT_FUNDED, None),
+                                     (self.standard, MinerBucket.SUBACCOUNT_CHALLENGE, GRANTED_SIZE)):
+            with self.subTest(bucket=bucket):
+                self.assertNotIn("source", self._logged(hotkey, bucket, size))
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Dashboards: subaccount_info.default_pro_account_size
+# Dashboards: no default_pro_account_size
 # ═══════════════════════════════════════════════════════════════════════════════
 
-class TestDashboardDefaultProAccountSize(unittest.TestCase):
+class TestDashboardsCarryNoDefaultProAccountSize(unittest.TestCase):
 
     def setUp(self):
         self.manager = _bare_manager()
         self.standard = _add_standard(self.manager)
         self.pro = _add_pro(self.manager)
+        self.hl = _add_standard(self.manager, subaccount_id=2)
+        self.manager.get_subaccount_info_for_synthetic(self.hl).hl_address = "0x" + "ab" * 20
 
     def _v1_info(self, hotkey):
         return self.manager.get_subaccount_dashboard_data(hotkey)["subaccount_info"]
@@ -321,48 +520,21 @@ class TestDashboardDefaultProAccountSize(unittest.TestCase):
         )
         return dashboard["subaccount_info"]
 
-    def test_v1_publishes_the_network_size_for_standard_and_pro(self):
-        for hotkey in (self.standard, self.pro):
+    def test_v1_subaccount_info(self):
+        for hotkey in (self.standard, self.pro, self.hl):
             with self.subTest(hotkey=hotkey):
-                self.assertEqual(self._v1_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+                self.assertNotIn(REMOVED_FIELD, self._v1_info(hotkey))
 
-    def test_v2_publishes_the_network_size_for_standard_and_pro(self):
-        for hotkey in (self.standard, self.pro):
+    def test_v2_subaccount_info_keeps_the_granted_size(self):
+        for hotkey, granted in ((self.standard, None), (self.pro, GRANTED_SIZE), (self.hl, None)):
             with self.subTest(hotkey=hotkey):
-                self.assertEqual(self._v2_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
-
-    def test_v2_keeps_pro_account_size_as_the_granted_size(self):
-        standard = self._v2_info(self.standard)
-        self.assertIsNone(standard["pro_account_size"])
-        self.assertEqual(standard["account_type"], AccountType.STANDARD.value)
-
-        pro = self._v2_info(self.pro)
-        self.assertEqual(pro["pro_account_size"], GRANTED_SIZE)
-        self.assertEqual(pro["account_type"], AccountType.PRO.value)
-        self.assertNotEqual(pro["pro_account_size"], pro[FIELD])
-
-    def test_v1_and_v2_carry_the_same_value_in_the_same_place(self):
-        for hotkey in (self.standard, self.pro):
-            with self.subTest(hotkey=hotkey):
-                self.assertEqual(self._v1_info(hotkey)[FIELD], self._v2_info(hotkey)[FIELD])
-
-    def test_dashboards_follow_a_change_to_the_network_size(self):
-        changed = ValiConfig.PRO_ACCOUNT_SIZE - 1
-        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", changed):
-            self.assertEqual(self._v1_info(self.standard)[FIELD], changed)
-            self.assertEqual(self._v2_info(self.standard)[FIELD], changed)
-            # A granted size does not follow it
-            self.assertEqual(self._v2_info(self.pro)["pro_account_size"], GRANTED_SIZE)
-
-    def test_hl_subaccounts_carry_the_field_too(self):
-        hotkey = _add_standard(self.manager, subaccount_id=2)
-        self.manager.get_subaccount_info_for_synthetic(hotkey).hl_address = "0x" + "ab" * 20
-        self.assertEqual(self._v1_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(self._v2_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+                info = self._v2_info(hotkey)
+                self.assertNotIn(REMOVED_FIELD, info)
+                self.assertEqual(info["pro_account_size"], granted)
 
 
-class TestDashboardEndpointsDefaultProAccountSize(unittest.TestCase):
-    """The field on the wire, through the real validator REST handlers and websocket frame builder."""
+class TestDashboardEndpointsCarryNoDefaultProAccountSize(unittest.TestCase):
+    """On the wire, through the real validator REST handlers and websocket frame builder."""
 
     def setUp(self):
         from vanta_api.validator_rest_server import ValidatorRestServer
@@ -386,10 +558,12 @@ class TestDashboardEndpointsDefaultProAccountSize(unittest.TestCase):
         server._limit_order_client = clients["limit_order"]
         server._debt_ledger_client = clients["debt_ledger"]
         server._statistics_client = clients["statistics"]
+        self.server = server
         app = Flask(__name__)
         app.config["TESTING"] = True
         app.route("/entity/subaccount/<synthetic_hotkey>", methods=["GET"])(server.get_subaccount_dashboard)
         app.route("/v2/entity/subaccount/<synthetic_hotkey>", methods=["GET"])(server.v2_get_subaccount_dashboard)
+        app.route("/hl-traders/<hl_address>", methods=["GET"])(server.get_hl_trader)
         self.client = app.test_client()
 
     def _get(self, path):
@@ -398,22 +572,25 @@ class TestDashboardEndpointsDefaultProAccountSize(unittest.TestCase):
         return json.loads(resp.data)["dashboard"]["subaccount_info"]
 
     def test_v1_endpoint(self):
-        standard = self._get(f"/entity/subaccount/{self.standard}")
-        pro = self._get(f"/entity/subaccount/{self.pro}")
-        self.assertEqual(standard[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(pro[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+        for hotkey in (self.standard, self.pro):
+            with self.subTest(hotkey=hotkey):
+                self.assertNotIn(REMOVED_FIELD, self._get(f"/entity/subaccount/{hotkey}"))
 
     def test_v2_endpoint(self):
-        standard = self._get(f"/v2/entity/subaccount/{self.standard}")
-        pro = self._get(f"/v2/entity/subaccount/{self.pro}")
-        self.assertEqual(standard[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertIsNone(standard["pro_account_size"])
-        self.assertEqual(pro[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(pro["pro_account_size"], GRANTED_SIZE)
+        for hotkey, granted in ((self.standard, None), (self.pro, GRANTED_SIZE)):
+            with self.subTest(hotkey=hotkey):
+                info = self._get(f"/v2/entity/subaccount/{hotkey}")
+                self.assertNotIn(REMOVED_FIELD, info)
+                self.assertEqual(info["pro_account_size"], granted)
 
-    def test_websocket_frames_carry_the_field_on_every_update(self):
-        """The websocket rebuilds subaccount_info in full on each frame, including incremental ones
-        where the watermarked sections have nothing new and are left out."""
+    def test_hl_traders_endpoint(self):
+        self.server._entity_client.get_synthetic_hotkey_for_hl_address.return_value = self.standard
+        info = self._get("/hl-traders/0x" + "ab" * 20)
+        self.assertEqual(info["synthetic_hotkey"], self.standard)
+        self.assertNotIn(REMOVED_FIELD, info)
+
+    def test_websocket_frames(self):
+        """The websocket rebuilds subaccount_info in full on each frame, including incremental ones."""
         from vanta_api.websocket_server import DashboardSubscription, WebSocketServer, WebSocketServerClient
 
         server = object.__new__(WebSocketServer)
@@ -443,7 +620,7 @@ class TestDashboardEndpointsDefaultProAccountSize(unittest.TestCase):
                     server._send_dashboard_update(hotkey, ws_client, subscription)
                     _client, serialized = server._send_serialized.call_args.args
                     info = json.loads(serialized)["data"]["dashboard"]["subaccount_info"]
-                    self.assertEqual(info[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+                    self.assertNotIn(REMOVED_FIELD, info)
                     self.assertEqual(info["pro_account_size"], granted)
 
 

--- a/tests/vali_tests/test_pro_account_size.py
+++ b/tests/vali_tests/test_pro_account_size.py
@@ -1,0 +1,451 @@
+"""
+The network-owned pro account size.
+
+Covers:
+  * ValiConfig.PRO_ACCOUNT_SIZE: the size a pro promotion grants, bounded by MAX_PRO_ACCOUNT_SIZE at import.
+  * EntityManager.apply_bucket_account_size: entering the pro track with no size grants the network size,
+    an explicit size is still honoured (and capped), a recorded size is kept, a failed or rejected move
+    changes nothing, and a standard account never picks up a pro size (so payout_scale stays 1.0).
+  * subaccount_info.default_pro_account_size: present with the same name in the same place in the v1
+    (GET /entity/subaccount/<hotkey>) and v2 (GET /v2/entity/subaccount/<hotkey>, websocket) dashboards,
+    for standard and pro subaccounts, next to an untouched subaccount_info.pro_account_size.
+
+EntityManager is built with object.__new__ and only the attributes these methods touch, so no RPC servers
+are started.
+"""
+import json
+import re
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+import vali_objects.vali_config as vali_config_module
+from entity_management.entity_manager import EntityData, EntityManager, SubaccountInfo
+from entity_management.entity_utils import create_subaccount_dashboard
+from vali_objects.enums.account_type_enum import AccountType
+from vali_objects.enums.miner_bucket_enum import MinerBucket
+from vali_objects.vali_config import ValiConfig
+
+NOW_MS = 1_748_000_000_000
+ENTITY_HOTKEY = "entity_alpha"
+STANDARD_SIZE = 100_000.0
+GRANTED_SIZE = 500_000.0  # deliberately different from ValiConfig.PRO_ACCOUNT_SIZE
+FIELD = "default_pro_account_size"
+
+
+def _bare_manager():
+    """An EntityManager with in-memory entities, a mocked account client, and no disk writes."""
+    manager = object.__new__(EntityManager)
+    manager.is_backtesting = True
+    manager.running_unit_tests = True
+    manager.entities = {}
+    manager._entities_lock = threading.RLock()
+    manager._entity_locks = {}
+    manager._miner_account_client = MagicMock()
+    manager._miner_account_client.set_miner_account_size.return_value = {"account_size": "set"}
+    manager._miner_account_client.get_account.return_value = None
+    manager._challenge_period_client = MagicMock()
+    manager._challenge_period_client.has_miner.return_value = False
+    manager._challenge_period_client.get_drawdown_stats.return_value = None
+    manager._debt_ledger_client = MagicMock()
+    manager._debt_ledger_client.get_ledger.return_value = None
+    manager._position_client = MagicMock()
+    manager._position_client.get_positions_for_one_hotkey.return_value = []
+    manager._limit_order_client = MagicMock()
+    manager._limit_order_client.to_dashboard_dict.return_value = None
+    manager._statistics_client = MagicMock()
+    manager._statistics_client.get_miner_statistics_for_hotkey.return_value = None
+    manager._elimination_client = MagicMock()
+    manager._elimination_client.get_elimination.return_value = None
+    return manager
+
+
+def _add_standard(manager, subaccount_id=0, account_size=STANDARD_SIZE):
+    info = SubaccountInfo(
+        subaccount_id=subaccount_id,
+        subaccount_uuid=f"uuid-{subaccount_id}",
+        synthetic_hotkey=f"{ENTITY_HOTKEY}_{subaccount_id}",
+        created_at_ms=NOW_MS,
+        account_size=account_size,
+        asset_class="forex",
+    )
+    entity = manager.entities.setdefault(
+        ENTITY_HOTKEY, EntityData(entity_hotkey=ENTITY_HOTKEY, registered_at_ms=NOW_MS)
+    )
+    entity.subaccounts[subaccount_id] = info
+    return info.synthetic_hotkey
+
+
+def _add_pro(manager, subaccount_id=1, pro_size=GRANTED_SIZE):
+    """A subaccount already promoted onto a pro account of pro_size."""
+    hotkey = _add_standard(manager, subaccount_id)
+    info = manager.get_subaccount_info_for_synthetic(hotkey)
+    info.standard_account_size = STANDARD_SIZE
+    info.pro_account_size = pro_size
+    info.account_size = pro_size
+    info.account_type = AccountType.PRO.value
+    return hotkey
+
+
+def _no_section_clients():
+    """Dashboard section clients that have nothing to report, so only subaccount_info is built."""
+    clients = {name: MagicMock() for name in (
+        "challenge_period", "elimination", "miner_account", "position", "limit_order", "debt_ledger",
+        "statistics",
+    )}
+    clients["challenge_period"].get_dashboard.return_value = None
+    clients["challenge_period"].get_drawdown_stats.return_value = None
+    clients["challenge_period"].get_pro_stats.return_value = None
+    for name in ("elimination", "miner_account", "position", "limit_order", "debt_ledger", "statistics"):
+        clients[name].get_dashboard.return_value = None
+    return clients
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ValiConfig
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestProAccountSizeConfig(unittest.TestCase):
+
+    def test_network_grants_one_million_today(self):
+        self.assertEqual(ValiConfig.PRO_ACCOUNT_SIZE, 1_000_000)
+
+    def test_grant_is_positive_and_within_the_cap(self):
+        self.assertGreater(ValiConfig.PRO_ACCOUNT_SIZE, 0)
+        self.assertLessEqual(ValiConfig.PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE)
+
+    def test_import_fails_for_a_grant_outside_the_cap(self):
+        """Editing PRO_ACCOUNT_SIZE above MAX_PRO_ACCOUNT_SIZE (or to a non-positive value) breaks import."""
+        path = vali_config_module.__file__
+        with open(path) as f:
+            source = f.read()
+        assignment = re.compile(r"^(    PRO_ACCOUNT_SIZE = ).*$", re.M)
+        self.assertEqual(len(assignment.findall(source)), 1)
+
+        for bad in ("MAX_PRO_ACCOUNT_SIZE + 1", "0", "-1"):
+            with self.subTest(PRO_ACCOUNT_SIZE=bad):
+                tampered = assignment.sub(lambda m: m.group(1) + bad, source)
+                with self.assertRaisesRegex(ValueError, "PRO_ACCOUNT_SIZE"):
+                    exec(compile(tampered, path, "exec"), {"__name__": "vali_config_probe", "__file__": path})
+
+        # The untouched source imports cleanly, so the failures above come from the guard
+        namespace = {"__name__": "vali_config_probe", "__file__": path}
+        exec(compile(source, path, "exec"), namespace)
+        self.assertEqual(namespace["ValiConfig"].PRO_ACCOUNT_SIZE, ValiConfig.PRO_ACCOUNT_SIZE)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# EntityManager.apply_bucket_account_size
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestApplyBucketAccountSizeDefault(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = _bare_manager()
+        self.standard = _add_standard(self.manager)
+        self.set_size = self.manager._miner_account_client.set_miner_account_size
+
+    def _info(self, hotkey):
+        return self.manager.get_subaccount_info_for_synthetic(hotkey)
+
+    def test_transition_without_a_size_records_the_network_size(self):
+        success, message = self.manager.apply_bucket_account_size(
+            self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION
+        )
+
+        self.assertTrue(success, message)
+        info = self._info(self.standard)
+        self.assertEqual(info.pro_account_size, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+        self.assertEqual(info.account_type, AccountType.PRO.value)
+        # TRANSITION keeps trading the standard account
+        self.assertEqual(info.account_size, STANDARD_SIZE)
+        self.set_size.assert_not_called()
+
+    def test_direct_pro_challenge_without_a_size_trades_the_network_size(self):
+        success, message = self.manager.apply_bucket_account_size(self.standard, MinerBucket.PRO_CHALLENGE_DIRECT)
+
+        self.assertTrue(success, message)
+        info = self._info(self.standard)
+        self.assertEqual(info.pro_account_size, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(info.account_size, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.set_size.assert_called_once()
+        self.assertEqual(self.set_size.call_args.kwargs["account_size"], ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(
+            self.set_size.call_args.kwargs["collateral_balance_theta"],
+            ValiConfig.PRO_ACCOUNT_SIZE / ValiConfig.ENTITY_COST_PER_THETA,
+        )
+
+    def test_default_is_read_when_the_promotion_happens(self):
+        """The network can change the size; a promotion grants whatever it is at that moment."""
+        changed = ValiConfig.PRO_ACCOUNT_SIZE - 1
+        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", changed):
+            self.assertTrue(self.manager.apply_bucket_account_size(
+                self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION)[0])
+        self.assertEqual(self._info(self.standard).pro_account_size, changed)
+
+    def test_explicit_size_is_honoured(self):
+        success, message = self.manager.apply_bucket_account_size(
+            self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION, GRANTED_SIZE
+        )
+
+        self.assertTrue(success, message)
+        self.assertEqual(self._info(self.standard).pro_account_size, GRANTED_SIZE)
+
+    def test_explicit_size_above_the_cap_is_rejected_and_changes_nothing(self):
+        success, message = self.manager.apply_bucket_account_size(
+            self.standard, MinerBucket.PRO_CHALLENGE_DIRECT, ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1
+        )
+
+        self.assertFalse(success)
+        self.assertIn("exceeds maximum", message)
+        info = self._info(self.standard)
+        self.assertIsNone(info.pro_account_size)
+        self.assertIsNone(info.standard_account_size)
+        self.assertEqual(info.account_type, AccountType.STANDARD.value)
+        self.assertEqual(info.account_size, STANDARD_SIZE)
+        self.set_size.assert_not_called()
+
+    def test_recorded_size_is_kept_over_the_network_size(self):
+        """Once granted, a size survives later pro moves even if the network size has changed since."""
+        pro = _add_pro(self.manager)
+
+        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", GRANTED_SIZE + 1):
+            success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.PRO_FUNDED)
+
+        self.assertTrue(success, message)
+        info = self._info(pro)
+        self.assertEqual(info.pro_account_size, GRANTED_SIZE)
+        self.assertEqual(info.account_size, GRANTED_SIZE)
+        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+
+    def test_transition_then_promotion_grants_the_size_recorded_at_transition(self):
+        """The admin move records the network size; the miner's own promotion (no size) trades it."""
+        self.assertTrue(self.manager.apply_bucket_account_size(
+            self.standard, MinerBucket.PRO_CHALLENGE_TRANSITION)[0])
+
+        success, message = self.manager.apply_bucket_account_size(
+            self.standard, MinerBucket.PRO_CHALLENGE_FROM_STANDARD
+        )
+
+        self.assertTrue(success, message)
+        info = self._info(self.standard)
+        self.assertEqual(info.account_size, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+        self.assertAlmostEqual(self.manager.get_payout_scale(self.standard),
+                               STANDARD_SIZE / ValiConfig.PRO_ACCOUNT_SIZE)
+
+    def test_failed_account_resize_leaves_a_standard_account_untouched(self):
+        """A pro move whose account resize fails leaves the subaccount standard, with no pro size."""
+        self.set_size.return_value = None
+
+        for size in (None, GRANTED_SIZE):
+            with self.subTest(pro_account_size=size):
+                success, message = self.manager.apply_bucket_account_size(
+                    self.standard, MinerBucket.PRO_CHALLENGE_DIRECT, size
+                )
+
+                self.assertFalse(success)
+                self.assertIn("Failed to set account size", message)
+                info = self._info(self.standard)
+                self.assertIsNone(info.pro_account_size)
+                self.assertIsNone(info.standard_account_size)
+                self.assertEqual(info.account_type, AccountType.STANDARD.value)
+                self.assertEqual(info.account_size, STANDARD_SIZE)
+                self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
+
+    def test_failed_account_resize_is_not_written_to_disk(self):
+        self.set_size.return_value = None
+        with patch.object(self.manager, "_write_entities_from_memory_to_disk") as write:
+            self.manager.apply_bucket_account_size(self.standard, MinerBucket.PRO_CHALLENGE_DIRECT)
+        write.assert_not_called()
+
+    def test_standard_buckets_never_record_a_pro_size(self):
+        for bucket in (MinerBucket.SUBACCOUNT_CHALLENGE, MinerBucket.SUBACCOUNT_FUNDED, MinerBucket.SUBACCOUNT_ALPHA):
+            with self.subTest(bucket=bucket):
+                # Even a stray explicit size is ignored for a standard bucket
+                success, message = self.manager.apply_bucket_account_size(self.standard, bucket, GRANTED_SIZE)
+                self.assertTrue(success, message)
+                info = self._info(self.standard)
+                self.assertIsNone(info.pro_account_size)
+                self.assertIsNone(info.standard_account_size)
+                self.assertEqual(info.account_type, AccountType.STANDARD.value)
+                self.assertEqual(info.account_size, STANDARD_SIZE)
+                self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
+        self.set_size.assert_not_called()
+
+    def test_standard_account_payout_scale_is_unaffected_by_the_network_size(self):
+        """Publishing a network size must not give a never-promoted account a payout scale."""
+        for size in (ValiConfig.PRO_ACCOUNT_SIZE, ValiConfig.PRO_ACCOUNT_SIZE - 1):
+            with self.subTest(PRO_ACCOUNT_SIZE=size), patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", size):
+                self.assertEqual(self.manager.get_payout_scale(self.standard), 1.0)
+                self.assertEqual(self.manager.get_subaccount_dashboard(self.standard)[FIELD], size)
+                self.assertIsNone(self._info(self.standard).pro_account_size)
+
+    def test_demotion_restores_the_standard_size_and_keeps_the_granted_one(self):
+        pro = _add_pro(self.manager)
+
+        success, message = self.manager.apply_bucket_account_size(pro, MinerBucket.SUBACCOUNT_FUNDED)
+
+        self.assertTrue(success, message)
+        info = self._info(pro)
+        self.assertEqual(info.account_size, STANDARD_SIZE)
+        self.assertEqual(info.account_type, AccountType.STANDARD.value)
+        self.assertEqual(info.pro_account_size, GRANTED_SIZE)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dashboards: subaccount_info.default_pro_account_size
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDashboardDefaultProAccountSize(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = _bare_manager()
+        self.standard = _add_standard(self.manager)
+        self.pro = _add_pro(self.manager)
+
+    def _v1_info(self, hotkey):
+        return self.manager.get_subaccount_dashboard_data(hotkey)["subaccount_info"]
+
+    def _v2_info(self, hotkey):
+        clients = _no_section_clients()
+        dashboard = create_subaccount_dashboard(
+            hotkey,
+            self.manager.get_subaccount_dashboard(hotkey),
+            clients["challenge_period"], clients["elimination"], clients["miner_account"],
+            clients["position"], clients["limit_order"], clients["debt_ledger"], clients["statistics"],
+            0, 0, 0, 0,
+        )
+        return dashboard["subaccount_info"]
+
+    def test_v1_publishes_the_network_size_for_standard_and_pro(self):
+        for hotkey in (self.standard, self.pro):
+            with self.subTest(hotkey=hotkey):
+                self.assertEqual(self._v1_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+
+    def test_v2_publishes_the_network_size_for_standard_and_pro(self):
+        for hotkey in (self.standard, self.pro):
+            with self.subTest(hotkey=hotkey):
+                self.assertEqual(self._v2_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+
+    def test_v2_keeps_pro_account_size_as_the_granted_size(self):
+        standard = self._v2_info(self.standard)
+        self.assertIsNone(standard["pro_account_size"])
+        self.assertEqual(standard["account_type"], AccountType.STANDARD.value)
+
+        pro = self._v2_info(self.pro)
+        self.assertEqual(pro["pro_account_size"], GRANTED_SIZE)
+        self.assertEqual(pro["account_type"], AccountType.PRO.value)
+        self.assertNotEqual(pro["pro_account_size"], pro[FIELD])
+
+    def test_v1_and_v2_carry_the_same_value_in_the_same_place(self):
+        for hotkey in (self.standard, self.pro):
+            with self.subTest(hotkey=hotkey):
+                self.assertEqual(self._v1_info(hotkey)[FIELD], self._v2_info(hotkey)[FIELD])
+
+    def test_dashboards_follow_a_change_to_the_network_size(self):
+        changed = ValiConfig.PRO_ACCOUNT_SIZE - 1
+        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", changed):
+            self.assertEqual(self._v1_info(self.standard)[FIELD], changed)
+            self.assertEqual(self._v2_info(self.standard)[FIELD], changed)
+            # A granted size does not follow it
+            self.assertEqual(self._v2_info(self.pro)["pro_account_size"], GRANTED_SIZE)
+
+    def test_hl_subaccounts_carry_the_field_too(self):
+        hotkey = _add_standard(self.manager, subaccount_id=2)
+        self.manager.get_subaccount_info_for_synthetic(hotkey).hl_address = "0x" + "ab" * 20
+        self.assertEqual(self._v1_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(self._v2_info(hotkey)[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+
+
+class TestDashboardEndpointsDefaultProAccountSize(unittest.TestCase):
+    """The field on the wire, through the real validator REST handlers and websocket frame builder."""
+
+    def setUp(self):
+        from vanta_api.validator_rest_server import ValidatorRestServer
+
+        self.manager = _bare_manager()
+        self.standard = _add_standard(self.manager)
+        self.pro = _add_pro(self.manager)
+
+        server = object.__new__(ValidatorRestServer)
+        server._get_api_key_safe = MagicMock(return_value="key")
+        server.is_valid_api_key = MagicMock(return_value=True)
+        server.can_access_tier = MagicMock(return_value=True)
+        server._entity_client = MagicMock()
+        server._entity_client.get_subaccount_dashboard.side_effect = self.manager.get_subaccount_dashboard
+        server._entity_client.get_subaccount_dashboard_data.side_effect = self.manager.get_subaccount_dashboard_data
+        clients = _no_section_clients()
+        server._challenge_period_client = clients["challenge_period"]
+        server._elimination_client = clients["elimination"]
+        server._miner_account_client = clients["miner_account"]
+        server._position_client = clients["position"]
+        server._limit_order_client = clients["limit_order"]
+        server._debt_ledger_client = clients["debt_ledger"]
+        server._statistics_client = clients["statistics"]
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.route("/entity/subaccount/<synthetic_hotkey>", methods=["GET"])(server.get_subaccount_dashboard)
+        app.route("/v2/entity/subaccount/<synthetic_hotkey>", methods=["GET"])(server.v2_get_subaccount_dashboard)
+        self.client = app.test_client()
+
+    def _get(self, path):
+        resp = self.client.get(path)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        return json.loads(resp.data)["dashboard"]["subaccount_info"]
+
+    def test_v1_endpoint(self):
+        standard = self._get(f"/entity/subaccount/{self.standard}")
+        pro = self._get(f"/entity/subaccount/{self.pro}")
+        self.assertEqual(standard[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(pro[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+
+    def test_v2_endpoint(self):
+        standard = self._get(f"/v2/entity/subaccount/{self.standard}")
+        pro = self._get(f"/v2/entity/subaccount/{self.pro}")
+        self.assertEqual(standard[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertIsNone(standard["pro_account_size"])
+        self.assertEqual(pro[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(pro["pro_account_size"], GRANTED_SIZE)
+
+    def test_websocket_frames_carry_the_field_on_every_update(self):
+        """The websocket rebuilds subaccount_info in full on each frame, including incremental ones
+        where the watermarked sections have nothing new and are left out."""
+        from vanta_api.websocket_server import DashboardSubscription, WebSocketServer, WebSocketServerClient
+
+        server = object.__new__(WebSocketServer)
+        server._event_loop = MagicMock()
+        server._entity_client = MagicMock()
+        server._entity_client.get_subaccount_dashboard.side_effect = self.manager.get_subaccount_dashboard
+        clients = _no_section_clients()
+        server._challenge_period_client = clients["challenge_period"]
+        server._elimination_client = clients["elimination"]
+        server._miner_account_client = clients["miner_account"]
+        server._position_client = clients["position"]
+        server._limit_order_client = clients["limit_order"]
+        server._debt_ledger_client = clients["debt_ledger"]
+        server._statistics_client = clients["statistics"]
+        server._send_serialized = MagicMock()
+
+        for hotkey, granted in ((self.standard, None), (self.pro, GRANTED_SIZE)):
+            ws_client = WebSocketServerClient(client_id=1, websocket=MagicMock(), api_key="k", tier=200)
+            subscription = DashboardSubscription()
+            for frame in ("initial", "incremental"):
+                with self.subTest(hotkey=hotkey, frame=frame), \
+                        patch("vanta_api.websocket_server.asyncio.run_coroutine_threadsafe"):
+                    if frame == "incremental":
+                        subscription.positions_time_ms = NOW_MS
+                        subscription.checkpoints_time_ms = NOW_MS
+                    server._send_serialized.reset_mock()
+                    server._send_dashboard_update(hotkey, ws_client, subscription)
+                    _client, serialized = server._send_serialized.call_args.args
+                    info = json.loads(serialized)["data"]["dashboard"]["subaccount_info"]
+                    self.assertEqual(info[FIELD], ValiConfig.PRO_ACCOUNT_SIZE)
+                    self.assertEqual(info["pro_account_size"], granted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vali_tests/test_pro_transition_promotion.py
+++ b/tests/vali_tests/test_pro_transition_promotion.py
@@ -1,17 +1,22 @@
 """
-Unit tests for the miner-initiated promotion out of PRO_CHALLENGE_TRANSITION.
+Unit tests for the miner-initiated promotion out of PRO_CHALLENGE_TRANSITION, and for the admin endpoint
+that sets the pro account size.
+
+The admin sets the pro account size when offering the pro track; a miner never chooses one.
 
 Covers:
   * ChallengePeriodManager.promote_pro_transition: the bucket guard, the account switch that closes
-    positions / cancels limit orders / restarts the ledgers, the granted pro account size sent with
-    the request, the fallback to the size recorded when the subaccount entered the transition, and the
-    network's ValiConfig.PRO_ACCOUNT_SIZE when no size is sent or recorded (through a real EntityManager).
-  * The admin endpoint POST /admin/miner-bucket/<hotkey>: entering the pro track without a size grants
-    the network size; an explicit size is still honoured and capped.
-  * The validator HTTP endpoint: coldkey signature bound to the target subaccount and the requested
-    size, nonce + timestamp replay protection, field validation, and subaccount ownership.
-  * The gateway HTTP endpoint: the signed payload forwarded to the validator, with and without a
-    pro_account_size, and validator errors passed through.
+    positions / cancels limit orders / restarts the ledgers, and the size recorded when the admin offered
+    the transition (through a real EntityManager), including the organic promotions and a re-offer after a
+    demotion.
+  * The admin endpoint POST /admin/miner-bucket/<hotkey>: a size is required to enter the pro track and must
+    be a finite number within [$200,000, $1,000,000]; PRO_FUNDED may re-set it; a bad size is refused before
+    anything moves (the literals NaN and Infinity, which Flask's JSON parser accepts, included).
+  * The validator HTTP endpoint: any request carrying pro_account_size is a 400 that never reaches the
+    challenge period client and never consumes its nonce; coldkey signature bound to every remaining field,
+    nonce + timestamp replay protection, field validation, and subaccount ownership.
+  * The gateway HTTP endpoint: the payload it signs and forwards never carries a size, a request with one is
+    refused before signing, and validator errors are passed through.
 """
 import contextlib
 import json
@@ -29,7 +34,10 @@ from vali_objects.enums.miner_bucket_enum import MinerBucket
 from vali_objects.enums.order_source_enum import OrderSource
 from vali_objects.vali_config import ValiConfig
 from tests.vali_tests.test_pro_account_size import (
+    GRANTED_SIZE,
+    REQUIRED,
     STANDARD_SIZE,
+    _add_demoted,
     _add_pro,
     _add_standard as _add_standard_subaccount,
     _bare_manager as _bare_entity_manager,
@@ -72,22 +80,23 @@ def _in_transition(manager, bucket=MinerBucket.PRO_CHALLENGE_TRANSITION):
     return manager
 
 
-def test_promotion_moves_the_bucket_and_records_the_size(manager):
+def test_promotion_moves_the_bucket_and_sends_no_size(manager):
+    """The miner does not choose a size: the entity manager keeps the one recorded at the transition."""
     _in_transition(manager)
 
-    success, message = manager.promote_pro_transition(HOTKEY, NOW_MS, 500_000)
+    success, message = manager.promote_pro_transition(HOTKEY, NOW_MS)
 
     assert success, message
     assert manager.miner_states[HOTKEY].current_bucket == MinerBucket.PRO_CHALLENGE_FROM_STANDARD
     manager._entity_client.apply_bucket_account_size.assert_any_call(
-        HOTKEY, MinerBucket.PRO_CHALLENGE_FROM_STANDARD, 500_000
+        HOTKEY, MinerBucket.PRO_CHALLENGE_FROM_STANDARD, None
     )
 
 
 def test_promotion_winds_down_the_standard_account(manager):
     _in_transition(manager)
 
-    assert manager.promote_pro_transition(HOTKEY, NOW_MS, 500_000)[0]
+    assert manager.promote_pro_transition(HOTKEY, NOW_MS)[0]
 
     manager._position_client.close_all_positions.assert_called_once_with(
         hotkey=HOTKEY, close_time_ms=NOW_MS, order_source=OrderSource.SUBACCOUNT_PROMOTION
@@ -98,18 +107,6 @@ def test_promotion_winds_down_the_standard_account(manager):
     manager._debt_ledger_client.delete_debt_ledger.assert_called_once_with(HOTKEY)
     manager._miner_account_client.reset_account.assert_called_once_with(
         HOTKEY, MinerBucket.PRO_CHALLENGE_FROM_STANDARD
-    )
-
-
-def test_no_size_sent_keeps_the_recorded_one(manager):
-    """A request without a size passes None down, so the entity manager uses the size recorded when the
-    miner entered the transition (or the network size when none is recorded)."""
-    _in_transition(manager)
-
-    assert manager.promote_pro_transition(HOTKEY, NOW_MS)[0]
-
-    manager._entity_client.apply_bucket_account_size.assert_any_call(
-        HOTKEY, MinerBucket.PRO_CHALLENGE_FROM_STANDARD, None
     )
 
 
@@ -136,80 +133,119 @@ def test_pro_funded_always_starts_fresh(manager, challenge_bucket):
 def test_entity_rejection_blocks_the_promotion(manager):
     """When the entity manager cannot size the pro account, nothing is wound down."""
     _in_transition(manager)
-    manager._entity_client.apply_bucket_account_size.return_value = (
-        False, f"Failed to set account size for {HOTKEY}"
-    )
+    manager._entity_client.apply_bucket_account_size.return_value = (False, REQUIRED)
 
     success, message = manager.promote_pro_transition(HOTKEY, NOW_MS)
 
     assert not success
-    assert "Failed to set account size" in message
+    assert REQUIRED in message
     assert manager.miner_states[HOTKEY].current_bucket == MinerBucket.PRO_CHALLENGE_TRANSITION
     manager._position_client.close_all_positions.assert_not_called()
 
 
-def _with_real_entity_manager(manager):
+def _with_real_entity_manager(manager, hotkey_factory=_add_standard_subaccount):
     """Swap the mocked entity client for a real in-memory EntityManager holding one standard
     SUBACCOUNT_FUNDED subaccount. Returns (entity_manager, synthetic_hotkey)."""
     entity_manager = _bare_entity_manager()
-    hotkey = _add_standard_subaccount(entity_manager)
+    hotkey = hotkey_factory(entity_manager)
     manager._entity_client = entity_manager
     manager.set_miner_bucket(hotkey, MinerBucket.SUBACCOUNT_FUNDED, NOW_MS)
     return entity_manager, hotkey
 
 
-def _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=None):
+def _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=GRANTED_SIZE):
     """What POST /admin/miner-bucket does: size the subaccount, then move the bucket."""
     assert entity_manager.apply_bucket_account_size(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, pro_account_size)[0]
     assert manager.admin_set_bucket(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, NOW_MS)[0]
 
 
-def test_promotion_with_no_size_anywhere_grants_the_network_size(manager):
+def test_promotion_trades_the_size_the_admin_set(manager):
     entity_manager, hotkey = _with_real_entity_manager(manager)
-    _admin_move_to_transition(manager, entity_manager, hotkey)
+    _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=250_000)
 
     success, message = manager.promote_pro_transition(hotkey, NOW_MS)
 
     assert success, message
     assert manager.miner_states[hotkey].current_bucket == MinerBucket.PRO_CHALLENGE_FROM_STANDARD
     info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
-    assert info.pro_account_size == ValiConfig.PRO_ACCOUNT_SIZE
-    assert info.account_size == ValiConfig.PRO_ACCOUNT_SIZE
+    assert info.pro_account_size == 250_000
+    assert info.account_size == 250_000
     assert info.standard_account_size == STANDARD_SIZE
-    assert entity_manager.get_payout_scale(hotkey) == pytest.approx(STANDARD_SIZE / ValiConfig.PRO_ACCOUNT_SIZE)
+    assert entity_manager.get_payout_scale(hotkey) == pytest.approx(STANDARD_SIZE / 250_000)
 
 
-def test_promotion_keeps_the_size_recorded_at_transition_after_the_network_size_changes(manager):
+def test_promotion_without_a_recorded_size_is_rejected(manager):
+    """A subaccount that never had a size set (nothing to fall back on) is not promoted onto a pro
+    account of unknown size."""
     entity_manager, hotkey = _with_real_entity_manager(manager)
-    granted = ValiConfig.PRO_ACCOUNT_SIZE
+    manager.set_miner_bucket(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, NOW_MS)
+
+    success, message = manager.promote_pro_transition(hotkey, NOW_MS)
+
+    assert not success
+    assert REQUIRED in message
+    assert manager.miner_states[hotkey].current_bucket == MinerBucket.PRO_CHALLENGE_TRANSITION
+    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
+    assert info.pro_account_size is None
+    assert info.account_size == STANDARD_SIZE
+    manager._position_client.close_all_positions.assert_not_called()
+
+
+def test_organic_promotion_keeps_the_recorded_size(manager):
+    """The end-of-week auto promotion and the pro funded promotion send no size either."""
+    entity_manager, hotkey = _with_real_entity_manager(manager)
     _admin_move_to_transition(manager, entity_manager, hotkey)
 
-    with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", granted / 2):
-        assert manager.promote_pro_transition(hotkey, NOW_MS)[0]
+    assert manager.promote_hotkeys([hotkey], NOW_MS)
+    assert manager.miner_states[hotkey].current_bucket == MinerBucket.PRO_CHALLENGE_FROM_STANDARD
+    assert entity_manager.get_subaccount_info_for_synthetic(hotkey).account_size == GRANTED_SIZE
 
+    assert manager.promote_hotkeys([hotkey], NOW_MS + 1000)
+    assert manager.miner_states[hotkey].current_bucket == MinerBucket.PRO_FUNDED
     info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
-    assert info.pro_account_size == granted
-    assert info.account_size == granted
+    assert info.pro_account_size == GRANTED_SIZE
+    assert info.account_size == GRANTED_SIZE
 
 
-def test_promotion_honours_an_explicit_size(manager):
-    entity_manager, hotkey = _with_real_entity_manager(manager)
-    _admin_move_to_transition(manager, entity_manager, hotkey)
+def test_reoffer_after_a_demotion_needs_a_new_size(manager):
+    """A demoted subaccount keeps its old pro size on record, but re-entering the track needs a size."""
+    entity_manager, hotkey = _with_real_entity_manager(manager, hotkey_factory=_add_demoted)
+    assert entity_manager.get_subaccount_info_for_synthetic(hotkey).pro_account_size == GRANTED_SIZE
 
-    assert manager.promote_pro_transition(hotkey, NOW_MS, 500_000)[0]
+    success, message = entity_manager.apply_bucket_account_size(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION)
+    assert not success
+    assert REQUIRED in message
 
-    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
-    assert info.pro_account_size == 500_000
-    assert info.account_size == 500_000
-
-
-def test_promotion_keeps_an_admin_granted_size(manager):
-    entity_manager, hotkey = _with_real_entity_manager(manager)
-    _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=500_000)
-
+    _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=200_000)
     assert manager.promote_pro_transition(hotkey, NOW_MS)[0]
+    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
+    assert info.pro_account_size == 200_000
+    assert info.account_size == 200_000
 
-    assert entity_manager.get_subaccount_info_for_synthetic(hotkey).account_size == 500_000
+
+def test_a_failed_promotion_rolls_back_the_pro_sizing(manager):
+    """The pro account is sized before the bucket moves, so a failed move must put the sizing back:
+    PRO_CHALLENGE_FROM_STANDARD trades the pro size, and a subaccount left holding it while still in
+    PRO_CHALLENGE_TRANSITION is supposed to be trading the standard account."""
+    entity_manager, hotkey = _with_real_entity_manager(manager)
+    _admin_move_to_transition(manager, entity_manager, hotkey)
+    before = entity_manager.get_subaccount_info_for_synthetic(hotkey).model_copy()
+    assert before.account_size == STANDARD_SIZE
+
+    with patch.object(manager, "admin_set_bucket", return_value=(False, "bucket move failed")):
+        success, message = manager.promote_pro_transition(hotkey, NOW_MS)
+
+    assert not success
+    assert "bucket move failed" in message
+    assert manager.miner_states[hotkey].current_bucket == MinerBucket.PRO_CHALLENGE_TRANSITION
+    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
+    assert info.account_size == STANDARD_SIZE
+    assert info.standard_account_size == before.standard_account_size
+    assert info.pro_account_size == GRANTED_SIZE
+    assert info.account_type == before.account_type
+    resized_to = [c.kwargs['account_size']
+                  for c in entity_manager._miner_account_client.set_miner_account_size.call_args_list]
+    assert resized_to[-1] == STANDARD_SIZE
 
 
 @pytest.mark.parametrize("bucket", [
@@ -222,7 +258,7 @@ def test_promotion_keeps_an_admin_granted_size(manager):
 def test_only_transition_subaccounts_can_promote(manager, bucket):
     _in_transition(manager, bucket)
 
-    success, message = manager.promote_pro_transition(HOTKEY, NOW_MS, 500_000)
+    success, message = manager.promote_pro_transition(HOTKEY, NOW_MS)
 
     assert not success
     assert bucket.value in message
@@ -232,7 +268,7 @@ def test_only_transition_subaccounts_can_promote(manager, bucket):
 
 
 def test_unknown_hotkey_is_rejected(manager):
-    success, message = manager.promote_pro_transition("not_a_miner_0", NOW_MS, 500_000)
+    success, message = manager.promote_pro_transition("not_a_miner_0", NOW_MS)
 
     assert not success
     assert "not found" in message
@@ -241,19 +277,27 @@ def test_unknown_hotkey_is_rejected(manager):
 
 def test_promotion_is_not_repeatable(manager):
     _in_transition(manager)
-    assert manager.promote_pro_transition(HOTKEY, NOW_MS, 500_000)[0]
+    assert manager.promote_pro_transition(HOTKEY, NOW_MS)[0]
 
-    success, message = manager.promote_pro_transition(HOTKEY, NOW_MS + 1000, 500_000)
+    success, message = manager.promote_pro_transition(HOTKEY, NOW_MS + 1000)
 
     assert not success
     assert MinerBucket.PRO_CHALLENGE_FROM_STANDARD.value in message
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Section 2 — Validator endpoint
+# Section 2 — Validator endpoints
 # ═══════════════════════════════════════════════════════════════════════════════
 
 PRO_TRANSITION_SIGNED_FIELDS = ("entity_coldkey", "entity_hotkey", "synthetic_hotkey", "nonce", "timestamp")
+SIZE_REFUSED = "pro_account_size is not accepted"
+# Every kind of size a miner might send: in range, the bounds, out of range, wrong type, null, and the
+# non-finite floats json.dumps writes as the literals NaN / Infinity / -Infinity.
+EXPLICIT_SIZES = (
+    GRANTED_SIZE, ValiConfig.MIN_PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE,
+    ValiConfig.MIN_PRO_ACCOUNT_SIZE - 1, ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1, 1, 0, -1,
+    "500000", True, None, float("nan"), float("inf"), float("-inf"),
+)
 
 
 def _validator_pro_transition_client():
@@ -264,7 +308,7 @@ def _validator_pro_transition_client():
     server = object.__new__(ValidatorRestServer)
     server._entity_client = MagicMock()
     server._entity_client.get_subaccount_info_for_synthetic.return_value = {
-        "pro_account_size": 500_000, "account_size": 500_000,
+        "pro_account_size": GRANTED_SIZE, "account_size": GRANTED_SIZE,
     }
     server._challenge_period_client = MagicMock()
     server._challenge_period_client.promote_pro_transition.return_value = (True, "promoted")
@@ -286,13 +330,12 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
         self.server, self.client = _validator_pro_transition_client()
 
     def _body(self, signed=None, drop=(), **tampered):
-        """A correctly signed request. `signed` overrides fields before signing (what a gateway would
-        have sent), `drop` removes them before signing, `tampered` overrides after signing."""
+        """A correctly signed request. `signed` overrides or adds fields before signing (what a gateway
+        would have sent), `drop` removes them before signing, `tampered` overrides after signing."""
         fields = {
             "entity_coldkey": self.coldkey.ss58_address,
             "entity_hotkey": self.hotkey.ss58_address,
             "synthetic_hotkey": self.synthetic,
-            "pro_account_size": 500_000,
             "nonce": uuid.uuid4().hex,
             "timestamp": TimeUtil.now_in_millis(),
         }
@@ -305,29 +348,68 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
         return body
 
     def _post(self, body):
-        resp = self.client.post("/entity/subaccount/pro-transition", json=body)
+        # json.dumps writes NaN / Infinity as bare literals, exactly what request.get_json() parses back
+        resp = self.client.post("/entity/subaccount/pro-transition", data=json.dumps(body),
+                                content_type="application/json")
         return resp.status_code, json.loads(resp.data)
 
-    def _promote_call(self):
-        return self.server._challenge_period_client.promote_pro_transition.call_args.args
+    def _promote(self):
+        return self.server._challenge_period_client.promote_pro_transition
 
-    def test_valid_request_reaches_the_challenge_period_client(self):
+    def test_valid_request_reaches_the_challenge_period_client_without_a_size(self):
+        """The promotion keeps the size the admin recorded: the endpoint never passes one."""
         status, data = self._post(self._body())
         self.assertEqual(status, 200)
         self.assertEqual(data['bucket'], MinerBucket.PRO_CHALLENGE_FROM_STANDARD.value)
-        self.assertEqual(data['pro_account_size'], 500_000)
-        hotkey, _timestamp, size = self._promote_call()
+        self.assertEqual(data['pro_account_size'], GRANTED_SIZE)
+        self._promote().assert_called_once()
+        self.assertEqual(len(self._promote().call_args.args), 2)
+        hotkey, timestamp = self._promote().call_args.args
+        self.assertEqual(self._promote().call_args.kwargs, {})
         self.assertEqual(hotkey, self.synthetic)
-        self.assertEqual(size, 500_000)
+        self.assertLess(abs(timestamp - TimeUtil.now_in_millis()), 60_000)
 
-    def test_size_is_optional(self):
-        """No size in the payload promotes on the size already recorded for the subaccount."""
-        status, _ = self._post(self._body(drop=("pro_account_size",)))
-        self.assertEqual(status, 200)
-        self.assertIsNone(self._promote_call()[2])
+    def _assert_size_refused_without_consuming_the_nonce(self, body):
+        """`body` carries a pro_account_size: it is a 400, and its nonce still works without the size."""
+        self._promote().reset_mock()
+        status, data = self._post(body)
+        self.assertEqual(status, 400, data)
+        self.assertIn(SIZE_REFUSED, data['error'])
+        self.assertIn("/admin/miner-bucket", data['error'])
+        self._promote().assert_not_called()
+
+        retry = self._body(signed={"nonce": body["nonce"], "timestamp": body["timestamp"]})
+        self.assertNotIn("pro_account_size", retry)
+        status, data = self._post(retry)
+        self.assertEqual(status, 200, data)
+        self._promote().assert_called_once()
+
+    def test_any_signed_size_is_400(self):
+        """A correctly signed size is refused whatever its value: a miner never chooses its pro size."""
+        for size in EXPLICIT_SIZES:
+            with self.subTest(pro_account_size=size):
+                self._assert_size_refused_without_consuming_the_nonce(
+                    self._body(signed={"pro_account_size": size})
+                )
+
+    def test_a_size_added_to_a_signed_request_is_400(self):
+        """A size bolted onto a request signed without one is refused on the size, not the signature."""
+        for size in (ValiConfig.MAX_PRO_ACCOUNT_SIZE, 1, float("nan")):
+            with self.subTest(pro_account_size=size):
+                self._assert_size_refused_without_consuming_the_nonce(self._body(pro_account_size=size))
+
+    def test_size_is_refused_before_the_signature_and_ownership_checks(self):
+        other = Keypair.create_from_uri("//Charlie")
+        self.server._verify_coldkey_owns_hotkey.return_value = False
+        status, data = self._post(self._body(signed={"pro_account_size": GRANTED_SIZE},
+                                             signature=other.sign(b"anything").hex()))
+        self.assertEqual(status, 400)
+        self.assertIn(SIZE_REFUSED, data['error'])
+        self.server._verify_coldkey_owns_hotkey.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_manager_rejection_is_a_400(self):
-        self.server._challenge_period_client.promote_pro_transition.return_value = (
+        self._promote().return_value = (
             False, "entity_0 is in SUBACCOUNT_FUNDED, not PRO_CHALLENGE_TRANSITION"
         )
         status, data = self._post(self._body())
@@ -338,26 +420,26 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
         other = Keypair.create_from_uri("//Charlie")
         status, _ = self._post(self._body(signature=other.sign(b"anything").hex()))
         self.assertEqual(status, 401)
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_coldkey_not_owning_hotkey_is_403(self):
         self.server._verify_coldkey_owns_hotkey.return_value = False
         status, _ = self._post(self._body())
         self.assertEqual(status, 403)
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_subaccount_of_another_entity_is_403(self):
         other = Keypair.create_from_uri("//Charlie")
         status, data = self._post(self._body(signed={"synthetic_hotkey": f"{other.ss58_address}_0"}))
         self.assertEqual(status, 403)
         self.assertIn("does not belong to entity", data['error'])
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_non_subaccount_hotkey_is_400(self):
         status, data = self._post(self._body(signed={"synthetic_hotkey": self.hotkey.ss58_address}))
         self.assertEqual(status, 400)
         self.assertIn("not a subaccount", data['error'])
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_missing_and_malformed_fields_are_400(self):
         for field in ("synthetic_hotkey", "nonce", "timestamp", "signature"):
@@ -372,20 +454,7 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
             with self.subTest(signed=bad):
                 status, _ = self._post(self._body(signed=bad))
                 self.assertEqual(status, 400)
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
-
-    def test_invalid_sizes_are_400(self):
-        for bad in (0, -1, "500000", True, ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1):
-            with self.subTest(pro_account_size=bad):
-                status, data = self._post(self._body(signed={"pro_account_size": bad}))
-                self.assertEqual(status, 400)
-                self.assertIn("pro_account_size", data['error'])
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
-
-    def test_max_size_is_allowed(self):
-        status, _ = self._post(self._body(signed={"pro_account_size": ValiConfig.MAX_PRO_ACCOUNT_SIZE}))
-        self.assertEqual(status, 200)
-        self.assertEqual(self._promote_call()[2], ValiConfig.MAX_PRO_ACCOUNT_SIZE)
+        self._promote().assert_not_called()
 
     # ==================== replay protection ====================
 
@@ -395,11 +464,11 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
         status, data = self._post(body)
         self.assertEqual(status, 401)
         self.assertIn("Nonce already used", data['error'])
-        self.server._challenge_period_client.promote_pro_transition.assert_called_once()
+        self._promote().assert_called_once()
 
     def test_signature_is_bound_to_every_signed_field(self):
         for field, value in (
-            ("pro_account_size", 750_000),
+            ("entity_coldkey", Keypair.create_from_uri("//Charlie").ss58_address),
             ("synthetic_hotkey", f"{self.hotkey.ss58_address}_1"),
             ("nonce", uuid.uuid4().hex),
             ("timestamp", TimeUtil.now_in_millis() + 30_000),
@@ -410,15 +479,15 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
                 body[field] = value
                 status, _ = self._post(body)
                 self.assertEqual(status, 401)
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
-    def test_a_size_cannot_be_added_to_a_signed_request(self):
-        """A signature made without a size does not cover one bolted on in transit."""
-        body = self._body(drop=("pro_account_size",))
-        body["pro_account_size"] = ValiConfig.MAX_PRO_ACCOUNT_SIZE
+    def test_signature_covers_exactly_the_signed_fields(self):
+        """The validator rebuilds only PRO_TRANSITION_SIGNED_FIELDS: a signature over anything more fails."""
+        body = self._body(signed={"extra": "field"})
+        del body["extra"]
         status, _ = self._post(body)
         self.assertEqual(status, 401)
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_expired_or_future_timestamp_is_rejected(self):
         now = TimeUtil.now_in_millis()
@@ -426,7 +495,7 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
             with self.subTest(timestamp=timestamp):
                 status, _ = self._post(self._body(signed={"timestamp": timestamp}))
                 self.assertEqual(status, 401)
-        self.server._challenge_period_client.promote_pro_transition.assert_not_called()
+        self._promote().assert_not_called()
 
     def test_nonce_is_consumed_only_after_signature_and_ownership_pass(self):
         body = self._body()
@@ -460,52 +529,199 @@ class TestAdminMinerBucketProSize(unittest.TestCase):
         app.route("/admin/miner-bucket/<hotkey>", methods=["POST"])(self.server.set_miner_bucket_admin)
         self.client = app.test_client()
 
-    def _post(self, body):
-        resp = self.client.post(f"/admin/miner-bucket/{self.hotkey}", json=body)
+    def _post(self, body, hotkey=None):
+        resp = self.client.post(f"/admin/miner-bucket/{hotkey or self.hotkey}", json=body)
         return resp.status_code, json.loads(resp.data)
 
-    def _info(self):
-        return self.entity_manager.get_subaccount_info_for_synthetic(self.hotkey)
+    def _post_raw(self, raw_json, hotkey=None):
+        resp = self.client.post(f"/admin/miner-bucket/{hotkey or self.hotkey}", data=raw_json,
+                                content_type="application/json")
+        return resp.status_code, json.loads(resp.data)
 
-    def _assert_network_size_granted(self, bucket, account_size):
-        status, data = self._post({"bucket": bucket.value})
+    def _info(self, hotkey=None):
+        return self.entity_manager.get_subaccount_info_for_synthetic(hotkey or self.hotkey)
+
+    def _assert_nothing_moved(self, hotkey=None):
+        info = self._info(hotkey)
+        self.assertIsNone(info.pro_account_size)
+        self.assertIsNone(info.standard_account_size)
+        self.assertEqual(info.account_size, STANDARD_SIZE)
+        self.assertEqual(info.account_type, "standard")
+        self.entity_manager._miner_account_client.set_miner_account_size.assert_not_called()
+        self.server._challenge_period_client.admin_set_bucket.assert_not_called()
+        self.server._miner_account_client.set_miner_bucket.assert_not_called()
+
+    def test_entering_the_track_without_a_size_is_400(self):
+        for bucket in (MinerBucket.PRO_CHALLENGE_TRANSITION, MinerBucket.PRO_CHALLENGE_DIRECT):
+            with self.subTest(bucket=bucket):
+                status, data = self._post({"bucket": bucket.value})
+                self.assertEqual(status, 400)
+                self.assertEqual(data['error'], REQUIRED)
+                self._assert_nothing_moved()
+
+    def test_entering_the_track_with_a_size_records_it(self):
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value,
+                                   "pro_account_size": 450_000})
         self.assertEqual(status, 200, data)
         info = self._info()
-        self.assertEqual(info.pro_account_size, ValiConfig.PRO_ACCOUNT_SIZE)
-        self.assertEqual(info.account_size, account_size)
+        self.assertEqual(info.pro_account_size, 450_000)
+        self.assertEqual(info.standard_account_size, STANDARD_SIZE)
+        self.assertEqual(info.account_size, STANDARD_SIZE)  # TRANSITION keeps the standard account
         self.server._challenge_period_client.admin_set_bucket.assert_called_once()
 
-    def test_transition_without_a_size_grants_the_network_size(self):
-        self._assert_network_size_granted(MinerBucket.PRO_CHALLENGE_TRANSITION, STANDARD_SIZE)
-
-    def test_direct_pro_challenge_without_a_size_grants_the_network_size(self):
-        self._assert_network_size_granted(MinerBucket.PRO_CHALLENGE_DIRECT, ValiConfig.PRO_ACCOUNT_SIZE)
-
-    def test_explicit_size_is_honoured(self):
-        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value, "pro_account_size": 500_000})
+    def test_direct_pro_challenge_trades_the_size(self):
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_DIRECT.value,
+                                   "pro_account_size": 450_000})
         self.assertEqual(status, 200, data)
-        self.assertEqual(self._info().pro_account_size, 500_000)
+        self.assertEqual(self._info().account_size, 450_000)
 
-    def test_explicit_size_above_the_cap_is_rejected_before_the_bucket_moves(self):
-        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value,
-                                   "pro_account_size": ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1})
-        self.assertEqual(status, 400)
-        self.assertIn("exceeds maximum", data['error'])
-        self.assertIsNone(self._info().pro_account_size)
+    def test_range_bounds_are_inclusive(self):
+        for i, (size, accepted) in enumerate(((199_999, False), (200_000, True),
+                                              (1_000_000, True), (1_000_001, False)), start=10):
+            hotkey = _add_standard_subaccount(self.entity_manager, subaccount_id=i)
+            self.entity_manager._miner_account_client.reset_mock()
+            self.server._challenge_period_client.reset_mock()
+            self.server._challenge_period_client.can_admin_set_bucket.return_value = (True, "")
+            self.server._challenge_period_client.admin_set_bucket.return_value = (True, "moved")
+            self.server._miner_account_client.reset_mock()
+            with self.subTest(pro_account_size=size):
+                status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_DIRECT.value,
+                                           "pro_account_size": size}, hotkey=hotkey)
+                if accepted:
+                    self.assertEqual(status, 200, data)
+                    self.assertEqual(self._info(hotkey).pro_account_size, size)
+                else:
+                    self.assertEqual(status, 400, data)
+                    self.assertIn("outside the allowed range", data['error'])
+                    self._assert_nothing_moved(hotkey)
+
+    def test_non_finite_sizes_are_rejected_before_anything_moves(self):
+        """Flask's request.get_json() parses these literals, and NaN passes a plain range check."""
+        for bucket in (MinerBucket.PRO_CHALLENGE_TRANSITION, MinerBucket.PRO_CHALLENGE_DIRECT,
+                       MinerBucket.SUBACCOUNT_CHALLENGE):
+            for literal in ("NaN", "Infinity", "-Infinity", "1e999"):
+                with self.subTest(bucket=bucket, pro_account_size=literal):
+                    status, data = self._post_raw(
+                        f'{{"bucket": "{bucket.value}", "pro_account_size": {literal}}}'
+                    )
+                    self.assertEqual(status, 400, data)
+                    self.assertIn("must be a finite number", data['error'])
+                    self._assert_nothing_moved()
+                    self.server._challenge_period_client.can_admin_set_bucket.assert_not_called()
+
+    def test_non_numeric_sizes_are_rejected_before_anything_moves(self):
+        for size in ("500000", True, False, [500_000]):
+            with self.subTest(pro_account_size=size):
+                status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_DIRECT.value,
+                                           "pro_account_size": size})
+                self.assertEqual(status, 400, data)
+                self.assertIn("must be a number", data['error'])
+                self._assert_nothing_moved()
+                self.server._challenge_period_client.can_admin_set_bucket.assert_not_called()
+
+    def test_pro_funded_may_re_set_the_size(self):
+        pro = _add_pro(self.entity_manager, pro_size=GRANTED_SIZE)
+
+        status, data = self._post({"bucket": MinerBucket.PRO_FUNDED.value,
+                                   "pro_account_size": 1_000_001}, hotkey=pro)
+        self.assertEqual(status, 400, data)
+        self.assertEqual(self._info(pro).pro_account_size, GRANTED_SIZE)
+
+        status, data = self._post({"bucket": MinerBucket.PRO_FUNDED.value,
+                                   "pro_account_size": 900_000}, hotkey=pro)
+        self.assertEqual(status, 200, data)
+        info = self._info(pro)
+        self.assertEqual(info.pro_account_size, 900_000)
+        self.assertEqual(info.account_size, 900_000)
+
+    def test_pro_funded_without_a_size_keeps_the_recorded_one(self):
+        pro = _add_pro(self.entity_manager, pro_size=GRANTED_SIZE)
+        status, data = self._post({"bucket": MinerBucket.PRO_FUNDED.value}, hotkey=pro)
+        self.assertEqual(status, 200, data)
+        info = self._info(pro)
+        self.assertEqual(info.pro_account_size, GRANTED_SIZE)
+        self.assertEqual(info.account_size, GRANTED_SIZE)
+
+    def test_reoffer_after_a_demotion_requires_a_size(self):
+        demoted = _add_demoted(self.entity_manager)
+
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value}, hotkey=demoted)
+        self.assertEqual(status, 400, data)
+        self.assertEqual(data['error'], REQUIRED)
+        self.assertEqual(self._info(demoted).account_type, "standard")
         self.server._challenge_period_client.admin_set_bucket.assert_not_called()
 
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value,
+                                   "pro_account_size": 350_000}, hotkey=demoted)
+        self.assertEqual(status, 200, data)
+        self.assertEqual(self._info(demoted).pro_account_size, 350_000)
+
     def test_standard_bucket_never_records_a_pro_size(self):
-        status, data = self._post({"bucket": MinerBucket.SUBACCOUNT_CHALLENGE.value})
+        status, data = self._post({"bucket": MinerBucket.SUBACCOUNT_CHALLENGE.value,
+                                   "pro_account_size": 450_000})
         self.assertEqual(status, 200, data)
         self.assertIsNone(self._info().pro_account_size)
         self.assertEqual(self.entity_manager.get_payout_scale(self.hotkey), 1.0)
 
-    def test_recorded_size_is_kept_on_a_later_pro_move(self):
-        pro = _add_pro(self.entity_manager, pro_size=500_000)
-        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", 750_000):
-            resp = self.client.post(f"/admin/miner-bucket/{pro}", json={"bucket": MinerBucket.PRO_FUNDED.value})
-        self.assertEqual(resp.status_code, 200, resp.data)
-        info = self.entity_manager.get_subaccount_info_for_synthetic(pro)
+    def test_a_failed_bucket_move_leaves_no_pro_marking(self):
+        """The sizing is committed before the bucket moves, so a failed move must roll it back: a
+        subaccount left marked pro would trade the pro size in a standard bucket, and the next
+        size-less re-offer would take the "recorded" branch instead of demanding a size."""
+        for i, bucket in enumerate((MinerBucket.PRO_CHALLENGE_TRANSITION, MinerBucket.PRO_CHALLENGE_DIRECT),
+                                   start=20):
+            with self.subTest(bucket=bucket):
+                hotkey = _add_standard_subaccount(self.entity_manager, subaccount_id=i)
+                self.entity_manager._miner_account_client.reset_mock()
+                self.server._challenge_period_client.admin_set_bucket.return_value = (
+                    False, f"{hotkey} account size update failed, bucket unchanged")
+
+                status, data = self._post({"bucket": bucket.value, "pro_account_size": 500_000}, hotkey=hotkey)
+                self.assertEqual(status, 400, data)
+
+                info = self._info(hotkey)
+                self.assertEqual(info.account_type, "standard")
+                self.assertIsNone(info.pro_account_size)
+                self.assertIsNone(info.standard_account_size)
+                self.assertEqual(info.account_size, STANDARD_SIZE)
+                self.server._miner_account_client.set_miner_bucket.assert_not_called()
+                # PRO_CHALLENGE_DIRECT trades the pro size, so its resize was committed too and the
+                # live account must be put back; TRANSITION keeps the standard account and never moved it
+                sizes = [call.kwargs['account_size']
+                         for call in self.entity_manager._miner_account_client.set_miner_account_size.call_args_list]
+                self.assertEqual(sizes[-1] if sizes else STANDARD_SIZE, STANDARD_SIZE)
+
+                # behavioural backstop: the offer did not happen, so a size is still required
+                self.server._challenge_period_client.admin_set_bucket.return_value = (True, "moved")
+                status, data = self._post({"bucket": bucket.value}, hotkey=hotkey)
+                self.assertEqual(status, 400, data)
+                self.assertEqual(data['error'], REQUIRED)
+
+    def test_a_bucket_move_that_raises_leaves_no_pro_marking(self):
+        """The 500 path: an exception inside admin_set_bucket (its wind-down or its disk write) must
+        not leave the sizing write landed either."""
+        hotkey = _add_standard_subaccount(self.entity_manager, subaccount_id=30)
+        self.server._challenge_period_client.admin_set_bucket.side_effect = RuntimeError("disk full")
+
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_DIRECT.value,
+                                   "pro_account_size": 500_000}, hotkey=hotkey)
+
+        self.assertEqual(status, 500, data)
+        info = self._info(hotkey)
+        self.assertEqual(info.account_type, "standard")
+        self.assertIsNone(info.pro_account_size)
+        self.assertEqual(info.account_size, STANDARD_SIZE)
+
+    def test_a_successful_move_is_never_rolled_back(self):
+        """set_miner_bucket runs after the bucket moved; if it raises, the sizing must stand."""
+        hotkey = _add_standard_subaccount(self.entity_manager, subaccount_id=31)
+        self.server._miner_account_client.set_miner_bucket.side_effect = RuntimeError("bookkeeping blew up")
+
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_DIRECT.value,
+                                   "pro_account_size": 500_000}, hotkey=hotkey)
+
+        self.assertEqual(status, 500, data)
+        info = self._info(hotkey)
+        self.assertEqual(info.account_type, "pro")
         self.assertEqual(info.pro_account_size, 500_000)
         self.assertEqual(info.account_size, 500_000)
 
@@ -535,16 +751,17 @@ class TestGatewayProTransitionEndpoint(unittest.TestCase):
         self.client = app.test_client()
 
     def _post(self, body):
-        resp = self.client.post("/api/promote-pro-transition", json=body)
+        # json.dumps writes NaN / Infinity as bare literals, exactly what request.get_json() parses back
+        resp = self.client.post("/api/promote-pro-transition", data=json.dumps(body),
+                                content_type="application/json")
         return resp.status_code, json.loads(resp.data)
 
     def _forward(self, body=None):
         """Post to the gateway with the validator call patched; returns (status, data, payload sent)."""
         validator_resp = MagicMock(status_code=200)
-        validator_resp.json.return_value = {"status": "success", "pro_account_size": 500_000}
+        validator_resp.json.return_value = {"status": "success", "pro_account_size": GRANTED_SIZE}
         with patch("requests.post", return_value=validator_resp) as post:
-            status, data = self._post(body if body is not None
-                                      else {"synthetic_hotkey": self.synthetic, "pro_account_size": 500_000})
+            status, data = self._post(body if body is not None else {"synthetic_hotkey": self.synthetic})
         self.assertEqual(post.call_args.args[0], "http://validator.test/entity/subaccount/pro-transition")
         return status, data, post.call_args.kwargs['json']
 
@@ -553,24 +770,32 @@ class TestGatewayProTransitionEndpoint(unittest.TestCase):
         self.assertTrue(Keypair(ss58_address=self.coldkey.ss58_address).verify(
             signed, bytes.fromhex(payload['signature'])))
 
-    def test_forwards_signed_payload_to_validator(self):
+    def test_forwards_a_signed_payload_with_no_size(self):
         status, data, payload = self._forward()
         self.assertEqual(status, 200)
-        self.assertEqual(data['pro_account_size'], 500_000)
+        self.assertEqual(data['pro_account_size'], GRANTED_SIZE)
         self.assertEqual(payload['entity_coldkey'], self.coldkey.ss58_address)
         self.assertEqual(payload['entity_hotkey'], self.hotkey.ss58_address)
         self.assertEqual(payload['synthetic_hotkey'], self.synthetic)
-        self.assertEqual(payload['pro_account_size'], 500_000)
         self.assertIsInstance(payload['nonce'], str)
         self.assertTrue(payload['nonce'])
         self.assertIsInstance(payload['timestamp'], int)
         self.assertLess(abs(payload['timestamp'] - TimeUtil.now_in_millis()), 60_000)
-        self._assert_signed(payload, PRO_TRANSITION_SIGNED_FIELDS + ("pro_account_size",))
-
-    def test_omitted_size_is_left_out_of_the_payload(self):
-        _status, _data, payload = self._forward({"synthetic_hotkey": self.synthetic})
-        self.assertNotIn('pro_account_size', payload)
+        # No size is signed or sent: the payload is exactly the signed fields plus signature and version
+        self.assertEqual(set(payload), set(PRO_TRANSITION_SIGNED_FIELDS) | {"signature", "version"})
         self._assert_signed(payload, PRO_TRANSITION_SIGNED_FIELDS)
+
+    def test_any_size_is_refused_before_signing(self):
+        """The admin owns the pro size, so the gateway never signs or forwards a miner-chosen one."""
+        self.gw._coldkey = MagicMock()
+        for size in EXPLICIT_SIZES:
+            with self.subTest(pro_account_size=size), patch("requests.post") as post:
+                status, data = self._post({"synthetic_hotkey": self.synthetic, "pro_account_size": size})
+                self.assertEqual(status, 400, data)
+                self.assertIn(SIZE_REFUSED, data['message'])
+                self.assertIn("/admin/miner-bucket", data['message'])
+                post.assert_not_called()
+        self.gw._coldkey.sign.assert_not_called()
 
     def test_each_request_gets_a_fresh_nonce(self):
         first = self._forward()[2]
@@ -579,20 +804,17 @@ class TestGatewayProTransitionEndpoint(unittest.TestCase):
         self.assertNotEqual(first['signature'], second['signature'])
 
     def test_gateway_payload_is_accepted_by_the_validator_endpoint(self):
-        for body in ({"synthetic_hotkey": self.synthetic, "pro_account_size": 500_000},
-                     {"synthetic_hotkey": self.synthetic}):
-            with self.subTest(body=body):
-                payload = self._forward(body)[2]
-                server, client = _validator_pro_transition_client()
-                resp = client.post("/entity/subaccount/pro-transition", json=payload)
-                self.assertEqual(resp.status_code, 200, resp.data)
-                server._challenge_period_client.promote_pro_transition.assert_called_once()
-                self.assertEqual(
-                    server._challenge_period_client.promote_pro_transition.call_args.args[2],
-                    body.get("pro_account_size"),
-                )
-                # The same bytes a second time are a replay
-                self.assertEqual(client.post("/entity/subaccount/pro-transition", json=payload).status_code, 401)
+        payload = self._forward()[2]
+        server, client = _validator_pro_transition_client()
+        resp = client.post("/entity/subaccount/pro-transition", json=payload)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        promote = server._challenge_period_client.promote_pro_transition
+        promote.assert_called_once()
+        self.assertEqual(promote.call_args.args[0], self.synthetic)
+        self.assertEqual(len(promote.call_args.args), 2)
+        self.assertEqual(promote.call_args.kwargs, {})
+        # The same bytes a second time are a replay
+        self.assertEqual(client.post("/entity/subaccount/pro-transition", json=payload).status_code, 401)
 
     def test_validator_error_is_passed_through(self):
         validator_resp = MagicMock(status_code=400)
@@ -605,12 +827,9 @@ class TestGatewayProTransitionEndpoint(unittest.TestCase):
     def test_invalid_input_never_reaches_validator(self):
         with patch("requests.post") as post:
             for body in (
-                {"synthetic_hotkey": self.synthetic, "pro_account_size": 0},
-                {"synthetic_hotkey": self.synthetic, "pro_account_size": "500000"},
-                {"synthetic_hotkey": self.synthetic, "pro_account_size": True},
-                {"synthetic_hotkey": self.synthetic, "pro_account_size": ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1},
-                {"pro_account_size": 500_000},
+                {"pro_account_size": GRANTED_SIZE},
                 {"synthetic_hotkey": ""},
+                {"synthetic_hotkey": 123},
             ):
                 with self.subTest(body=body):
                     status, _ = self._post(body)

--- a/tests/vali_tests/test_pro_transition_promotion.py
+++ b/tests/vali_tests/test_pro_transition_promotion.py
@@ -4,7 +4,10 @@ Unit tests for the miner-initiated promotion out of PRO_CHALLENGE_TRANSITION.
 Covers:
   * ChallengePeriodManager.promote_pro_transition: the bucket guard, the account switch that closes
     positions / cancels limit orders / restarts the ledgers, the granted pro account size sent with
-    the request, and the fallback to the size recorded when the subaccount entered the transition.
+    the request, the fallback to the size recorded when the subaccount entered the transition, and the
+    network's ValiConfig.PRO_ACCOUNT_SIZE when no size is sent or recorded (through a real EntityManager).
+  * The admin endpoint POST /admin/miner-bucket/<hotkey>: entering the pro track without a size grants
+    the network size; an explicit size is still honoured and capped.
   * The validator HTTP endpoint: coldkey signature bound to the target subaccount and the requested
     size, nonce + timestamp replay protection, field validation, and subaccount ownership.
   * The gateway HTTP endpoint: the signed payload forwarded to the validator, with and without a
@@ -25,6 +28,12 @@ from vali_objects.challenge_period.challengeperiod_manager import ChallengePerio
 from vali_objects.enums.miner_bucket_enum import MinerBucket
 from vali_objects.enums.order_source_enum import OrderSource
 from vali_objects.vali_config import ValiConfig
+from tests.vali_tests.test_pro_account_size import (
+    STANDARD_SIZE,
+    _add_pro,
+    _add_standard as _add_standard_subaccount,
+    _bare_manager as _bare_entity_manager,
+)
 
 NOW_MS = 1_748_000_000_000
 HOTKEY = "entity_0"
@@ -93,7 +102,8 @@ def test_promotion_winds_down_the_standard_account(manager):
 
 
 def test_no_size_sent_keeps_the_recorded_one(manager):
-    """A request without a size promotes on the size recorded when the miner entered the transition."""
+    """A request without a size passes None down, so the entity manager uses the size recorded when the
+    miner entered the transition (or the network size when none is recorded)."""
     _in_transition(manager)
 
     assert manager.promote_pro_transition(HOTKEY, NOW_MS)[0]
@@ -123,19 +133,83 @@ def test_pro_funded_always_starts_fresh(manager, challenge_bucket):
     manager._debt_ledger_client.delete_debt_ledger.assert_called_once_with(HOTKEY)
 
 
-def test_unset_size_blocks_the_promotion(manager):
-    """The entity manager rejects a pro bucket with no size on either side; nothing is wound down."""
+def test_entity_rejection_blocks_the_promotion(manager):
+    """When the entity manager cannot size the pro account, nothing is wound down."""
     _in_transition(manager)
     manager._entity_client.apply_bucket_account_size.return_value = (
-        False, "pro_account_size is required to enter the pro track"
+        False, f"Failed to set account size for {HOTKEY}"
     )
 
     success, message = manager.promote_pro_transition(HOTKEY, NOW_MS)
 
     assert not success
-    assert "pro_account_size is required" in message
+    assert "Failed to set account size" in message
     assert manager.miner_states[HOTKEY].current_bucket == MinerBucket.PRO_CHALLENGE_TRANSITION
     manager._position_client.close_all_positions.assert_not_called()
+
+
+def _with_real_entity_manager(manager):
+    """Swap the mocked entity client for a real in-memory EntityManager holding one standard
+    SUBACCOUNT_FUNDED subaccount. Returns (entity_manager, synthetic_hotkey)."""
+    entity_manager = _bare_entity_manager()
+    hotkey = _add_standard_subaccount(entity_manager)
+    manager._entity_client = entity_manager
+    manager.set_miner_bucket(hotkey, MinerBucket.SUBACCOUNT_FUNDED, NOW_MS)
+    return entity_manager, hotkey
+
+
+def _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=None):
+    """What POST /admin/miner-bucket does: size the subaccount, then move the bucket."""
+    assert entity_manager.apply_bucket_account_size(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, pro_account_size)[0]
+    assert manager.admin_set_bucket(hotkey, MinerBucket.PRO_CHALLENGE_TRANSITION, NOW_MS)[0]
+
+
+def test_promotion_with_no_size_anywhere_grants_the_network_size(manager):
+    entity_manager, hotkey = _with_real_entity_manager(manager)
+    _admin_move_to_transition(manager, entity_manager, hotkey)
+
+    success, message = manager.promote_pro_transition(hotkey, NOW_MS)
+
+    assert success, message
+    assert manager.miner_states[hotkey].current_bucket == MinerBucket.PRO_CHALLENGE_FROM_STANDARD
+    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
+    assert info.pro_account_size == ValiConfig.PRO_ACCOUNT_SIZE
+    assert info.account_size == ValiConfig.PRO_ACCOUNT_SIZE
+    assert info.standard_account_size == STANDARD_SIZE
+    assert entity_manager.get_payout_scale(hotkey) == pytest.approx(STANDARD_SIZE / ValiConfig.PRO_ACCOUNT_SIZE)
+
+
+def test_promotion_keeps_the_size_recorded_at_transition_after_the_network_size_changes(manager):
+    entity_manager, hotkey = _with_real_entity_manager(manager)
+    granted = ValiConfig.PRO_ACCOUNT_SIZE
+    _admin_move_to_transition(manager, entity_manager, hotkey)
+
+    with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", granted / 2):
+        assert manager.promote_pro_transition(hotkey, NOW_MS)[0]
+
+    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
+    assert info.pro_account_size == granted
+    assert info.account_size == granted
+
+
+def test_promotion_honours_an_explicit_size(manager):
+    entity_manager, hotkey = _with_real_entity_manager(manager)
+    _admin_move_to_transition(manager, entity_manager, hotkey)
+
+    assert manager.promote_pro_transition(hotkey, NOW_MS, 500_000)[0]
+
+    info = entity_manager.get_subaccount_info_for_synthetic(hotkey)
+    assert info.pro_account_size == 500_000
+    assert info.account_size == 500_000
+
+
+def test_promotion_keeps_an_admin_granted_size(manager):
+    entity_manager, hotkey = _with_real_entity_manager(manager)
+    _admin_move_to_transition(manager, entity_manager, hotkey, pro_account_size=500_000)
+
+    assert manager.promote_pro_transition(hotkey, NOW_MS)[0]
+
+    assert entity_manager.get_subaccount_info_for_synthetic(hotkey).account_size == 500_000
 
 
 @pytest.mark.parametrize("bucket", [
@@ -362,6 +436,78 @@ class TestValidatorProTransitionEndpoint(unittest.TestCase):
         self.assertEqual(self._post(body)[0], 403)
         self.server._verify_coldkey_owns_hotkey.return_value = True
         self.assertEqual(self._post(body)[0], 200)
+
+
+class TestAdminMinerBucketProSize(unittest.TestCase):
+    """POST /admin/miner-bucket/<hotkey> sizing a pro move through a real in-memory EntityManager."""
+
+    def setUp(self):
+        from vanta_api.validator_rest_server import ValidatorRestServer
+
+        self.entity_manager = _bare_entity_manager()
+        self.hotkey = _add_standard_subaccount(self.entity_manager)
+        self.server = object.__new__(ValidatorRestServer)
+        self.server._get_api_key_safe = MagicMock(return_value="key")
+        self.server.is_valid_api_key = MagicMock(return_value=True)
+        self.server.can_access_tier = MagicMock(return_value=True)
+        self.server._entity_client = self.entity_manager
+        self.server._challenge_period_client = MagicMock()
+        self.server._challenge_period_client.can_admin_set_bucket.return_value = (True, "")
+        self.server._challenge_period_client.admin_set_bucket.return_value = (True, "moved")
+        self.server._miner_account_client = MagicMock()
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.route("/admin/miner-bucket/<hotkey>", methods=["POST"])(self.server.set_miner_bucket_admin)
+        self.client = app.test_client()
+
+    def _post(self, body):
+        resp = self.client.post(f"/admin/miner-bucket/{self.hotkey}", json=body)
+        return resp.status_code, json.loads(resp.data)
+
+    def _info(self):
+        return self.entity_manager.get_subaccount_info_for_synthetic(self.hotkey)
+
+    def _assert_network_size_granted(self, bucket, account_size):
+        status, data = self._post({"bucket": bucket.value})
+        self.assertEqual(status, 200, data)
+        info = self._info()
+        self.assertEqual(info.pro_account_size, ValiConfig.PRO_ACCOUNT_SIZE)
+        self.assertEqual(info.account_size, account_size)
+        self.server._challenge_period_client.admin_set_bucket.assert_called_once()
+
+    def test_transition_without_a_size_grants_the_network_size(self):
+        self._assert_network_size_granted(MinerBucket.PRO_CHALLENGE_TRANSITION, STANDARD_SIZE)
+
+    def test_direct_pro_challenge_without_a_size_grants_the_network_size(self):
+        self._assert_network_size_granted(MinerBucket.PRO_CHALLENGE_DIRECT, ValiConfig.PRO_ACCOUNT_SIZE)
+
+    def test_explicit_size_is_honoured(self):
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value, "pro_account_size": 500_000})
+        self.assertEqual(status, 200, data)
+        self.assertEqual(self._info().pro_account_size, 500_000)
+
+    def test_explicit_size_above_the_cap_is_rejected_before_the_bucket_moves(self):
+        status, data = self._post({"bucket": MinerBucket.PRO_CHALLENGE_TRANSITION.value,
+                                   "pro_account_size": ValiConfig.MAX_PRO_ACCOUNT_SIZE + 1})
+        self.assertEqual(status, 400)
+        self.assertIn("exceeds maximum", data['error'])
+        self.assertIsNone(self._info().pro_account_size)
+        self.server._challenge_period_client.admin_set_bucket.assert_not_called()
+
+    def test_standard_bucket_never_records_a_pro_size(self):
+        status, data = self._post({"bucket": MinerBucket.SUBACCOUNT_CHALLENGE.value})
+        self.assertEqual(status, 200, data)
+        self.assertIsNone(self._info().pro_account_size)
+        self.assertEqual(self.entity_manager.get_payout_scale(self.hotkey), 1.0)
+
+    def test_recorded_size_is_kept_on_a_later_pro_move(self):
+        pro = _add_pro(self.entity_manager, pro_size=500_000)
+        with patch.object(ValiConfig, "PRO_ACCOUNT_SIZE", 750_000):
+            resp = self.client.post(f"/admin/miner-bucket/{pro}", json={"bucket": MinerBucket.PRO_FUNDED.value})
+        self.assertEqual(resp.status_code, 200, resp.data)
+        info = self.entity_manager.get_subaccount_info_for_synthetic(pro)
+        self.assertEqual(info.pro_account_size, 500_000)
+        self.assertEqual(info.account_size, 500_000)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/vali_objects/challenge_period/challengeperiod_manager.py
+++ b/vali_objects/challenge_period/challengeperiod_manager.py
@@ -763,9 +763,10 @@ class ChallengePeriodManager(CacheController):
     ) -> tuple[bool, str]:
         """Promote a subaccount out of PRO_CHALLENGE_TRANSITION on the miner's own request
 
-        pro_account_size is an optional override for the size of the granted pro account. Sending
-        none keeps the size recorded when the miner entered the transition, or grants the network's
-        ValiConfig.PRO_ACCOUNT_SIZE when none is recorded (see EntityManager.apply_bucket_account_size).
+        The pro account size is the one the admin set when offering the transition. The miner-signed
+        POST /entity/subaccount/pro-transition never passes pro_account_size (a request carrying one is
+        rejected before it gets here), so None keeps the recorded size; a subaccount with no recorded
+        size is rejected (see EntityManager.apply_bucket_account_size).
         """
         state = self.miner_states.get(hotkey)
         if state is None:
@@ -777,7 +778,11 @@ class ChallengePeriodManager(CacheController):
         target_bucket = MinerBucket.PRO_CHALLENGE_TRANSITION.next_bucket
         logger.info(f"[CHALLENGE] pro transition requested (pro_account_size={pro_account_size}): {state}")
 
-        # Record the granted pro size first: the account switch reads it back to size the new account
+        # Record the granted pro size first: the account switch reads it back to size the new account.
+        # That commits, and PRO_CHALLENGE_FROM_STANDARD trades the pro size, so snapshot it first: a
+        # failed move would otherwise leave the subaccount holding the pro size while still in
+        # PRO_CHALLENGE_TRANSITION, which is supposed to keep trading the standard account.
+        sizing_snapshot = self._entity_client.snapshot_bucket_account_size(hotkey)
         success, message = self._entity_client.apply_bucket_account_size(
             hotkey, target_bucket, pro_account_size
         )
@@ -785,7 +790,26 @@ class ChallengePeriodManager(CacheController):
             logger.warning(f"[CHALLENGE] pro transition rejected for {hotkey}: {message}")
             return False, message
 
-        return self.admin_set_bucket(hotkey, target_bucket, current_time_ms)
+        try:
+            success, message = self.admin_set_bucket(hotkey, target_bucket, current_time_ms)
+        except Exception:
+            self._restore_bucket_account_size(hotkey, sizing_snapshot)
+            raise
+        if not success:
+            self._restore_bucket_account_size(hotkey, sizing_snapshot)
+        return success, message
+
+    def _restore_bucket_account_size(self, hotkey: str, sizing_snapshot: dict | None) -> None:
+        """Put a committed apply_bucket_account_size back when the bucket move it was for did not
+        happen. A no-op without a snapshot, and never allowed to mask the failure it is cleaning up."""
+        if not sizing_snapshot:
+            return
+        try:
+            restored, message = self._entity_client.restore_bucket_account_size(hotkey, sizing_snapshot)
+            if not restored:
+                logger.error(f"[CHALLENGE] could not roll back the account size for {hotkey}: {message}")
+        except Exception as restore_error:
+            logger.error(f"[CHALLENGE] could not roll back the account size for {hotkey}: {restore_error}")
 
     def can_admin_set_bucket(self, hotkey: str, bucket: MinerBucket) -> tuple[bool, str]:
         """Report whether admin_set_bucket would reject this move, without changing anything."""

--- a/vali_objects/challenge_period/challengeperiod_manager.py
+++ b/vali_objects/challenge_period/challengeperiod_manager.py
@@ -763,9 +763,9 @@ class ChallengePeriodManager(CacheController):
     ) -> tuple[bool, str]:
         """Promote a subaccount out of PRO_CHALLENGE_TRANSITION on the miner's own request
 
-        pro_account_size sets the size of the granted pro account. Sending none keeps the size
-        recorded when the miner entered the transition; a miner with no recorded size is rejected
-        rather than promoted onto a pro account of unknown size.
+        pro_account_size is an optional override for the size of the granted pro account. Sending
+        none keeps the size recorded when the miner entered the transition, or grants the network's
+        ValiConfig.PRO_ACCOUNT_SIZE when none is recorded (see EntityManager.apply_bucket_account_size).
         """
         state = self.miner_states.get(hotkey)
         if state is None:

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -650,7 +650,19 @@ class ValiConfig:
     ENTITY_COST_PER_THETA_LOW = 2500  # CPT value used for smaller account sizes <=10k
     ENTITY_COST_PER_THETA_LOW_THRESHOLD = 10_000  # Account sizes at or below this use ENTITY_COST_PER_THETA_LOW
     MAX_SUBACCOUNT_ACCOUNT_SIZE = 100_000  # Maximum account size in USD for entity subaccounts
-    MAX_PRO_ACCOUNT_SIZE = 1_000_000  # Maximum account size in USD for pro accounts
+    MAX_PRO_ACCOUNT_SIZE = 1_000_000  # Hard cap in USD on any pro account size, granted or explicitly requested
+    # Pro account size in USD the network grants when a subaccount enters the pro track without an
+    # explicit size. The network owns this value, not the UI or the admin; every subaccount dashboard
+    # publishes it as subaccount_info.default_pro_account_size so a UI can show what a promotion will
+    # grant before it happens. It stays separate from MAX_PRO_ACCOUNT_SIZE because the size recorded
+    # on a pro subaccount is re-checked against the cap on every later pro move: lowering the grant for
+    # future promotions must not also lower the cap and strand subaccounts already granted more.
+    PRO_ACCOUNT_SIZE = 1_000_000
+    if not 0 < PRO_ACCOUNT_SIZE <= MAX_PRO_ACCOUNT_SIZE:
+        raise ValueError(
+            f"PRO_ACCOUNT_SIZE ${PRO_ACCOUNT_SIZE} must be positive and at most "
+            f"MAX_PRO_ACCOUNT_SIZE ${MAX_PRO_ACCOUNT_SIZE}"
+        )
 
     # Entity margin collateral requirement (funded subaccounts only):
     #   required_theta = sum(max_slash_usd - cumulative_slashed_usd) / CPT_RISK

--- a/vali_objects/vali_config.py
+++ b/vali_objects/vali_config.py
@@ -650,17 +650,14 @@ class ValiConfig:
     ENTITY_COST_PER_THETA_LOW = 2500  # CPT value used for smaller account sizes <=10k
     ENTITY_COST_PER_THETA_LOW_THRESHOLD = 10_000  # Account sizes at or below this use ENTITY_COST_PER_THETA_LOW
     MAX_SUBACCOUNT_ACCOUNT_SIZE = 100_000  # Maximum account size in USD for entity subaccounts
-    MAX_PRO_ACCOUNT_SIZE = 1_000_000  # Hard cap in USD on any pro account size, granted or explicitly requested
-    # Pro account size in USD the network grants when a subaccount enters the pro track without an
-    # explicit size. The network owns this value, not the UI or the admin; every subaccount dashboard
-    # publishes it as subaccount_info.default_pro_account_size so a UI can show what a promotion will
-    # grant before it happens. It stays separate from MAX_PRO_ACCOUNT_SIZE because the size recorded
-    # on a pro subaccount is re-checked against the cap on every later pro move: lowering the grant for
-    # future promotions must not also lower the cap and strand subaccounts already granted more.
-    PRO_ACCOUNT_SIZE = 1_000_000
-    if not 0 < PRO_ACCOUNT_SIZE <= MAX_PRO_ACCOUNT_SIZE:
+    # Allowed range in USD for a pro account size. There is no network default: the admin sets the
+    # size when offering the pro track (POST /admin/miner-bucket/<hotkey>), and the network enforces
+    # only this inclusive range (plus finite and positive), not any UI preset list.
+    MAX_PRO_ACCOUNT_SIZE = 1_000_000
+    MIN_PRO_ACCOUNT_SIZE = 200_000
+    if not 0 < MIN_PRO_ACCOUNT_SIZE <= MAX_PRO_ACCOUNT_SIZE:
         raise ValueError(
-            f"PRO_ACCOUNT_SIZE ${PRO_ACCOUNT_SIZE} must be positive and at most "
+            f"MIN_PRO_ACCOUNT_SIZE ${MIN_PRO_ACCOUNT_SIZE} must be positive and at most "
             f"MAX_PRO_ACCOUNT_SIZE ${MAX_PRO_ACCOUNT_SIZE}"
         )
 

--- a/vanta_api/entity_miner_rest_server.py
+++ b/vanta_api/entity_miner_rest_server.py
@@ -1292,10 +1292,14 @@ class EntityMinerRestServer(MinerRestServer):
 
         Request body (JSON):
         {
-            "synthetic_hotkey": "<entity_hotkey>_<id>",  // Required
-            "pro_account_size": 500000                   // Optional, USD size of the granted pro account.
-                                                         // Omit to keep the size recorded at transition.
+            "synthetic_hotkey": "<entity_hotkey>_<id>"   // Required
         }
+
+        The pro account size is set by the network: omit pro_account_size (the Vanta UI always does)
+        and the subaccount is promoted on the size recorded when it entered the transition, which is
+        the network's ValiConfig.PRO_ACCOUNT_SIZE (published as subaccount_info.default_pro_account_size)
+        unless an admin granted a different size. An explicit "pro_account_size" (USD, positive, at most
+        ValiConfig.MAX_PRO_ACCOUNT_SIZE) is still accepted, signed, and forwarded as an override.
 
         Every open position is closed, every pending limit order is cancelled, and the ledgers restart
         on the pro account, so this cannot be undone.

--- a/vanta_api/entity_miner_rest_server.py
+++ b/vanta_api/entity_miner_rest_server.py
@@ -1295,11 +1295,10 @@ class EntityMinerRestServer(MinerRestServer):
             "synthetic_hotkey": "<entity_hotkey>_<id>"   // Required
         }
 
-        The pro account size is set by the network: omit pro_account_size (the Vanta UI always does)
-        and the subaccount is promoted on the size recorded when it entered the transition, which is
-        the network's ValiConfig.PRO_ACCOUNT_SIZE (published as subaccount_info.default_pro_account_size)
-        unless an admin granted a different size. An explicit "pro_account_size" (USD, positive, at most
-        ValiConfig.MAX_PRO_ACCOUNT_SIZE) is still accepted, signed, and forwarded as an override.
+        The subaccount is promoted on the pro account size the admin set when offering the transition.
+        A miner cannot choose or change it: a request that includes "pro_account_size" at all (even null)
+        is rejected with a 400 before anything is signed or sent to the validator, which would reject it
+        too. Only the validator's admin endpoint POST /admin/miner-bucket/<hotkey> sets a pro account size.
 
         Every open position is closed, every pending limit order is cancelled, and the ledgers restart
         on the pro account, so this cannot be undone.
@@ -1318,26 +1317,20 @@ class EntityMinerRestServer(MinerRestServer):
         if not isinstance(synthetic_hotkey, str) or not synthetic_hotkey:
             return jsonify({'status': 'error', 'message': 'synthetic_hotkey must be a non-empty string'}), 400
 
-        send_size = "pro_account_size" in request_data
-        pro_account_size = request_data.get("pro_account_size")
-        if send_size:
-            if (not isinstance(pro_account_size, (int, float))
-                    or isinstance(pro_account_size, bool)
-                    or pro_account_size <= 0):
-                return jsonify({'status': 'error', 'message': 'pro_account_size must be a positive number'}), 400
-            if pro_account_size > ValiConfig.MAX_PRO_ACCOUNT_SIZE:
-                return jsonify({
-                    'status': 'error',
-                    'message': (f'pro_account_size ${pro_account_size} exceeds maximum allowed '
-                                f'${ValiConfig.MAX_PRO_ACCOUNT_SIZE}')
-                }), 400
+        # The admin sets the pro account size; never sign or forward a miner-chosen one
+        if "pro_account_size" in request_data:
+            return jsonify({
+                'status': 'error',
+                'message': ('pro_account_size is not accepted: the pro account size is set by the admin when '
+                            'offering the pro track (validator POST /admin/miner-bucket/<hotkey>), and '
+                            'promoting out of PRO_CHALLENGE_TRANSITION keeps it'),
+            }), 400
 
         if not self._coldkey or not self._hotkey or not self._validator_url:
             return jsonify({'status': 'error', 'message': 'Wallet not configured'}), 500
 
         try:
             # The validator rebuilds this exact dict to verify; nonce + timestamp make it single use.
-            # pro_account_size is part of the signature only when the miner sent one.
             signed_fields = {
                 "entity_coldkey": self._coldkey.ss58_address,
                 "entity_hotkey": self._hotkey.ss58_address,
@@ -1345,8 +1338,6 @@ class EntityMinerRestServer(MinerRestServer):
                 "nonce": uuid.uuid4().hex,
                 "timestamp": int(time.time() * 1000),
             }
-            if send_size:
-                signed_fields["pro_account_size"] = pro_account_size
             message = json.dumps(signed_fields, sort_keys=True).encode('utf-8')
             signature = self._coldkey.sign(message).hex()
         except Exception as e:

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -2697,9 +2697,11 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         The entity coldkey signs the sorted JSON of every field except signature and version;
         nonce + timestamp make each signature single use within a 5 minute window (NonceManager).
 
-        pro_account_size is optional and sets the size of the granted pro account. Omit it to keep the
-        size recorded when the subaccount entered the transition; when it is sent it must be signed
-        with the rest of the payload. A subaccount with no size on either side is rejected.
+        The pro account size is set by the network, so pro_account_size is normally omitted (the Vanta
+        UI never sends it): the subaccount keeps the size recorded when it entered the transition, or
+        gets ValiConfig.PRO_ACCOUNT_SIZE (subaccount_info.default_pro_account_size) when none is
+        recorded. An explicit pro_account_size is still accepted as an override, at most
+        ValiConfig.MAX_PRO_ACCOUNT_SIZE, and must then be signed with the rest of the payload.
 
         Example:
         curl -X POST http://localhost:48888/entity/subaccount/pro-transition \\
@@ -2708,7 +2710,6 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             "entity_hotkey": "5GhDr...",
             "entity_coldkey": "5FxY...",
             "synthetic_hotkey": "5GhDr..._0",
-            "pro_account_size": 500000,
             "nonce": "3f9c1e...",
             "timestamp": 1749234567890,
             "signature": "0x..."
@@ -2753,7 +2754,8 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if not isinstance(timestamp, int) or isinstance(timestamp, bool):
                 return jsonify({'error': 'timestamp must be an integer in milliseconds'}), 400
 
-            # Optional: sent only when the miner wants a size other than the one already recorded
+            # Optional override: omitted, the subaccount keeps its recorded size or gets
+            # ValiConfig.PRO_ACCOUNT_SIZE
             pro_account_size = data.get('pro_account_size')
             if pro_account_size is not None:
                 if (not isinstance(pro_account_size, (int, float))
@@ -3006,14 +3008,18 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
 
         JSON body:
           bucket: MinerBucket value string (required)
-          pro_account_size: USD size of the granted pro account (required when entering the pro track,
-                            optional afterwards to keep the size already recorded)
+          pro_account_size: optional override, USD size of the granted pro account (at most
+                            ValiConfig.MAX_PRO_ACCOUNT_SIZE). The size is set by the network, so the
+                            Vanta UI omits it: entering the pro track without one grants the size
+                            already recorded on the subaccount, or ValiConfig.PRO_ACCOUNT_SIZE
+                            (subaccount_info.default_pro_account_size) when none is recorded.
+                            Ignored for standard buckets.
 
         Example:
         curl -X POST "http://localhost:48888/admin/miner-bucket/<hotkey>" \\
           -H "Authorization: Bearer YOUR_API_KEY" \\
           -H "Content-Type: application/json" \\
-          -d '{"bucket": "PRO_CHALLENGE_TRANSITION", "pro_account_size": 500000}'
+          -d '{"bucket": "PRO_CHALLENGE_TRANSITION"}'
         """
         api_key = self._get_api_key_safe()
         if not self.is_valid_api_key(api_key):

--- a/vanta_api/validator_rest_server.py
+++ b/vanta_api/validator_rest_server.py
@@ -19,7 +19,7 @@ from bittensor_wallet import Keypair
 from entity_management.entity_client import EntityClient
 from time_util.time_util import MS_IN_24_HOURS, TimeUtil
 from entity_management.entity_utils import create_subaccount_dashboard
-from entity_management.entity_utils import is_synthetic_hotkey, parse_synthetic_hotkey
+from entity_management.entity_utils import is_synthetic_hotkey, parse_synthetic_hotkey, pro_account_size_error
 from shared_objects.rpc.common_data_client import CommonDataClient
 from shared_objects.rpc.metagraph_client import MetagraphClient
 from shared_objects.rpc.rpc_server_base import RPCServerBase
@@ -2697,11 +2697,10 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         The entity coldkey signs the sorted JSON of every field except signature and version;
         nonce + timestamp make each signature single use within a 5 minute window (NonceManager).
 
-        The pro account size is set by the network, so pro_account_size is normally omitted (the Vanta
-        UI never sends it): the subaccount keeps the size recorded when it entered the transition, or
-        gets ValiConfig.PRO_ACCOUNT_SIZE (subaccount_info.default_pro_account_size) when none is
-        recorded. An explicit pro_account_size is still accepted as an override, at most
-        ValiConfig.MAX_PRO_ACCOUNT_SIZE, and must then be signed with the rest of the payload.
+        The subaccount is promoted on the pro account size the admin set when offering the transition.
+        A miner cannot choose or change it: a request that includes pro_account_size at all (even null)
+        is rejected with a 400 before the signature is checked or the nonce is consumed. Only the admin
+        endpoint POST /admin/miner-bucket/<hotkey> sets a pro account size.
 
         Example:
         curl -X POST http://localhost:48888/entity/subaccount/pro-transition \\
@@ -2735,6 +2734,15 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if vanta_cli_error:
                 return jsonify({'error': vanta_cli_error}), 400
 
+            # The admin sets the pro account size; a miner never chooses one. Refused before any
+            # signature or nonce work, so the request's nonce stays unused.
+            if 'pro_account_size' in data:
+                return jsonify({'error': (
+                    'pro_account_size is not accepted: the pro account size is set by the admin when '
+                    'offering the pro track (POST /admin/miner-bucket/<hotkey>), and promoting out of '
+                    'PRO_CHALLENGE_TRANSITION keeps it'
+                )}), 400
+
             required_fields = ['entity_coldkey', 'entity_hotkey', 'synthetic_hotkey',
                                'nonce', 'timestamp', 'signature']
             missing_fields = [field for field in required_fields if field not in data]
@@ -2754,26 +2762,13 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if not isinstance(timestamp, int) or isinstance(timestamp, bool):
                 return jsonify({'error': 'timestamp must be an integer in milliseconds'}), 400
 
-            # Optional override: omitted, the subaccount keeps its recorded size or gets
-            # ValiConfig.PRO_ACCOUNT_SIZE
-            pro_account_size = data.get('pro_account_size')
-            if pro_account_size is not None:
-                if (not isinstance(pro_account_size, (int, float))
-                        or isinstance(pro_account_size, bool)
-                        or pro_account_size <= 0):
-                    return jsonify({'error': 'pro_account_size must be a positive number'}), 400
-                if pro_account_size > ValiConfig.MAX_PRO_ACCOUNT_SIZE:
-                    return jsonify({'error': (f'pro_account_size ${pro_account_size} exceeds maximum allowed '
-                                              f'${ValiConfig.MAX_PRO_ACCOUNT_SIZE}')}), 400
-
             parsed_entity_hotkey, _ = parse_synthetic_hotkey(synthetic_hotkey)
             if parsed_entity_hotkey is None:
                 return jsonify({'error': f'{synthetic_hotkey} is not a subaccount'}), 400
             if parsed_entity_hotkey != entity_hotkey:
                 return jsonify({'error': f'Subaccount {synthetic_hotkey} does not belong to entity {entity_hotkey}'}), 403
 
-            # The signature binds the target subaccount and the requested size; nonce + timestamp make
-            # it single use.
+            # The signature binds the target subaccount; nonce + timestamp make it single use.
             signed_fields = {
                 "entity_coldkey": entity_coldkey,
                 "entity_hotkey": entity_hotkey,
@@ -2781,8 +2776,6 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 "nonce": nonce,
                 "timestamp": timestamp,
             }
-            if 'pro_account_size' in data:
-                signed_fields["pro_account_size"] = data['pro_account_size']
 
             keypair = Keypair(ss58_address=entity_coldkey)
             signed_message = json.dumps(signed_fields, sort_keys=True).encode('utf-8')
@@ -2802,9 +2795,10 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             if not nonce_ok:
                 return jsonify({'error': nonce_error}), 401
 
-            # Closes positions, cancels limit orders, restarts the ledgers, and moves the bucket
+            # Closes positions, cancels limit orders, restarts the ledgers, and moves the bucket. No size
+            # is passed, so the pro account keeps the size recorded when the admin offered the transition.
             success, message = self._challenge_period_client.promote_pro_transition(
-                synthetic_hotkey, TimeUtil.now_in_millis(), pro_account_size
+                synthetic_hotkey, TimeUtil.now_in_millis()
             )
             if not success:
                 return jsonify({'error': message}), 400
@@ -3008,18 +3002,23 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
 
         JSON body:
           bucket: MinerBucket value string (required)
-          pro_account_size: optional override, USD size of the granted pro account (at most
-                            ValiConfig.MAX_PRO_ACCOUNT_SIZE). The size is set by the network, so the
-                            Vanta UI omits it: entering the pro track without one grants the size
-                            already recorded on the subaccount, or ValiConfig.PRO_ACCOUNT_SIZE
-                            (subaccount_info.default_pro_account_size) when none is recorded.
-                            Ignored for standard buckets.
+          pro_account_size: USD size of the pro account. There is no network default: this endpoint is
+                            the only way to set one. When sent it must be a finite number within
+                            [ValiConfig.MIN_PRO_ACCOUNT_SIZE, ValiConfig.MAX_PRO_ACCOUNT_SIZE]
+                            ($200,000 to $1,000,000 inclusive), whatever the bucket, or the request is
+                            a 400 before anything changes.
+                            - Required when entering the pro track (e.g. SUBACCOUNT_FUNDED ->
+                              PRO_CHALLENGE_TRANSITION), including a re-offer after a demotion: a size
+                              from an earlier pro journey is never reused.
+                            - Optional on a move within the pro track (e.g. to PRO_FUNDED): a new size
+                              replaces the recorded one, omitted keeps it.
+                            - Ignored for standard buckets, which never record a pro size.
 
         Example:
         curl -X POST "http://localhost:48888/admin/miner-bucket/<hotkey>" \\
           -H "Authorization: Bearer YOUR_API_KEY" \\
           -H "Content-Type: application/json" \\
-          -d '{"bucket": "PRO_CHALLENGE_TRANSITION"}'
+          -d '{"bucket": "PRO_CHALLENGE_TRANSITION", "pro_account_size": 500000}'
         """
         api_key = self._get_api_key_safe()
         if not self.is_valid_api_key(api_key):
@@ -3027,6 +3026,9 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
         if not self.can_access_tier(api_key, 500):
             return jsonify({'error': 'Set miner bucket endpoint requires tier 500 access'}), 403
 
+        # Set once the sizing below is committed and cleared once the bucket move makes it correct;
+        # while it holds a snapshot the sizing must be rolled back on every way out (see below)
+        sizing_snapshot = None
         try:
             data = request.get_json(silent=True) or {}
             bucket_str = data.get('bucket')
@@ -3036,11 +3038,13 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 valid = [b.value for b in MinerBucket]
                 return jsonify({'error': f'Invalid bucket. Must be one of: {valid}'}), 400
 
+            # request.get_json() parses the literals NaN and Infinity, and NaN passes a plain range
+            # check, so the size must be a finite number within the pro range
             pro_account_size = data.get('pro_account_size')
-            if pro_account_size is not None and (not isinstance(pro_account_size, (int, float))
-                                                 or isinstance(pro_account_size, bool)
-                                                 or pro_account_size <= 0):
-                return jsonify({'error': 'pro_account_size must be a positive number'}), 400
+            if pro_account_size is not None:
+                size_error = pro_account_size_error(pro_account_size)
+                if size_error:
+                    return jsonify({'error': size_error}), 400
 
             if bucket.is_subaccount and not is_synthetic_hotkey(hotkey):
                 return jsonify({'error': f'{bucket.value} is a subaccount bucket; {hotkey} is not a subaccount'}), 400
@@ -3051,19 +3055,28 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
                 return jsonify({'error': message}), 400
 
             # Point the subaccount at the account size the target bucket trades before the
-            # challenge period manager resets the account against it
+            # challenge period manager resets the account against it. This commits — it resizes the
+            # live account and writes the record to disk — so snapshot the sizing first: if the bucket
+            # move below then fails, the subaccount must not be left marked pro, which would both let
+            # the next size-less offer reuse this size and leave the account trading it outside the
+            # pro track.
             if bucket.is_subaccount:
+                snapshot = self._entity_client.snapshot_bucket_account_size(hotkey)
                 success, message = self._entity_client.apply_bucket_account_size(
                     hotkey, bucket, pro_account_size
                 )
                 if not success:
                     return jsonify({'error': message}), 400
+                sizing_snapshot = snapshot
 
             success, message = self._challenge_period_client.admin_set_bucket(
                 hotkey, bucket, TimeUtil.now_in_millis()
             )
             if not success:
+                self._restore_bucket_account_size(hotkey, sizing_snapshot)
                 return jsonify({'error': message}), 400
+            # The bucket moved, so the sizing is now the correct one and must survive anything below
+            sizing_snapshot = None
             self._miner_account_client.set_miner_bucket(hotkey, bucket)
 
             return jsonify({
@@ -3074,9 +3087,27 @@ class ValidatorRestServer(BaseRestServer, RPCServerBase):
             }), 200
 
         except Exception as e:
+            # An exception inside admin_set_bucket (its wind-down, its disk write) must not leave the
+            # sizing write landed behind a 500 either
+            self._restore_bucket_account_size(hotkey, sizing_snapshot)
             logger.error(f"Error setting bucket for hotkey {hotkey}: {e}")
             logger.error(traceback.format_exc())
             return jsonify({'error': f'Internal server error: {str(e)}'}), 500
+
+    def _restore_bucket_account_size(self, hotkey: str, sizing_snapshot: Optional[dict]) -> None:
+        """Put a committed apply_bucket_account_size back when the bucket move it was for did not
+        happen. A no-op without a snapshot, and never allowed to mask the failure it is cleaning up."""
+        if not sizing_snapshot:
+            return
+        try:
+            restored, restore_message = self._entity_client.restore_bucket_account_size(
+                hotkey, sizing_snapshot
+            )
+            if not restored:
+                logger.error(f"Could not roll back the account size for {hotkey}: {restore_message}")
+        except Exception as restore_error:
+            logger.error(f"Could not roll back the account size for {hotkey}: {restore_error}")
+            logger.error(traceback.format_exc())
 
     def get_subaccount_dashboard(self, synthetic_hotkey):
         """


### PR DESCRIPTION
## Summary

The admin sets a pro account's size when promoting it. The network owns only the allowed range, not a default. Targets `feat/da--pro-accounts`.

This replaces the design in the first commit on this branch (`c0bdf797`), which gave the network a `PRO_ACCOUNT_SIZE = 1_000_000` default and published it as `subaccount_info.default_pro_account_size`. There is no network-owned pro size — both are gone, along with the "fall back to the network size" branch.

- **Range, not a default.** `ValiConfig.MIN_PRO_ACCOUNT_SIZE = 200_000` and `MAX_PRO_ACCOUNT_SIZE = 1_000_000`, inclusive, checked at import. The network enforces the range plus numeric-and-finite; the preset list the Command Center offers ($200K–$1M in $50K steps, so an admin can't fat-finger a zero) is a UI concern and is deliberately not mirrored here.
- **Required to enter the pro track.** `SUBACCOUNT_FUNDED → PRO_CHALLENGE_TRANSITION` and the other entries take a size or fail with `pro_account_size is required to enter the pro track`. A re-offer after a demotion requires one again: a demotion leaves the earlier size on record, and that recorded size is never silently reused when the subaccount is entering from a standard account. A move *within* the track may carry a new size (an admin re-setting it on `PRO_FUNDED`) or omit it to keep the recorded one. Standard buckets never record a pro size.
- **A miner cannot choose its own size.** The coldkey-signed `POST /entity/subaccount/pro-transition` and the gateway's `POST /api/promote-pro-transition` now 400 on the mere presence of `pro_account_size`, before the signature is checked or the nonce is consumed — so a rejected request doesn't burn the nonce. Neither signs nor forwards a size. The tier-500 `POST /admin/miner-bucket/<hotkey>` is the only way to set one.
- **Non-finite sizes are rejected at every entry point.** Flask's `request.get_json()` parses the literals `NaN` and `Infinity`, and `NaN` fails every ordered comparison, so a plain range check lets it through. `pro_account_size_error` (new, in `entity_management/entity_utils.py`) checks type and finiteness before the range, and `apply_bucket_account_size` re-checks a recorded size defensively before trading on it.
- **Rollback when the bucket move fails.** Kept from `c0bdf797`: sizes are computed first and stored only after the account resize succeeds. This commit extends that past the resize. `apply_bucket_account_size` commits — it resizes the live account and writes the record to disk — before its caller moves the bucket, so both callers that pair the two (`POST /admin/miner-bucket/<hotkey>` and `ChallengePeriodManager.promote_pro_transition`) now snapshot the sizing and roll it back when the move fails or raises. Without it, a failed move left the subaccount marked pro in a bucket that never changed, which both let the next size-less offer take the "recorded" branch instead of demanding a size, and left a `PRO_CHALLENGE_DIRECT`/`PRO_CHALLENGE_FROM_STANDARD` account live at the pro size off the pro track. The rollback restores the live account size before the record, since a record restored behind a still-resized account is a divergence no later move heals.
- The promotion log line now records whether the granted size was `explicit` or `recorded`.

## Settled: recorded sizes are not re-checked against the range

A **recorded** size is checked only for being a finite positive number, not re-checked against today's `[MIN, MAX]`. A recorded size could only have been set through the range-checked entry, and re-checking would strand an in-flight pro account — an organic `FROM_STANDARD → PRO_FUNDED` would fail forever — if the range is ever moved. Confirmed by the product owner (Lucas, 2026-09-12) and locked by `test_recorded_size_is_not_rechecked_against_the_range`.

## Test plan

- [x] `tests/vali_tests/test_pro_account_size.py` rewritten: range constants and the import-time check, no `PRO_ACCOUNT_SIZE`, `pro_account_size_error` (bool/str/NaN/Infinity), the `199_999 / 200_000 / 1_000_000 / 1_000_001` bounds, required-on-entry, the full offer → start → demote → re-offer journey, recorded-within-track, the `PRO_FUNDED` re-set, standard targets, failed resize leaves the account untouched, the log source, and no `default_pro_account_size` in v1, v2, the websocket frames or `/hl-traders`
- [x] `test_pro_transition_promotion.py` rewritten: manager, the admin endpoint through a real `EntityManager`, the validator endpoint's size refusal with a nonce-reuse proof, and the existing signature-binding, replay, ownership and timestamp coverage kept; the gateway never signs or forwards a size
- [x] 81 passed, 342 subtests passed
- [x] Adversarial review across config/semantics, endpoint-contract and test lenses; the confirmed findings are fixed in this commit
- [ ] Unchanged pre-existing failures, identical on the base branch: 18 in `test_hl_trader_endpoint.py`, `test_create_pro_subaccount_lands_in_pro_challenge_bucket`, and the 34/26 in the wider sweeps. `test_challengeperiod_integration.py` still fails at collection on `main` (missing `ValiConfig.SUBACCOUNT_STATIC_RULES_EFFECTIVE_MS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
